### PR TITLE
Refactor free port allocation for devices

### DIFF
--- a/common/mutex_manager.go
+++ b/common/mutex_manager.go
@@ -4,8 +4,8 @@ import "sync"
 
 // ResourceMutexManager manages different mutexes for various resources.
 type ResourceMutexManager struct {
-	StreamSettings            sync.Mutex
-	ResetLocalDeviceFreePorts sync.Mutex
+	StreamSettings   sync.Mutex
+	LocalDevicePorts sync.Mutex
 }
 
 // Global instance of ResourceMutexManager

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -745,14 +745,13 @@ func resetLocalDevice(device *models.Device, reason string) {
 			device.GoIOSTunnel.Close()
 		}
 
-		common.MutexManager.ResetLocalDeviceFreePorts.Lock()
-		defer common.MutexManager.ResetLocalDeviceFreePorts.Unlock()
-
 		// Free any used ports from the map where we keep them
+		common.MutexManager.LocalDevicePorts.Lock()
 		delete(providerutil.UsedPorts, device.WDAPort)
 		delete(providerutil.UsedPorts, device.StreamPort)
 		delete(providerutil.UsedPorts, device.AppiumPort)
 		delete(providerutil.UsedPorts, device.WDAStreamPort)
+		common.MutexManager.LocalDevicePorts.Unlock()
 	}
 }
 


### PR DESCRIPTION
* Use common mutex for allocating ports and removing them from the map on device reset
* Use loop instead of recursion for allocating ports and lock/unlock mutex only when accessing the UsedPorts map