### PR TITLE
Set relaxed security on Appium servers

### DIFF
--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -587,7 +587,16 @@ func startAppium(device *models.Device) {
 	}
 	device.AppiumPort = appiumPort
 
-	cmd := exec.CommandContext(device.Context, "appium", "-p", device.AppiumPort, "--log-timestamp", "--session-override", "--log-no-colors", "--default-capabilities", string(capabilitiesJson))
+	cmd := exec.CommandContext(
+		device.Context,
+		"appium",
+		"-p",
+		device.AppiumPort,
+		"--log-timestamp",
+		"--session-override",
+		"--log-no-colors",
+		"--relaxed-security",
+		"--default-capabilities", string(capabilitiesJson))
 
 	logger.ProviderLogger.LogDebug("device_setup", fmt.Sprintf("Starting Appium on device `%s` with command `%s`", device.UDID, cmd.Args))
 	// Create a pipe to capture the command's output


### PR DESCRIPTION
* GADS is meant to be in-house so I see no harm in directly setting relaxed security on the Appium servers started by the `provider`