### PR TITLE
Support only custom WebDriverAgent fork

### DIFF
--- a/common/models/config.go
+++ b/common/models/config.go
@@ -14,7 +14,6 @@ type Provider struct {
 	ProviderFolder       string `json:"-" bson:"-"`
 	LastUpdatedTimestamp int64  `json:"last_updated" bson:"last_updated"`
 	UseGadsIosStream     bool   `json:"use_gads_ios_stream" bson:"use_gads_ios_stream"`
-	UseCustomWDA         bool   `json:"use_custom_wda" bson:"use_custom_wda"`
 	HubAddress           string `json:"hub_address" bson:"-"`
 }
 

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -66,8 +66,7 @@ type Device struct {
 	StreamScalingFactor  int    `json:"stream_scaling_factor,omitempty" bson:"-"` // The target scaling factor for the MJPEG video streams
 	/// PROVIDER ONLY VALUES
 	//// RETURNABLE VALUES
-	InstalledApps []string `json:"installed_apps" bson:"-"`  // list of installed apps on device
-	UsesCustomWDA bool     `json:"uses_custom_wda" bson:"-"` // Flag for iOS device if provider sets up custom WDA
+	InstalledApps []string `json:"installed_apps" bson:"-"` // list of installed apps on device
 	///// NON-RETURNABLE VALUES
 	AppiumSessionID  string             `json:"-" bson:"-"` // current Appium session ID
 	WDASessionID     string             `json:"-" bson:"-"` // current WebDriverAgent session ID

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -132,7 +132,10 @@ Example installation command for Ubuntu -  `sudo apt install usbmuxd`.
 
 #### WebDriverAgent ipa
 You need to prepare and upload a signed `WebDriverAgent` ipa file from the hub UI in `Admin > Files`  
-GADS supports only the custom WebDriverAgent from my fork.  
+GADS supports only WebDriverAgent from my [fork](https://github.com/shamanec/WebDriverAgent).  
+The fork has optimizations for the mjpeg video stream and additional endpoints for faster tap/swipe interactions that are not available in the mainstream repo.  
+Additionally those endpoints require different coordinates for interaction from mainstream WDA which forces separate handling for the remote control which is too much work.  
+Fork is kept up to date with latest mainstream.  
   
 #### Prebuilt custom WebDriverAgent
 - Download the prebuilt `WebDriverAgent.ipa` from my fork of [WebDriverAgent](https://github.com/shamanec/WebDriverAgent)

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -132,8 +132,7 @@ Example installation command for Ubuntu -  `sudo apt install usbmuxd`.
 
 #### WebDriverAgent ipa
 You need to prepare and upload a signed `WebDriverAgent` ipa file from the hub UI in `Admin > Files`  
-By using the custom WebDriverAgent from my fork you can have faster tap/swipe interactions on iOS devices (the provider configuration should be set to use the custom WebDriverAgent through hub UI).  
-You can use mainstream WebDriverAgent as well  
+GADS supports only the custom WebDriverAgent from my fork.  
   
 #### Prebuilt custom WebDriverAgent
 - Download the prebuilt `WebDriverAgent.ipa` from my fork of [WebDriverAgent](https://github.com/shamanec/WebDriverAgent)
@@ -143,20 +142,8 @@ You can use mainstream WebDriverAgent as well
   - [codesign](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html)
   - Re-sign from hub UI - TODO
 
-#### Prebuilt mainstream WebDriverAgent
-- Download the latest prebuilt `WebDriverAgentRunner-Runner.zip` from the [WebDriverAgent](https://github.com/appium/WebDriverAgent/releases) releases
-- Unzip the `.app` bundle in any folder.
-- Navigate to the folder above and create an empty directory with the name `Payload`.
-- Copy the `.app` bundle inside the `Payload` folder
-- Compress the `Payload` directory into an archive (.zip file) and give it a new name with `.ipa` appended to the end of the file name.
-- Use any tool to re-sign it with your developer account (or provisioning profile + certificate)
-  - [zsign](https://github.com/zhlynn/zsign)
-  - [fastlane-sigh](https://docs.fastlane.tools/actions/sigh/)
-  - [codesign](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html)
-  - Re-sign from hub UI - TODO
-
 #### Build WebDriverAgent IPA file manually using Xcode
-- Download the code of the latest mainstream [WebDriverAgent](https://github.com/appium/WebDriverAgent/releases) release or alternatively the code from the `main` branch of my fork of [WebDriverAgent](https://github.com/shamanec/WebDriverAgent) for faster tap/swipe interactions.
+- Download the code from the `main` branch of my fork of [WebDriverAgent](https://github.com/shamanec/WebDriverAgent).
 - Open `WebDriverAgent.xcodeproj` in Xcode.
 - Select signing profile for WebDriverAgentRunner. To do this go to: *Targets*, select WebDriverAgentRunner. There should be a field for assigning teams certificates to the target.
 - Select `Build > Clean build folder` (just in case)

--- a/hub/gads-ui/src/components/Admin/Providers/ProvidersAdministration.js
+++ b/hub/gads-ui/src/components/Admin/Providers/ProvidersAdministration.js
@@ -66,7 +66,6 @@ function NewProvider({ handleGetProvidersData }) {
     const [ios, setIos] = useState(false)
     const [android, setAndroid] = useState(false)
     const [wdaBundleId, setWdaBundleId] = useState('')
-    const [useCustomWda, setUseCustomWda] = useState(false)
     const [useSeleniumGrid, setUseSeleniumGrid] = useState(false)
     const [seleniumGridInstance, setSeleniumGridInstance] = useState('')
     const [loading, setLoading] = useState(false)
@@ -83,7 +82,6 @@ function NewProvider({ handleGetProvidersData }) {
         body.provide_ios = ios
         if (ios) {
             body.wda_bundle_id = wdaBundleId
-            body.use_custom_wda = useCustomWda
             body.supervision_password = supervisionPassword
         }
         body.use_selenium_grid = useSeleniumGrid
@@ -113,7 +111,6 @@ function NewProvider({ handleGetProvidersData }) {
                 setIos(false)
                 setAndroid(false)
                 setWdaBundleId('')
-                setUseCustomWda(false)
                 setUseSeleniumGrid(false)
                 setSeleniumGridInstance('')
                 setSupervisionPassword('')
@@ -267,26 +264,6 @@ function NewProvider({ handleGetProvidersData }) {
                         />
                     </Tooltip>
                     <Tooltip
-                        title='Select `Yes` if you are using the custom WebDriverAgent from my forked repository. It allows for faster tapping/swiping actions on iOS. If you are using mainstream WebDriverAgent this will break your interactions!'
-                        arrow
-                        placement='top'
-                    >
-                        <FormControl fullWidth required>
-                            <TextField
-                                size='small'
-                                value={useCustomWda}
-                                onChange={(e) => setUseCustomWda(e.target.value)}
-                                select
-                                label='Use custom WDA?'
-                                required
-                                disabled={!ios}
-                            >
-                                <MenuItem value={true}>Yes</MenuItem>
-                                <MenuItem value={false}>No</MenuItem>
-                            </TextField>
-                        </FormControl>
-                    </Tooltip>
-                    <Tooltip
                         title='Select `Yes` if you want the provider to register the devices Appium servers as Selenium Grid nodes. You need to have the Selenium Grid instance running separately from the provider!'
                         arrow
                         placement='top'
@@ -357,7 +334,6 @@ function ExistingProvider({ providerData, handleGetProvidersData }) {
     const [ios, setIos] = useState(providerData.provide_ios)
     const [android, setAndroid] = useState(providerData.provide_android)
     const [wdaBundleId, setWdaBundleId] = useState(providerData.wda_bundle_id)
-    const [useCustomWda, setUseCustomWda] = useState(providerData.use_custom_wda)
     const [useSeleniumGrid, setUseSeleniumGrid] = useState(providerData.use_selenium_grid)
     const [seleniumGridInstance, setSeleniumGridInstance] = useState(providerData.selenium_grid)
     const [supervisionPassword, setSupervisionPassword] = useState(providerData.supervision_password)
@@ -390,7 +366,6 @@ function ExistingProvider({ providerData, handleGetProvidersData }) {
         body.provide_ios = ios
         if (ios) {
             body.wda_bundle_id = wdaBundleId
-            body.use_custom_wda = useCustomWda
             body.supervision_password = supervisionPassword
         }
         body.use_selenium_grid = useSeleniumGrid
@@ -577,26 +552,6 @@ function ExistingProvider({ providerData, handleGetProvidersData }) {
                             autoComplete='off'
                             onChange={(event) => setSupervisionPassword(event.target.value)}
                         />
-                    </Tooltip>
-                    <Tooltip
-                        title='Select `Yes` if you are using the custom WebDriverAgent from my forked repository. It allows for faster tapping/swiping actions on iOS. If you are using mainstream WebDriverAgent this will break your interactions!'
-                        arrow
-                        placement='top'
-                    >
-                        <FormControl fullWidth required>
-                            <TextField
-                                size='small'
-                                value={useCustomWda}
-                                onChange={(e) => setUseCustomWda(e.target.value)}
-                                select
-                                label='Use custom WDA?'
-                                required
-                                disabled={!ios}
-                            >
-                                <MenuItem value={true}>Yes</MenuItem>
-                                <MenuItem value={false}>No</MenuItem>
-                            </TextField>
-                        </FormControl>
                     </Tooltip>
                     <Tooltip
                         title='Select `Yes` if you want the provider to register the devices Appium servers as Selenium Grid nodes. You need to have the Selenium Grid instance running separately from the provider!'

--- a/hub/gads-ui/src/components/DeviceControl/DeviceControl.js
+++ b/hub/gads-ui/src/components/DeviceControl/DeviceControl.js
@@ -151,34 +151,36 @@ export default function DeviceControl() {
                         fontWeight: 'bold'
                     }}
                 >Back to devices</Button>
-                <Tooltip
-                    title='Refresh the Appium session'
-                    arrow
-                    placement='bottom'
-                >
-                    <Button
-                        onClick={refreshAppiumSession}
-                        startIcon={
-                            <img
-                                src="/images/appium-logo.png"
-                                alt="icon"
-                                style={{
-                                    width: '24px',
-                                    height: '24px',
-                                }}
-                            />
-                        }
-                        variant='contained'
-                        style={{
-                            marginLeft: '20px',
-                            backgroundColor: '#2f3b26',
-                            color: '#9ba984',
-                            fontWeight: 'bold'
-                        }}
+                {deviceData?.os !== 'ios' && (
+                    <Tooltip
+                        title='Refresh the Appium session'
+                        arrow
+                        placement='bottom'
                     >
-                        Refresh
-                    </Button>
-                </Tooltip>
+                        <Button
+                            onClick={refreshAppiumSession}
+                            startIcon={
+                                <img
+                                    src="/images/appium-logo.png"
+                                    alt="icon"
+                                    style={{
+                                        width: '24px',
+                                        height: '24px',
+                                    }}
+                                />
+                            }
+                            variant='contained'
+                            style={{
+                                marginLeft: '20px',
+                                backgroundColor: '#2f3b26',
+                                color: '#9ba984',
+                                fontWeight: 'bold'
+                            }}
+                        >
+                            Refresh
+                        </Button>
+                    </Tooltip>
+                )}
             </div>
             {
                 isLoading ? (

--- a/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
+++ b/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
@@ -32,7 +32,6 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
     let deviceScreenRatio = deviceX / deviceY
     let deviceLandscapeScreenRatio = deviceY / deviceX
     let deviceOS = deviceData.os
-    let usesCustomWda = deviceData.uses_custom_wda
     let udid = deviceData.udid
     let useWebRTCVideo = deviceData.use_webrtc_video
     let webRTCVideoCodec = deviceData.webrtc_video_codec
@@ -619,15 +618,8 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
                 finalY = (y / canvasDimensions.width) * deviceY
             }
             if (deviceOS === 'ios') {
-                if (usesCustomWda) {
-                    finalX = deviceX - ((y / canvasDimensions.height) * deviceX)
-                    finalY = (x / canvasDimensions.width) * deviceY
-                } else {
-                    // On normal WDA in landscape X corresponds to the canvas width but it is actually the device's height
-                    finalX = (x / canvasDimensions.width) * deviceY
-                    // Y corresponds to the canvas height but it is actually the device's width
-                    finalY = (y / canvasDimensions.height) * deviceX
-                }
+                finalX = deviceX - ((y / canvasDimensions.height) * deviceX)
+                finalY = (x / canvasDimensions.width) * deviceY
             }
         }
 
@@ -675,15 +667,8 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
                 finalY = (y / canvasDimensions.width) * deviceY
             }
             if (deviceOS === 'ios') {
-                if (usesCustomWda) {
-                    finalX = deviceX - ((y / canvasDimensions.height) * deviceX)
-                    finalY = (x / canvasDimensions.width) * deviceY
-                } else {
-                    // On normal WDA in landscape X corresponds to the canvas width but it is actually the device's height
-                    finalX = (x / canvasDimensions.width) * deviceY
-                    // Y corresponds to the canvas height but it is actually the device's width
-                    finalY = (y / canvasDimensions.height) * deviceX
-                }
+                finalX = deviceX - ((y / canvasDimensions.height) * deviceX)
+                finalY = (x / canvasDimensions.width) * deviceY
             }
         }
 
@@ -736,36 +721,25 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
                 secondYFinal = (secondCoordY / canvasDimensions.width) * deviceY
             } else {
                 // For iOS its complete sh*t
-                if (usesCustomWda) {
-                    // NB: All calculations below are when the device is on its right side landscape(your left)
-                    // For custom WDA the 0 X coordinate is at the bottom of the canvas
-                    // And the 0 Y coordinate is at the left end of the canvas
-                    // This means that they kinda follow the portrait logic but inverted based on the side it is in landscape
-                    // Imagine a device that is X:Y=100:200
-                    // If you swipe vertically from bottom to the middle you are essentially swiping coordinates on the device X:0 and X: 50
-                    // And if you swipe horizontally from left to middle you are essentially swiping coordinates on the device Y: 0 and Y: 100
-                    // But on the canvas those are Y coordinates
-                    // And this is where it gets funky
-                    // For X we get the ratio from the canvas Y coordinate and the canvas height
-                    // And we multiply it by the device width because that is what it corresponds to
-                    // Then we subtract the value from the actual deviceX because the device width starts from the bottom of the canvas height
-                    firstXFinal = deviceX - ((firstCoordY / canvasDimensions.height) * deviceX)
-                    // For Y we get the ratio from the canvas X coordinate and the canvas width
-                    // And we multiply it by the device height because that is what it corresponds to
-                    firstYFinal = (firstCoordX / canvasDimensions.width) * deviceY
-                    // Same goes for the other two coordinates when the mouse is released
-                    secondXFinal = deviceX - ((secondCoordY / canvasDimensions.height) * deviceX)
-                    secondYFinal = (secondCoordX / canvasDimensions.width) * deviceY
-                } else {
-                    // On normal WDA the X coordinates correspond to the device height
-                    // and the Y coordinates correspond to the device width
-                    // So we calculate ratio based on canvas dimensions and coordinates
-                    // But multiply by device height for X swipe coordinates and by device width for Y swipe coordinates
-                    firstXFinal = (firstCoordX / canvasDimensions.width) * deviceY
-                    firstYFinal = (firstCoordY / canvasDimensions.height) * deviceX
-                    secondXFinal = (secondCoordX / canvasDimensions.width) * deviceY
-                    secondYFinal = (secondCoordY / canvasDimensions.height) * deviceX
-                }
+                // NB: All calculations below are when the device is on its right side landscape(your left)
+                // For custom WDA the 0 X coordinate is at the bottom of the canvas
+                // And the 0 Y coordinate is at the left end of the canvas
+                // This means that they kinda follow the portrait logic but inverted based on the side it is in landscape
+                // Imagine a device that is X:Y=100:200
+                // If you swipe vertically from bottom to the middle you are essentially swiping coordinates on the device X:0 and X: 50
+                // And if you swipe horizontally from left to middle you are essentially swiping coordinates on the device Y: 0 and Y: 100
+                // But on the canvas those are Y coordinates
+                // And this is where it gets funky
+                // For X we get the ratio from the canvas Y coordinate and the canvas height
+                // And we multiply it by the device width because that is what it corresponds to
+                // Then we subtract the value from the actual deviceX because the device width starts from the bottom of the canvas height
+                firstXFinal = deviceX - ((firstCoordY / canvasDimensions.height) * deviceX)
+                // For Y we get the ratio from the canvas X coordinate and the canvas width
+                // And we multiply it by the device height because that is what it corresponds to
+                firstYFinal = (firstCoordX / canvasDimensions.width) * deviceY
+                // Same goes for the other two coordinates when the mouse is released
+                secondXFinal = deviceX - ((secondCoordY / canvasDimensions.height) * deviceX)
+                secondYFinal = (secondCoordX / canvasDimensions.width) * deviceY
             }
         }
         console.log('Swipe is ' + firstXFinal + ':' + firstYFinal + '-' + secondXFinal + ':' + secondYFinal)

--- a/provider/devices/health.go
+++ b/provider/devices/health.go
@@ -12,6 +12,9 @@ import (
 
 // Check if a device is healthy by checking Appium and WebDriverAgent(for iOS) services
 func GetDeviceHealth(device *models.Device) (bool, error) {
+	if device.OS == "ios" {
+		return device.Connected, nil
+	}
 	err := checkAppiumSession(device)
 	if err != nil {
 		return false, err

--- a/provider/router/appium.go
+++ b/provider/router/appium.go
@@ -52,7 +52,7 @@ func appiumLockUnlock(device *models.Device, lock string) (*http.Response, error
 }
 
 func appiumTap(device *models.Device, x float64, y float64) (*http.Response, error) {
-	if config.ProviderConfig.UseCustomWDA && device.OS == "ios" {
+	if device.OS == "ios" {
 		requestBody := struct {
 			X float64 `json:"x"`
 			Y float64 `json:"y"`
@@ -109,7 +109,7 @@ func appiumTap(device *models.Device, x float64, y float64) (*http.Response, err
 
 func appiumTouchAndHold(device *models.Device, x float64, y float64) (*http.Response, error) {
 	// Generate the struct object for the Appium actions JSON request
-	if config.ProviderConfig.UseCustomWDA && device.OS == "ios" {
+	if device.OS == "ios" {
 		requestBody := struct {
 			X     float64 `json:"x"`
 			Y     float64 `json:"y"`
@@ -167,7 +167,7 @@ func appiumTouchAndHold(device *models.Device, x float64, y float64) (*http.Resp
 }
 
 func appiumSwipe(device *models.Device, x, y, endX, endY float64) (*http.Response, error) {
-	if config.ProviderConfig.UseCustomWDA && device.OS == "ios" {
+	if device.OS == "ios" {
 		requestBody := struct {
 			X     float64 `json:"startX"`
 			Y     float64 `json:"startY"`

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -241,7 +241,6 @@ func DeviceInfo(c *gin.Context) {
 
 	if dev, ok := devices.DBDeviceMap[udid]; ok {
 		devices.UpdateInstalledApps(dev)
-		dev.UsesCustomWDA = config.ProviderConfig.UseCustomWDA
 		c.JSON(http.StatusOK, dev)
 		return
 	}
@@ -372,7 +371,7 @@ func UpdateDeviceStreamSettings(c *gin.Context) {
 				device.StreamScalingFactor = streamSettings.ScalingFactor
 			}
 
-			err = devices.UpdateWebDriverAgentStreamSettings(device, false)
+			err = devices.UpdateWebDriverAgentStreamSettings(device)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update stream settings on iOS device " + err.Error()})
 				return


### PR DESCRIPTION
* Remove support for mainstream WebDriverAgent for device remote control
* Remove provider configuration property related to custom WebDriverAgent
* Update readme to include info only about custom WebDriverAgent fork
* Remove button for refreshing Appium session in remote control for iOS devices