### PR TITLE
Add platform-specific process detachment

### DIFF
--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -800,6 +800,8 @@ func startAppium(device *models.Device) {
 		"--relaxed-security",
 		"--default-capabilities", string(capabilitiesJson))
 
+	SetupProcessAttributes(cmd)
+
 	logger.ProviderLogger.LogDebug("device_setup", fmt.Sprintf("Starting Appium on device `%s` with command `%s`", device.UDID, cmd.Args))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/provider/devices/process_unix.go
+++ b/provider/devices/process_unix.go
@@ -1,0 +1,14 @@
+//go:build linux || darwin
+
+package devices
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func SetupProcessAttributes(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // This detaches the child process from the parent and terminal
+	}
+}

--- a/provider/devices/process_windows.go
+++ b/provider/devices/process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package devices
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func SetupProcessAttributes(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true, // Hide the window to detach the process from the terminal
+	}
+}


### PR DESCRIPTION
- The SetupProcessAttributes function was added with platform-specific logic to detach Appium processes from the terminal.
- For Unix-like systems (Linux/Darwin), the process is detached using Setsid.
- For Windows, the process window is hidden using HideWindow.