### PR TITLE
UI files folder

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,17 +1,16 @@
 package main
 
 import (
+	"GADS/device"
+	"GADS/models"
+	"GADS/router"
+	"GADS/util"
 	"embed"
 	"flag"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-
-	"GADS/device"
-	"GADS/models"
-	"GADS/router"
-	"GADS/util"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -40,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	osTempDir := os.TempDir()
-	uiFilesTempDir := fmt.Sprintf("%sgads-ui", osTempDir)
+	uiFilesTempDir := filepath.Join(osTempDir, "gads-ui")
 
 	// Print out some useful information
 	fmt.Printf("Using MongoDB instance on %s. You can change the instance with the --mongo-db flag\n", *mongoDB)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"embed"
 	"flag"
 	"fmt"
 	"os"
@@ -22,6 +23,9 @@ func setLogging() {
 	}
 	log.SetOutput(projectLogFile)
 }
+
+//go:embed gads-ui/build
+var uiFiles embed.FS
 
 func main() {
 	authFlag := flag.Bool("auth", false, "If authentication should be turned on")
@@ -70,7 +74,7 @@ func main() {
 	setLogging()
 	fmt.Println("")
 
-	r := router.HandleRequests(*authFlag)
+	r := router.HandleRequests(*authFlag, uiFiles)
 
 	// Start the GADS UI on the host IP address
 	address := fmt.Sprintf("%s:%s", util.ConfigData.HostAddress, util.ConfigData.Port)

--- a/router/handler.go
+++ b/router/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
+	"path/filepath"
 )
 
 func HandleRequests(authentication bool) *gin.Engine {
@@ -18,13 +19,15 @@ func HandleRequests(authentication bool) *gin.Engine {
 	config.AllowHeaders = []string{"X-Auth-Token", "Content-Type"}
 	r.Use(cors.New(config))
 
+	indexHtmlPath := filepath.Join(util.ConfigData.UIFilesTempDir, "index.html")
+
 	// Configuration for SAP applications
 	// Serve the static files from the built React app
 	r.Use(static.Serve("/", static.LocalFile(util.ConfigData.UIFilesTempDir, true)))
 	// For any missing route serve the index.htm from the static files
 	// This will fix the issue with accessing particular endpoint in the browser manually or with refresh
 	r.NoRoute(func(c *gin.Context) {
-		c.File(util.ConfigData.UIFilesTempDir + "/index.html")
+		c.File(indexHtmlPath)
 	})
 
 	authGroup := r.Group("/")

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -28,6 +28,8 @@ type ConfigJsonData struct {
 	AdminUsername        string `json:"admin_username"`
 	AdminPassword        string `json:"admin_password"`
 	AdminEmail           string `json:"admin_email"`
+	OSTempDir            string `json:"-"`
+	UIFilesTempDir       string `json:"-"`
 }
 
 var ConfigData *ConfigJsonData


### PR DESCRIPTION
* Embed the UI static files into the binary
* Unpack the UI static files into a temp or provided folder on app start
* Serve the UI static files from where they were unpacked

This allows us to have a standalone deployable binary without any dependencies on Node or Go on the host machine