### PR TITLE
Move control sessions creation to Go codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Features
 1. Provider logs for debugging  
-2. Devices remote control
+2. Devices remote control(most of which is wrapper around Appium)
   * Android
     - `minicap` video stream  
     - basic device interaction - Home, Lock, Unlock, Type text, Clear text  
@@ -31,6 +31,7 @@ Developed and tested on Ubuntu 18.04 LTS
 |[go-ios](https://github.com/danielpaulus/go-ios)|Many thanks for creating this tool to communicate with iOS devices on Linux, perfect for installing/reinstalling and running WebDriverAgentRunner without Xcode. Without it none of this would be possible|
 |[iOS App Signer](https://github.com/DanTheMan827/ios-app-signer)|This is an app for OS X that can (re)sign apps and bundle them into ipa files that are ready to be installed on an iOS device.|
 |[minicap](https://github.com/DeviceFarmer/minicap)|Stream screen capture data out of Android devices|  
+|[Appium](https://github.com/appium)|It would be impossible to control the devices remotely without Appium for the control and WebDriverAgent for the iOS screen stream, kudos!|  
 
 ## WIP demo video  
 

--- a/device_control.go
+++ b/device_control.go
@@ -129,7 +129,15 @@ func GetDevicePage(w http.ResponseWriter, r *http.Request) {
 	if selected_device.DeviceOS == "ios" {
 		webDriverAgentSessionID, err = CheckWDASession(selected_device.DeviceHost + ":" + selected_device.WdaPort)
 		if err != nil {
-			fmt.Println(err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	var appiumSessionID = ""
+	if selected_device.DeviceOS == "android" {
+		appiumSessionID, err = checkAppiumSession(selected_device.DeviceHost + ":" + selected_device.DeviceAppiumPort)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
 
@@ -141,11 +149,13 @@ func GetDevicePage(w http.ResponseWriter, r *http.Request) {
 		CanvasWidth             string
 		CanvasHeight            string
 		WebDriverAgentSessionID string
+		AppiumSessionID         string
 	}{
 		ContainerDeviceConfig:   selected_device,
 		CanvasWidth:             canvasWidth,
 		CanvasHeight:            canvasHeight,
 		WebDriverAgentSessionID: webDriverAgentSessionID,
+		AppiumSessionID:         appiumSessionID,
 	}
 
 	// Parse the template and return response with the container table rows

--- a/static/device_control_new.html
+++ b/static/device_control_new.html
@@ -385,14 +385,7 @@
     let canvas_height = "{{.CanvasHeight}}"
     let screen_size = "{{.ContainerDeviceConfig.ScreenSize}}"
     let wda_session_id = "{{.WebDriverAgentSessionID}}"
-    var appium_session_id
-
-    // On page load add the listeners and start the refresh containers job
-    window.addEventListener("DOMContentLoaded", function () {
-        if (device_os == "android") {
-            checkAppiumSession()
-        }
-    });
+    let appium_session_id = "{{.AppiumSessionID}}"
 
     document.getElementById("refresh-source").addEventListener('click', () => {
         getAppSource()
@@ -478,123 +471,6 @@
     document.getElementById("wipe-canvas").addEventListener('click', () => {
         wipeCanvas()
     })
-
-    async function checkAppiumSession() {
-
-        // build the json to create a session
-        json = JSON.stringify({
-            "capabilities": {
-                "alwaysMatch": {
-                    "appium:automationName": "UiAutomator2",
-                    "platformName": "Android",
-                    "appium:ensureWebviewsHavePages": true,
-                    "appium:nativeWebScreenshot": true,
-                    "appium:newCommandTimeout": 0,
-                    "appium:connectHardwareKeyboard": true
-                },
-                "firstMatch": [
-                    {}
-                ]
-            },
-            "desiredCapabilities": {
-                "appium:automationName": "UiAutomator2",
-                "platformName": "Android",
-                "appium:ensureWebviewsHavePages": true,
-                "appium:nativeWebScreenshot": true,
-                "appium:newCommandTimeout": 0,
-                "appium:connectHardwareKeyboard": true
-            }
-        })
-
-        let sessions_url = appium_url + "/sessions"
-        let session_url = appium_url + "/session"
-        const sessions_response = await fetch(sessions_url).then(response => {
-            return response.json()
-        })
-            .catch(function (error) {
-                alert("Could not get Appium sessions" + error)
-                window.location.href = "/devices"
-            })
-
-        if (sessions_response.value.length === 0) {
-            const session_response = await fetch(session_url, {
-                method: 'POST',
-                body: json,
-                headers: {
-                    'Content-type': 'application/json'
-                }
-            })
-                .then(response => {
-                    return response.json()
-                })
-                .catch(function (error) {
-                    alert("Could not create Appium session" + error)
-                    window.location.href = "/devices"
-                })
-            appium_session_id = session_response.value.sessionId
-        } else if (sessions_response.value[0].id === null) {
-            const session_response = await fetch(session_url, {
-                method: 'POST',
-                body: json,
-                headers: {
-                    'Content-type': 'application/json'
-                }
-            })
-                .then(response => {
-                    return response.json()
-                })
-                .catch(function (error) {
-                    alert("Could not create Appium session" + error)
-                    window.location.href = "/devices"
-                })
-            appium_session_id = session_response.value.sessionId
-        } else {
-            appium_session_id = sessions_response.value[0].id
-        }
-    }
-
-    async function typeText() {
-        var active_element_url;
-        var element_value_url;
-
-        if (device_os == "android") {
-            active_element_url = appium_url + "/session/" + appium_session_id + "/element/active"
-        } else if (device_os == "ios") {
-            active_element_url = wda_url + "/session/" + wda_session_id + "/element/active"
-        } else {
-            return
-        }
-
-        const control_response = await fetch(active_element_url).then(response => {
-            if (response.ok) {
-                return response.json()
-            } else {
-                return null
-            }
-        })
-
-        var element_id = control_response.value.ELEMENT
-        if (device_os == "android") {
-            element_value_url = appium_url + "/session/" + appium_session_id + "/element/" + element_id + "/value"
-        } else {
-            element_value_url = wda_url + "/session/" + wda_session_id + "/element/" + element_id + "/value"
-        }
-
-        if (control_response != null) {
-            if (element_id != "") {
-                var text_input = document.getElementById("type-text-input").value
-                await fetch(element_value_url, {
-                    method: 'POST',
-                    headers: {
-                        'Content-type': 'application/json'
-                    },
-                    body: JSON.stringify({ "text": text_input })
-                }).then(() => {
-                    document.getElementById("type-text-input").value = ""
-                })
-            }
-        }
-    }
 
     async function clearActiveElementText() {
         var active_element_url;

--- a/static/device_control_new.html
+++ b/static/device_control_new.html
@@ -472,6 +472,49 @@
         wipeCanvas()
     })
 
+    async function typeText() {
+        var active_element_url;
+        var element_value_url;
+
+        if (device_os == "android") {
+            active_element_url = appium_url + "/session/" + appium_session_id + "/element/active"
+        } else if (device_os == "ios") {
+            active_element_url = wda_url + "/session/" + wda_session_id + "/element/active"
+        } else {
+            return
+        }
+
+        const control_response = await fetch(active_element_url).then(response => {
+            if (response.ok) {
+                return response.json()
+            } else {
+                return null
+            }
+        })
+
+        var element_id = control_response.value.ELEMENT
+        if (device_os == "android") {
+            element_value_url = appium_url + "/session/" + appium_session_id + "/element/" + element_id + "/value"
+        } else {
+            element_value_url = wda_url + "/session/" + wda_session_id + "/element/" + element_id + "/value"
+        }
+
+        if (control_response != null) {
+            if (element_id != "") {
+                var text_input = document.getElementById("type-text-input").value
+                await fetch(element_value_url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-type': 'application/json'
+                    },
+                    body: JSON.stringify({ "text": text_input })
+                }).then(() => {
+                    document.getElementById("type-text-input").value = ""
+                })
+            }
+        }
+    }
+
     async function clearActiveElementText() {
         var active_element_url;
         var element_clear_url;

--- a/static/device_control_new.html
+++ b/static/device_control_new.html
@@ -384,15 +384,11 @@
     let canvas_width = "{{.CanvasWidth}}"
     let canvas_height = "{{.CanvasHeight}}"
     let screen_size = "{{.ContainerDeviceConfig.ScreenSize}}"
-    var wda_session_id
+    let wda_session_id = "{{.WebDriverAgentSessionID}}"
     var appium_session_id
 
     // On page load add the listeners and start the refresh containers job
     window.addEventListener("DOMContentLoaded", function () {
-        if (device_os == "ios") {
-            checkWDASession()
-        }
-
         if (device_os == "android") {
             checkAppiumSession()
         }
@@ -482,80 +478,6 @@
     document.getElementById("wipe-canvas").addEventListener('click', () => {
         wipeCanvas()
     })
-
-    // check if a wda session exists and connect to it or create a new one
-    function checkWDASession() {
-
-        // if there is no session id from the /status endpoint create a new session
-        // else just update the session id with the existing session
-        fetch(wda_url + "/status", {
-            method: 'GET',
-            headers: {
-                'Content-type': 'application/json'
-            }
-        })
-            .then((response) => {
-                return response.json()
-            })
-            .then((json) => {
-                if (json.sessionId === null) {
-                    createWDASession()
-                } else {
-                    wda_session_id = json.sessionId
-                }
-
-            })
-            .catch(function (error) {
-                wda_session_id = null
-                alert("Could not get WDA session. Error: " + error)
-                window.location.href = "/devices"
-            })
-    }
-
-    // create a wda session to the iOS device if no session exists
-    function createWDASession() {
-        let json = ""
-
-        // build the json to create a session
-        json = JSON.stringify({
-            "capabilities": {
-                "firstMatch": [
-                    {
-                        "arguments": [],
-                        "environment": {},
-                        "eventloopIdleDelaySec": 0,
-                        "shouldWaitForQuiescence": true,
-                        "shouldUseTestManagerForVisibilityDetection": false,
-                        "maxTypingFrequency": 60,
-                        "shouldUseSingletonTestManager": true,
-                        "shouldTerminateApp": true,
-                        "forceAppLaunch": true,
-                        "useNativeCachingStrategy": true,
-                        "forceSimulatorSoftwareKeyboardPresence": false
-                    }
-                ],
-                "alwaysMatch": {}
-            }
-        })
-
-        fetch(wda_url + "/session", {
-            method: 'POST',
-            body: json,
-            headers: {
-                'Content-type': 'application/json'
-            }
-        })
-            .then((response) => {
-                return response.json()
-            })
-            .then((json) => {
-                wda_session_id = data.sessionId
-            })
-            .catch(function (error) {
-                alert("Could not create WDA session. Error: " + error)
-                window.location.href = "/devices"
-            })
-    }
 
     async function checkAppiumSession() {
 


### PR DESCRIPTION
* Moved WDA session creation for iOS device control to Go server instead of web js
* Moved Appium session creation for Android device control to Go server instead of web js
* Cleaned device control js from the now obsolete functions