### PR TITLE
Fix Concurrent Port Access in resetLocalDevice with Mutex Locking

### DIFF
--- a/common/mutex_manager.go
+++ b/common/mutex_manager.go
@@ -4,7 +4,8 @@ import "sync"
 
 // ResourceMutexManager manages different mutexes for various resources.
 type ResourceMutexManager struct {
-	StreamSettings sync.Mutex
+	StreamSettings            sync.Mutex
+	ResetLocalDeviceFreePorts sync.Mutex
 }
 
 // Global instance of ResourceMutexManager

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -676,6 +676,9 @@ func resetLocalDevice(device *models.Device, reason string) {
 			device.GoIOSTunnel.Close()
 		}
 
+		common.MutexManager.ResetLocalDeviceFreePorts.Lock()
+		defer common.MutexManager.ResetLocalDeviceFreePorts.Unlock()
+
 		// Free any used ports from the map where we keep them
 		delete(providerutil.UsedPorts, device.WDAPort)
 		delete(providerutil.UsedPorts, device.StreamPort)


### PR DESCRIPTION
This PR ensures thread-safe access when freeing ports in `resetLocalDevice` by introducing a dedicated mutex. Key changes include:

- Added `ResetLocalDeviceFreePorts` Mutex:
  - Introduced `ResetLocalDeviceFreePorts` in `ResourceMutexManager` to prevent race conditions.
  - Applied `Lock()` and `Unlock()` when modifying providerutil.UsedPorts.

- Improved Port Management in resetLocalDevice:
  - Prevented potential concurrency issues when multiple devices are reset simultaneously.

These changes improve stability in multi-threaded environments, ensuring proper resource cleanup.

fixes #160 