### PR TITLE
Add device re-provision button

### DIFF
--- a/common/models/models.go
+++ b/common/models/models.go
@@ -63,6 +63,7 @@ type Device struct {
 	WDAStreamPort    string             `json:"-" bson:"-"` // port assigned to iOS devices for the WebDriverAgent stream
 	WDAPort          string             `json:"-" bson:"-"` // port assigned to iOS devices for the WebDriverAgent instance
 	WdaReadyChan     chan bool          `json:"-" bson:"-"` // channel for checking that WebDriverAgent is up after start
+	AppiumReadyChan  chan bool          `json:"-" bson:"-"` // channel for checking that Appium is up after start
 	Context          context.Context    `json:"-" bson:"-"` // context used to control the device set up since we have multiple goroutines
 	CtxCancel        context.CancelFunc `json:"-" bson:"-"` // cancel func for the context above, can be used to stop all running device goroutines
 	GoIOSDeviceEntry ios.DeviceEntry    `json:"-" bson:"-"` // `go-ios` device entry object used for `go-ios` library interactions

--- a/hub/gads-ui/src/components/Admin/Devices/DevicesAdministration.js
+++ b/hub/gads-ui/src/components/Admin/Devices/DevicesAdministration.js
@@ -142,7 +142,7 @@ function NewDevice({ providers, handleGetDeviceData }) {
                 width: '400px',
                 minWidth: '400px',
                 maxWidth: '400px',
-                height: '780px',
+                height: '830px',
                 borderRadius: '5px',
                 backgroundColor: '#9ba984'
             }}
@@ -345,8 +345,10 @@ function ExistingDevice({ deviceData, providersData, handleGetDeviceData }) {
     const [type, setType] = useState(deviceData.device_type)
     const udid = deviceData.udid
 
-    const [loading, setLoading] = useState(false);
+    const [loading, setLoading] = useState(false)
+    const [reprovisionLoading, setReprovisionLoading] = useState(false)
     const [updateDeviceStatus, setUpdateDeviceStatus] = useState(null)
+    const [reprovisionDeviceStatus, setReprovisionDeviceStatus] = useState(null)
 
     useEffect(() => {
         setProvider(deviceData.provider)
@@ -394,6 +396,30 @@ function ExistingDevice({ deviceData, providersData, handleGetDeviceData }) {
             })
     }
 
+    function handleReprovisionDevice(event) {
+        setReprovisionLoading(true)
+        setReprovisionDeviceStatus(null)
+        event.preventDefault()
+
+        let url = `/device/${udid}/reset`
+
+        api.post(url)
+            .then(() => {
+                setReprovisionDeviceStatus('success')
+            })
+            .catch(() => {
+                setReprovisionDeviceStatus('error')
+            })
+            .finally(() => {
+                setTimeout(() => {
+                    setReprovisionLoading(false)
+                    setTimeout(() => {
+                        setReprovisionDeviceStatus(null)
+                    }, 2000)
+                }, 1000)
+            })
+    }
+
     function handleDeleteDevice(event) {
         event.preventDefault()
 
@@ -417,7 +443,7 @@ function ExistingDevice({ deviceData, providersData, handleGetDeviceData }) {
                 width: '400px',
                 minWidth: '400px',
                 maxWidth: '400px',
-                height: '780px',
+                height: '830px',
                 borderRadius: '5px',
                 backgroundColor: '#9ba984'
             }}
@@ -599,6 +625,28 @@ function ExistingDevice({ deviceData, providersData, handleGetDeviceData }) {
                             <CloseIcon size={25} style={{ color: 'red', stroke: 'red', strokeWidth: 2 }} />
                         ) : (
                             'Update device'
+                        )}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        style={{
+                            backgroundColor: '#2f3b26',
+                            color: '#f4e6cd',
+                            fontWeight: "bold",
+                            boxShadow: 'none',
+                            height: '40px'
+                        }}
+                        onClick={handleReprovisionDevice}
+                        disabled={reprovisionLoading || reprovisionDeviceStatus === 'success' || reprovisionDeviceStatus === 'error'}
+                    >
+                        {reprovisionLoading ? (
+                            <CircularProgress size={25} style={{ color: '#f4e6cd' }} />
+                        ) : reprovisionDeviceStatus === 'success' ? (
+                            <CheckIcon size={25} style={{ color: '#f4e6cd', stroke: '#f4e6cd', strokeWidth: 2 }} />
+                        ) : reprovisionDeviceStatus === 'error' ? (
+                            <CloseIcon size={25} style={{ color: 'red', stroke: 'red', strokeWidth: 2 }} />
+                        ) : (
+                            'Re-provision device'
                         )}
                     </Button>
                     <Button

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -398,6 +398,7 @@ func findAvailableDevice(caps CommonCapabilities) (*models.LocalHubDevice, error
 				if strings.EqualFold(localDevice.Device.OS, "ios") &&
 					!localDevice.InUse &&
 					localDevice.Device.Connected &&
+					localDevice.Device.ProviderState == "live" &&
 					localDevice.Device.LastUpdatedTimestamp >= (time.Now().UnixMilli()-3000) &&
 					localDevice.IsAvailableForAutomation &&
 					localDevice.Device.Usage != "control" &&
@@ -414,6 +415,7 @@ func findAvailableDevice(caps CommonCapabilities) (*models.LocalHubDevice, error
 				if strings.EqualFold(localDevice.Device.OS, "android") &&
 					!localDevice.InUse &&
 					localDevice.Device.Connected &&
+					localDevice.Device.ProviderState == "live" &&
 					localDevice.Device.LastUpdatedTimestamp >= (time.Now().UnixMilli()-3000) &&
 					localDevice.IsAvailableForAutomation &&
 					localDevice.Device.Usage != "control" &&

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -59,7 +59,12 @@ func UpdateExpiredGridSessions() {
 	for {
 		devices.HubDevicesData.Mu.Lock()
 		for _, hubDevice := range devices.HubDevicesData.Devices {
-			if !hubDevice.Device.Connected || (hubDevice.LastAutomationActionTS <= (time.Now().UnixMilli()-hubDevice.AppiumNewCommandTimeout) && hubDevice.IsRunningAutomation) {
+			// Reset device if its not connected
+			// Or it hasn't received any Appium requests in the command timeout and is running automation
+			// Or if its provider state is not "live" - device was re-provisioned for example
+			if !hubDevice.Device.Connected ||
+				(hubDevice.LastAutomationActionTS <= (time.Now().UnixMilli()-hubDevice.AppiumNewCommandTimeout) && hubDevice.IsRunningAutomation) ||
+				hubDevice.Device.ProviderState != "live" {
 				hubDevice.IsRunningAutomation = false
 				hubDevice.IsAvailableForAutomation = true
 				hubDevice.SessionID = ""

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -59,7 +59,7 @@ func UpdateExpiredGridSessions() {
 	for {
 		devices.HubDevicesData.Mu.Lock()
 		for _, hubDevice := range devices.HubDevicesData.Devices {
-			if hubDevice.LastAutomationActionTS <= (time.Now().UnixMilli()-hubDevice.AppiumNewCommandTimeout) && hubDevice.IsRunningAutomation {
+			if !hubDevice.Device.Connected || (hubDevice.LastAutomationActionTS <= (time.Now().UnixMilli()-hubDevice.AppiumNewCommandTimeout) && hubDevice.IsRunningAutomation) {
 				hubDevice.IsRunningAutomation = false
 				hubDevice.IsAvailableForAutomation = true
 				hubDevice.SessionID = ""
@@ -69,7 +69,7 @@ func UpdateExpiredGridSessions() {
 			}
 		}
 		devices.HubDevicesData.Mu.Unlock()
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -302,11 +302,6 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				return
 			}
 			defer resp.Body.Close()
-			fmt.Println("KOLEO")
-			fmt.Println(resp.StatusCode)
-			if resp.StatusCode == 404 {
-				fmt.Println("OMG")
-			}
 
 			// If the request succeeded and was a delete request, remove the session ID from the map
 			if c.Request.Method == http.MethodDelete {

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -706,8 +706,13 @@ func ProviderUpdate(c *gin.Context) {
 		devices.HubDevicesData.Mu.Lock()
 		hubDevice, ok := devices.HubDevicesData.Devices[providerDevice.UDID]
 		if ok {
-			// Do not update anything if device is not connected
+			// If device is not connected reset all fields that might allow it to get stuck in Running automation state
+			// If its not connected, then its not running automation or is available for automation
 			if !providerDevice.Connected {
+				hubDevice.IsAvailableForAutomation = false
+				hubDevice.IsRunningAutomation = false
+				hubDevice.InUseBy = ""
+				hubDevice.SessionID = ""
 				devices.HubDevicesData.Mu.Unlock()
 				continue
 			}

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -706,6 +706,12 @@ func ProviderUpdate(c *gin.Context) {
 		devices.HubDevicesData.Mu.Lock()
 		hubDevice, ok := devices.HubDevicesData.Devices[providerDevice.UDID]
 		if ok {
+			// Do not update anything if device is not connected
+			if !providerDevice.Connected {
+				fmt.Printf("DEVICE %v is not connected\n", providerDevice.UDID)
+				devices.HubDevicesData.Mu.Unlock()
+				continue
+			}
 			// Set a timestamp to indicate last time info about the device was updated from the provider
 			providerDevice.LastUpdatedTimestamp = time.Now().UnixMilli()
 
@@ -731,6 +737,8 @@ func ProviderUpdate(c *gin.Context) {
 			}
 
 			hubDevice.Device = providerDevice
+			// fmt.Println("DAMN")
+			// fmt.Println(hubDevice.Device.Connected)
 		}
 		devices.HubDevicesData.Mu.Unlock()
 	}

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -708,7 +708,6 @@ func ProviderUpdate(c *gin.Context) {
 		if ok {
 			// Do not update anything if device is not connected
 			if !providerDevice.Connected {
-				fmt.Printf("DEVICE %v is not connected\n", providerDevice.UDID)
 				devices.HubDevicesData.Mu.Unlock()
 				continue
 			}
@@ -737,8 +736,6 @@ func ProviderUpdate(c *gin.Context) {
 			}
 
 			hubDevice.Device = providerDevice
-			// fmt.Println("DAMN")
-			// fmt.Println(hubDevice.Device.Connected)
 		}
 		devices.HubDevicesData.Mu.Unlock()
 	}

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -309,7 +309,7 @@ func setupAndroidDevice(device *models.Device) {
 	}
 
 	go startAppium(device)
-	go checkAppiumtUp(device)
+	go checkAppiumUp(device)
 
 	select {
 	case <-device.AppiumReadyChan:
@@ -468,7 +468,7 @@ func setupIOSDevice(device *models.Device) {
 	}
 
 	go startAppium(device)
-	go checkAppiumtUp(device)
+	go checkAppiumUp(device)
 
 	// Wait until WebDriverAgent successfully starts
 	select {

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -17,6 +17,7 @@ import (
 	"GADS/common/models"
 	"GADS/provider/config"
 	"GADS/provider/logger"
+
 	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
 )
@@ -439,6 +440,31 @@ func checkWebDriverAgentUp(device *models.Device) {
 		} else {
 			if resp.StatusCode == http.StatusOK {
 				device.WdaReadyChan <- true
+				return
+			}
+		}
+		loops++
+	}
+}
+
+func checkAppiumtUp(device *models.Device) {
+	var netClient = &http.Client{
+		Timeout: time.Second * 120,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%v/status", device.AppiumPort), nil)
+
+	loops := 0
+	for {
+		if loops >= 30 {
+			return
+		}
+		resp, err := netClient.Do(req)
+		if err != nil {
+			time.Sleep(1 * time.Second)
+		} else {
+			if resp.StatusCode == http.StatusOK {
+				device.AppiumReadyChan <- true
 				return
 			}
 		}

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -447,7 +447,7 @@ func checkWebDriverAgentUp(device *models.Device) {
 	}
 }
 
-func checkAppiumtUp(device *models.Device) {
+func checkAppiumUp(device *models.Device) {
 	var netClient = &http.Client{
 		Timeout: time.Second * 120,
 	}

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -319,6 +319,14 @@ func ResetDevice(c *gin.Context) {
 	udid := c.Param("udid")
 
 	if device, ok := devices.DBDeviceMap[udid]; ok {
+		if device.IsResetting {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Device setup is already being reset"})
+			return
+		}
+		if device.ProviderState != "live" {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Only devices in `live` state can be reset, current state is `" + device.ProviderState + "`"})
+			return
+		}
 		device.IsResetting = true
 		device.CtxCancel()
 		device.ProviderState = "init"


### PR DESCRIPTION
* Added a button in the Admin panel for re-provisioning device if it gets stuck for some reason
* Make devices fully available after Appium server is up(last step in device provisioning)
* Handle devices in grid better