### PR TITLE
Fix json key reference

### DIFF
--- a/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
+++ b/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
@@ -25,7 +25,7 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
     let deviceScreenRatio = deviceX / deviceY
     let deviceLandscapeScreenRatio = deviceY / deviceX
     let deviceOS = deviceData.os
-    let usesCustomWda = deviceData.usesCustomWda
+    let usesCustomWda = deviceData.uses_custom_wda
     let udid = deviceData.udid
 
     let streamUrl = ''


### PR DESCRIPTION
* touch&hold in portrait and interactions in landscape on iOS using custom WebDriverAgent were not working due to a bad json key reference