### PR TITLE
Improve MongoDB Connection Pool Configuration

### DIFF
--- a/common/db/db.go
+++ b/common/db/db.go
@@ -41,7 +41,10 @@ func InitMongoClient(mongoDb string) {
 		ApplyURI(connectionString).
 		SetServerSelectionTimeout(maxTimeout).
 		SetConnectTimeout(5 * time.Second).
-		SetSocketTimeout(maxTimeout)
+		SetSocketTimeout(maxTimeout).
+		SetMaxPoolSize(200).
+		SetMinPoolSize(10).
+		SetMaxConnIdleTime(5 * time.Minute)
 
 	mongoClient, err = mongo.Connect(mongoClientCtx, clientOptions)
 	if err != nil {


### PR DESCRIPTION
This PR enhances MongoDB connection management by optimizing the connection pool settings for better performance and resource utilization:

Pool Size Configuration:
  - Max Pool Size: Set to 200 to handle high-concurrency scenarios efficiently.
  - Min Pool Size: Set to 10 to ensure a baseline number of connections are always available.

Connection Management:
  - Max Idle Time: Configured to 5 minutes, allowing idle connections to close after inactivity, reducing unnecessary resource consumption.
  - These improvements enhance database performance by balancing connection reuse and resource efficiency.