### PR TITLE
Fix Appium capabilities JSON formatting

### DIFF
--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -702,6 +702,8 @@ func startAppium(device *models.Device) {
 	}
 
 	capabilitiesJson, _ := json.Marshal(capabilities)
+	capabilitiesJsonString := fmt.Sprintf("'%s'", string(capabilitiesJson))
+
 	cmd := exec.CommandContext(
 		device.Context,
 		"appium",
@@ -711,7 +713,7 @@ func startAppium(device *models.Device) {
 		"--session-override",
 		"--log-no-colors",
 		"--relaxed-security",
-		"--default-capabilities", string(capabilitiesJson))
+		"--default-capabilities", capabilitiesJsonString)
 
 	logger.ProviderLogger.LogDebug("device_setup", fmt.Sprintf("Starting Appium on device `%s` with command `%s`", device.UDID, cmd.Args))
 	// Create a pipe to capture the command's output


### PR DESCRIPTION
This update modifies the `startAppium` function to properly format the --default-capabilities parameter by wrapping the JSON string in single quotes. This ensures that the capabilities are correctly parsed when passed to the Appium command.

Command without single quote:
```sh
appium -p 58792 --log-timestamp --session-override --log-no-colors --relaxed-security --default-capabilities {"appium:udid":"DEVICEID","appium:automationName":"UiAutomator2","platformName":"Android","appium:deviceName":"Moto e7"}
```

Output:
```sh
usage: appium server [-h] [--address ADDRESS] [--allow-cors] [--allow-insecure ALLOW_INSECURE] [--base-path BASE_PATH]
                     [--callback-address CALLBACK_ADDRESS] [--callback-port CALLBACK_PORT] [--debug-log-spacing]
                     [--default-capabilities DEFAULT_CAPABILITIES] [--deny-insecure DENY_INSECURE]
                     [--keep-alive-timeout KEEP_ALIVE_TIMEOUT] [--local-timezone] [--log LOG] [--log-filters LOG_FILTERS]
                     [--log-level LOG_LEVEL] [--log-format LOG_FORMAT] [--log-no-colors] [--log-timestamp]
                     [--plugins-import-chunk-size PLUGINS_IMPORT_CHUNK_SIZE]
                     [--drivers-import-chunk-size DRIVERS_IMPORT_CHUNK_SIZE] [--long-stacktrace] [--no-perms-check]
                     [--nodeconfig NODECONFIG] [--port PORT] [--relaxed-security] [--shutdown-timeout SHUTDOWN_TIMEOUT]
                     [--session-override] [--ssl-cert-path SSL_CERT_PATH] [--ssl-key-path SSL_KEY_PATH] [--strict-caps]
                     [--tmp TMP] [--trace-dir TRACE_DIR] [--use-drivers USE_DRIVERS] [--use-plugins USE_PLUGINS]
                     [--webhook WEBHOOK] [--shell] [--show-build-info] [--show-debug-info] [--show-config] [--config CONFIGFILE]

appium server: error: argument --default-capabilities/-dc: invalid  value: 'appium:udid:DEVICEID'
```

Comand with single quote:
```sh
 appium -p 58792 --log-timestamp --session-override --log-no-colors --relaxed-security --default-capabilities '{"appium:udid":"DEVICEID","appium:automationName":"UiAutomator2","platformName":"Android","appium:deviceName":"Moto e7"}'
```

Output:
```sh
2025-02-14 17:25:58:216 - [Appium] Welcome to Appium v2.15.0
2025-02-14 17:25:58:222 - [Appium] Non-default server args:
2025-02-14 17:25:58:226 - [Appium] {
  logNoColors: true,
  logTimestamp: true,
  port: 58792,
  relaxedSecurityEnabled: true,
  sessionOverride: true
}
2025-02-14 17:25:58:226 - [Appium] Default capabilities, which will be added to each request unless overridden by desired capabilities:
2025-02-14 17:25:58:227 - [Appium] {
  'appium:udid': 'DEVICEID',
  'appium:automationName': 'UiAutomator2',
  platformName: 'Android',
  'appium:deviceName': 'Moto e7'
}
```