### PR TITLE
Add keyboard typing to iOS remote control and improve app uninstall

### DIFF
--- a/common/api/api.go
+++ b/common/api/api.go
@@ -1,0 +1,15 @@
+package api
+
+import "github.com/gin-gonic/gin"
+
+type APIResponse struct {
+	Message string      `json:"message,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+}
+
+func GenericResponse(c *gin.Context, statusCode int, message string, result interface{}) {
+	c.JSON(statusCode, APIResponse{
+		Message: message,
+		Result:  result,
+	})
+}

--- a/common/db/stream_settings.go
+++ b/common/db/stream_settings.go
@@ -48,16 +48,16 @@ func (m *MongoStore) GetGlobalStreamSettings() (models.StreamSettings, error) {
 		}
 	} else if err != nil {
 		return streamSettings, err
-	}
+	} else {
+		settingsBytes, err := bson.Marshal(globalSettings.Settings)
+		if err != nil {
+			return streamSettings, fmt.Errorf("failed to marshal settings: %v", err)
+		}
 
-	settingsBytes, err := bson.Marshal(globalSettings.Settings)
-	if err != nil {
-		return streamSettings, fmt.Errorf("failed to marshal settings: %v", err)
-	}
-
-	err = bson.Unmarshal(settingsBytes, &streamSettings)
-	if err != nil {
-		return streamSettings, fmt.Errorf("failed to unmarshal settings: %v", err)
+		err = bson.Unmarshal(settingsBytes, &streamSettings)
+		if err != nil {
+			return streamSettings, fmt.Errorf("failed to unmarshal settings: %v", err)
+		}
 	}
 
 	return streamSettings, nil

--- a/hub/gads-ui/src/components/DeviceControl/DeviceControl.js
+++ b/hub/gads-ui/src/components/DeviceControl/DeviceControl.js
@@ -30,7 +30,7 @@ export default function DeviceControl() {
                 return api.get(infoUrl)
             })
             .then(response => {
-                setDeviceData(response.data)
+                setDeviceData(response.data.result)
                 setInterval(() => {
                     setIsLoading(false)
                 }, 1000)

--- a/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
+++ b/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
@@ -58,6 +58,7 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
 
             // Don't process keyboard events when user is typing somewhere
             if (isInputFocused) {
+                console.log(`Ignoring keyboard input because we have a focused element with a tagName '${activeElement.tagName}' and editable state '${activeElement.isContentEditable}'`)
                 return
             }
 

--- a/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
+++ b/hub/gads-ui/src/components/DeviceControl/StreamCanvas/StreamCanvas.js
@@ -178,8 +178,8 @@ export default function StreamCanvas({ deviceData, shouldShowStream }) {
         if (protocol === 'https:') {
             wsType = 'wss'
         }
-        // let socketUrl = `${wsType}://${window.location.host}/devices/control/${udid}/webrtc`
-        let socketUrl = `${wsType}://192.168.1.41:10000/devices/control/${udid}/webrtc`
+        let socketUrl = `${wsType}://${window.location.host}/devices/control/${udid}/webrtc`
+        //let socketUrl = `${wsType}://192.168.1.41:10000/devices/control/${udid}/webrtc`
         ws.current = new WebSocket(socketUrl)
 
         ws.current.onopen = () => {

--- a/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Apps/UninstallApp.js
+++ b/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Apps/UninstallApp.js
@@ -1,7 +1,7 @@
 import { Box, Button, CircularProgress, FormControl, MenuItem, Select, Stack } from '@mui/material'
 import InstallMobileIcon from '@mui/icons-material/InstallMobile'
 import './InstallApp.css'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { api } from '../../../../../services/api.js'
 import { useSnackbar } from '../../../../../contexts/SnackBarContext.js'
 
@@ -32,7 +32,11 @@ export default function UninstallApp({ udid, installedApps }) {
 
         api.post(url, body)
             .then((response) => {
-                setInstalledAppsList(response.data.result)
+                if (response.data.result) {
+                    setInstalledAppsList(response.data.result)
+                } else {
+                    setInstalledAppsList([])
+                }
                 setSelectedAppUninstall('no-app')
                 setIsUninstalling(false)
             })

--- a/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Apps/UninstallApp.js
+++ b/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Apps/UninstallApp.js
@@ -1,7 +1,7 @@
 import { Box, Button, CircularProgress, FormControl, MenuItem, Select, Stack } from '@mui/material'
 import InstallMobileIcon from '@mui/icons-material/InstallMobile'
 import './InstallApp.css'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { api } from '../../../../../services/api.js'
 import { useSnackbar } from '../../../../../contexts/SnackBarContext.js'
 
@@ -10,6 +10,7 @@ export default function UninstallApp({ udid, installedApps }) {
     const [selectedAppUninstall, setSelectedAppUninstall] = useState('no-app')
     const [uninstallButtonDisabled, setUninstallButtonDisabled] = useState(true)
     const [isUninstalling, setIsUninstalling] = useState(false)
+    const [installedAppsList, setInstalledAppsList] = useState(installedApps)
 
     function handleUninstallChange(event) {
         const app = event.target.value
@@ -30,7 +31,9 @@ export default function UninstallApp({ udid, installedApps }) {
         }
 
         api.post(url, body)
-            .then(() => {
+            .then((response) => {
+                setInstalledAppsList(response.data.result)
+                setSelectedAppUninstall('no-app')
                 setIsUninstalling(false)
             })
             .catch(error => {
@@ -65,16 +68,16 @@ export default function UninstallApp({ udid, installedApps }) {
                         id='form-control'
                     >
                         <Select
-                            defaultValue='no-app'
+                            value={selectedAppUninstall}
                             id='app-select'
                             onChange={(event) => handleUninstallChange(event)}
                         >
                             <MenuItem
                                 className='select-items'
-                                value='no-app'
+                                value={selectedAppUninstall}
                             >No app selected</MenuItem>
                             {
-                                installedApps.map((installedApp) => {
+                                installedAppsList.map((installedApp) => {
                                     return (
                                         <MenuItem
                                             className='select-items'

--- a/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Clipboard.js
+++ b/hub/gads-ui/src/components/DeviceControl/Tabs/Actions/Clipboard.js
@@ -13,7 +13,7 @@ export default function Clipboard({ deviceData }) {
         const url = `/device/${deviceData.udid}/getClipboard`
         api.get(url)
             .then((response) => {
-                navigator.clipboard.writeText(response.data)
+                navigator.clipboard.writeText(response.data.message)
                 setIsGettingCb(false)
                 showSnackbar({
                     message: 'Device clipboard copied!',

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -77,6 +77,11 @@ func StartHub(flags *pflag.FlagSet, appVersion string, uiFiles embed.FS, resourc
 		log.Fatalf("Failed adding admin user on start - %s", err)
 	}
 
+	_, err = db.GlobalMongoStore.GetGlobalStreamSettings()
+	if err != nil {
+		log.Fatalf("Failed to get/update global stream settings - %s", err)
+	}
+
 	// Check if the default workspace exists
 	defaultWorkspace, err := db.GlobalMongoStore.GetDefaultWorkspace()
 	if err != nil {

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/gobwas/ws"
@@ -187,7 +188,7 @@ func GetInstalledAppsAndroid(device *models.Device) []string {
 	// Get the command output to string
 	result := strings.TrimSpace(outBuffer.String())
 	// Get all lines with package names
-	lines := strings.Split(result, "\n")
+	lines := regexp.MustCompile("\r?\n").Split(result, -1)
 
 	// Clean the package names and add them to the device installed apps
 	for _, line := range lines {

--- a/provider/router/appium.go
+++ b/provider/router/appium.go
@@ -342,7 +342,7 @@ func appiumActivateApp(device *models.Device, appIdentifier string) (*http.Respo
 			return nil, fmt.Errorf("appiumActivateApp: Failed to marshal request body json when activating app for device `%s` - %s", device.UDID, err)
 		}
 
-		return appiumRequest(device, http.MethodPost, "appium/device/activate_app", bytes.NewReader(reqJson))
+		return wdaRequest(device, http.MethodPost, "wda/apps/activate", bytes.NewReader(reqJson))
 	case "android":
 		requestBody := struct {
 			AppId string `json:"appId"`
@@ -380,7 +380,7 @@ func appiumGetClipboard(device *models.Device) (*http.Response, error) {
 		}
 		defer activateAppResp.Body.Close()
 
-		clipboardResp, err := appiumRequest(device, http.MethodPost, "appium/device/get_clipboard", bytes.NewReader(reqJson))
+		clipboardResp, err := wdaRequest(device, http.MethodPost, "wda/getPasteboard", bytes.NewReader(reqJson))
 		if err != nil {
 			return clipboardResp, fmt.Errorf("appiumGetClipboard: Failed to execute Appium request for device `%s` - %s", device.UDID, err)
 		}

--- a/provider/router/appium.go
+++ b/provider/router/appium.go
@@ -261,25 +261,37 @@ func getActiveElementID(resp *http.Response) (string, error) {
 }
 
 func appiumTypeText(device *models.Device, text string) (*http.Response, error) {
-	activeElementResp, err := appiumGetActiveElement(device)
-	if err != nil {
-		return activeElementResp, err
-	}
+	if device.OS == "ios" {
+		typeTextPayload := models.AppiumTypeText{
+			Text: text,
+		}
+		typeJSON, err := json.MarshalIndent(typeTextPayload, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return wdaRequest(device, http.MethodPost, "wda/type", bytes.NewBuffer(typeJSON))
+	} else {
+		activeElementResp, err := appiumGetActiveElement(device)
+		if err != nil {
+			return activeElementResp, err
+		}
 
-	activeElementID, err := getActiveElementID(activeElementResp)
-	if err != nil {
-		return nil, err
-	}
+		activeElementID, err := getActiveElementID(activeElementResp)
+		if err != nil {
+			return nil, err
+		}
 
-	typeTextPayload := models.AppiumTypeText{
-		Text: text,
-	}
+		typeTextPayload := models.AppiumTypeText{
+			Text: text,
+		}
 
-	typeJSON, err := json.MarshalIndent(typeTextPayload, "", "  ")
-	if err != nil {
-		return nil, err
+		typeJSON, err := json.MarshalIndent(typeTextPayload, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+
+		return appiumRequest(device, http.MethodPost, fmt.Sprintf("element/%s/value", activeElementID), bytes.NewBuffer(typeJSON))
 	}
-	return appiumRequest(device, http.MethodPost, fmt.Sprintf("element/%s/value", activeElementID), bytes.NewBuffer(typeJSON))
 }
 
 func appiumClearText(device *models.Device) (*http.Response, error) {

--- a/provider/router/device_routes.go
+++ b/provider/router/device_routes.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 
+	"GADS/common/api"
 	"GADS/common/models"
 	"GADS/provider/devices"
 
@@ -29,18 +30,18 @@ func DeviceHealth(c *gin.Context) {
 	bool, err := devices.GetDeviceHealth(dev)
 	if err != nil {
 		dev.Logger.LogInfo("device", fmt.Sprintf("Could not check device health - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
 	if bool {
 		dev.Logger.LogInfo("device", "Device is healthy")
-		c.Writer.WriteHeader(200)
+		api.GenericResponse(c, http.StatusOK, "Device is healthy", nil)
 		return
 	}
 
 	dev.Logger.LogError("device", "Device is not healthy")
-	c.Writer.WriteHeader(500)
+	api.GenericResponse(c, http.StatusInternalServerError, "Device is not healthy", nil)
 }
 
 // Call the respective Appium/WDA endpoint to go to Homescreen
@@ -53,7 +54,7 @@ func DeviceHome(c *gin.Context) {
 	homeResponse, err := appiumHome(device)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to navigate to Home/Springboard - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, "Failed to navigate to Home/Springboard", nil)
 		return
 	}
 	defer homeResponse.Body.Close()
@@ -62,13 +63,11 @@ func DeviceHome(c *gin.Context) {
 	homeResponseBody, err := io.ReadAll(homeResponse.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to navigate to Home/Springboard - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, "Failed to navigate to Home/Springboard", nil)
 		return
 	}
 
-	c.Writer.WriteHeader(homeResponse.StatusCode)
-	copyHeaders(c.Writer.Header(), homeResponse.Header)
-	fmt.Fprintf(c.Writer, string(homeResponseBody))
+	api.GenericResponse(c, homeResponse.StatusCode, string(homeResponseBody), nil)
 }
 
 func DeviceGetClipboard(c *gin.Context) {
@@ -80,7 +79,7 @@ func DeviceGetClipboard(c *gin.Context) {
 	clipboardResponse, err := appiumGetClipboard(device)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to get device clipboard value - %s", err))
-		c.String(http.StatusInternalServerError, "")
+		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
 		return
 	}
 	defer clipboardResponse.Body.Close()
@@ -89,7 +88,7 @@ func DeviceGetClipboard(c *gin.Context) {
 	clipboardResponseBody, err := io.ReadAll(clipboardResponse.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to read clipboard response body while getting clipboard value - %s", err))
-		c.String(http.StatusInternalServerError, "")
+		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
 		return
 	}
 
@@ -100,12 +99,12 @@ func DeviceGetClipboard(c *gin.Context) {
 	err = json.Unmarshal(clipboardResponseBody, &valueResp)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to unmarshal clipboard response body - %s", err))
-		c.String(http.StatusInternalServerError, "")
+		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
 	}
 
 	// Decode the value because Appium returns it as base64 encoded string
 	decoded, _ := base64.StdEncoding.DecodeString(valueResp.Value)
-	c.String(http.StatusOK, string(decoded))
+	api.GenericResponse(c, http.StatusOK, string(decoded), nil)
 }
 
 // Call respective Appium/WDA endpoint to lock the device
@@ -117,7 +116,7 @@ func DeviceLock(c *gin.Context) {
 	lockResponse, err := appiumLockUnlock(device, "lock")
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to lock device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer lockResponse.Body.Close()
@@ -126,13 +125,11 @@ func DeviceLock(c *gin.Context) {
 	lockResponseBody, err := io.ReadAll(lockResponse.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to lock device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(lockResponse.StatusCode)
-	copyHeaders(c.Writer.Header(), lockResponse.Header)
-	fmt.Fprintf(c.Writer, string(lockResponseBody))
+	api.GenericResponse(c, lockResponse.StatusCode, string(lockResponseBody), nil)
 }
 
 // Call the respective Appium/WDA endpoint to unlock the device
@@ -144,7 +141,7 @@ func DeviceUnlock(c *gin.Context) {
 	lockResponse, err := appiumLockUnlock(device, "unlock")
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to unlock device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer lockResponse.Body.Close()
@@ -153,13 +150,11 @@ func DeviceUnlock(c *gin.Context) {
 	lockResponseBody, err := io.ReadAll(lockResponse.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to unlock device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(lockResponse.StatusCode)
-	copyHeaders(c.Writer.Header(), lockResponse.Header)
-	fmt.Fprintf(c.Writer, string(lockResponseBody))
+	api.GenericResponse(c, lockResponse.StatusCode, string(lockResponseBody), nil)
 }
 
 // Call the respective Appium/WDA endpoint to take a screenshot of the device screen
@@ -175,13 +170,11 @@ func DeviceScreenshot(c *gin.Context) {
 	screenshotRespBody, err := io.ReadAll(screenshotResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to get screenshot from device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(screenshotResp.StatusCode)
-	copyHeaders(c.Writer.Header(), screenshotResp.Header)
-	fmt.Fprintf(c.Writer, string(screenshotRespBody))
+	api.GenericResponse(c, screenshotResp.StatusCode, string(screenshotRespBody), nil)
 }
 
 //======================================
@@ -195,7 +188,7 @@ func DeviceAppiumSource(c *gin.Context) {
 	sourceResp, err := appiumSource(device)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to get Appium source from device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
@@ -203,14 +196,12 @@ func DeviceAppiumSource(c *gin.Context) {
 	body, err := io.ReadAll(sourceResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to get Appium source from device - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer sourceResp.Body.Close()
 
-	c.Writer.WriteHeader(sourceResp.StatusCode)
-	copyHeaders(c.Writer.Header(), sourceResp.Header)
-	fmt.Fprint(c.Writer, string(body))
+	api.GenericResponse(c, sourceResp.StatusCode, string(body), nil)
 }
 
 //=======================================
@@ -223,7 +214,7 @@ func DeviceTypeText(c *gin.Context) {
 	var requestBody models.ActionData
 	if err := json.NewDecoder(c.Request.Body).Decode(&requestBody); err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to type text to active element - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
@@ -232,21 +223,19 @@ func DeviceTypeText(c *gin.Context) {
 	typeResp, err := appiumTypeText(device, requestBody.TextToType)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to type `%s` to active element - %s", requestBody.TextToType, err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
 	body, err := io.ReadAll(typeResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to type `%s` to active element - %s", requestBody.TextToType, err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer typeResp.Body.Close()
 
-	c.Writer.WriteHeader(typeResp.StatusCode)
-	copyHeaders(c.Writer.Header(), typeResp.Header)
-	fmt.Fprintf(c.Writer, string(body))
+	api.GenericResponse(c, typeResp.StatusCode, string(body), nil)
 }
 
 func DeviceClearText(c *gin.Context) {
@@ -257,21 +246,19 @@ func DeviceClearText(c *gin.Context) {
 	clearResp, err := appiumClearText(device)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Could not clear text from active element - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
 	body, err := io.ReadAll(clearResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Could not clear text from active element - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer clearResp.Body.Close()
 
-	c.Writer.WriteHeader(clearResp.StatusCode)
-	copyHeaders(c.Writer.Header(), clearResp.Header)
-	fmt.Fprintf(c.Writer, string(body))
+	api.GenericResponse(c, clearResp.StatusCode, string(body), nil)
 }
 
 func DeviceTap(c *gin.Context) {
@@ -280,7 +267,7 @@ func DeviceTap(c *gin.Context) {
 
 	var requestBody models.ActionData
 	if err := json.NewDecoder(c.Request.Body).Decode(&requestBody); err != nil {
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
@@ -289,7 +276,7 @@ func DeviceTap(c *gin.Context) {
 	tapResp, err := appiumTap(device, requestBody.X, requestBody.Y)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to tap at coordinates X:%v Y:%v - %s", fmt.Sprintf("%.2f", requestBody.X), fmt.Sprintf("%.2f", requestBody.Y), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer tapResp.Body.Close()
@@ -298,13 +285,11 @@ func DeviceTap(c *gin.Context) {
 	body, err := io.ReadAll(tapResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to tap at coordinates X:%v Y:%v` - %s", fmt.Sprintf("%.2f", requestBody.X), fmt.Sprintf("%.2f", requestBody.Y), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(tapResp.StatusCode)
-	copyHeaders(c.Writer.Header(), tapResp.Header)
-	fmt.Fprint(c.Writer, string(body))
+	api.GenericResponse(c, tapResp.StatusCode, string(body), nil)
 }
 
 func DeviceTouchAndHold(c *gin.Context) {
@@ -313,7 +298,7 @@ func DeviceTouchAndHold(c *gin.Context) {
 
 	var requestBody models.ActionData
 	if err := json.NewDecoder(c.Request.Body).Decode(&requestBody); err != nil {
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
@@ -322,7 +307,7 @@ func DeviceTouchAndHold(c *gin.Context) {
 	touchAndHoldResp, err := appiumTouchAndHold(device, requestBody.X, requestBody.Y)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to touch and hold at coordinates X:%v Y:%v - %s", fmt.Sprintf("%.2f", requestBody.X), fmt.Sprintf("%.2f", requestBody.Y), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer touchAndHoldResp.Body.Close()
@@ -331,13 +316,11 @@ func DeviceTouchAndHold(c *gin.Context) {
 	body, err := io.ReadAll(touchAndHoldResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to touch and hold at coordinates X:%v Y:%v` - %s", fmt.Sprintf("%.2f", requestBody.X), fmt.Sprintf("%.2f", requestBody.Y), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(touchAndHoldResp.StatusCode)
-	copyHeaders(c.Writer.Header(), touchAndHoldResp.Header)
-	fmt.Fprint(c.Writer, string(body))
+	api.GenericResponse(c, touchAndHoldResp.StatusCode, string(body), nil)
 }
 
 func DeviceSwipe(c *gin.Context) {
@@ -347,7 +330,7 @@ func DeviceSwipe(c *gin.Context) {
 	var requestBody models.ActionData
 	if err := json.NewDecoder(c.Request.Body).Decode(&requestBody); err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to decode request body when performing swipe - %s", err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
@@ -356,7 +339,7 @@ func DeviceSwipe(c *gin.Context) {
 	swipeResp, err := appiumSwipe(device, requestBody.X, requestBody.Y, requestBody.EndX, requestBody.EndY)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to swipe from X:%v Y:%v to X:%v Y:%v - %s", fmt.Sprintf("%.3f", requestBody.X), fmt.Sprintf("%.3f", requestBody.Y), fmt.Sprintf("%.3f", requestBody.EndX), fmt.Sprintf("%.3f", requestBody.EndY), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 	defer swipeResp.Body.Close()
@@ -365,11 +348,9 @@ func DeviceSwipe(c *gin.Context) {
 	body, err := io.ReadAll(swipeResp.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to swipe from X:%v Y:%v to X:%v Y:%v - %s", fmt.Sprintf("%.3f", requestBody.X), fmt.Sprintf("%.3f", requestBody.Y), fmt.Sprintf("%.3f", requestBody.EndX), fmt.Sprintf("%.3f", requestBody.EndY), err))
-		c.String(http.StatusInternalServerError, err.Error())
+		api.GenericResponse(c, http.StatusInternalServerError, err.Error(), nil)
 		return
 	}
 
-	c.Writer.WriteHeader(swipeResp.StatusCode)
-	copyHeaders(c.Writer.Header(), swipeResp.Header)
-	fmt.Fprint(c.Writer, string(body))
+	api.GenericResponse(c, swipeResp.StatusCode, string(body), nil)
 }

--- a/provider/router/device_routes.go
+++ b/provider/router/device_routes.go
@@ -79,7 +79,7 @@ func DeviceGetClipboard(c *gin.Context) {
 	clipboardResponse, err := appiumGetClipboard(device)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to get device clipboard value - %s", err))
-		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
+		api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to get device clipboard value - %s", err), nil)
 		return
 	}
 	defer clipboardResponse.Body.Close()
@@ -88,7 +88,7 @@ func DeviceGetClipboard(c *gin.Context) {
 	clipboardResponseBody, err := io.ReadAll(clipboardResponse.Body)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to read clipboard response body while getting clipboard value - %s", err))
-		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
+		api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to read clipboard response body while getting clipboard value - %s", err), nil)
 		return
 	}
 
@@ -99,7 +99,8 @@ func DeviceGetClipboard(c *gin.Context) {
 	err = json.Unmarshal(clipboardResponseBody, &valueResp)
 	if err != nil {
 		device.Logger.LogError("appium_interact", fmt.Sprintf("Failed to unmarshal clipboard response body - %s", err))
-		api.GenericResponse(c, http.StatusInternalServerError, "", nil)
+		api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to unmarshal clipboard response body - %s", err), nil)
+		return
 	}
 
 	// Decode the value because Appium returns it as base64 encoded string

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -314,7 +314,7 @@ func ResetDevice(c *gin.Context) {
 
 	if device, ok := devices.DBDeviceMap[udid]; ok {
 		if device.IsResetting {
-			api.GenericResponse(c, http.StatusInternalServerError, "Device setup is already being reset", nil)
+			api.GenericResponse(c, http.StatusConflict, "Device setup is already being reset", nil)
 			return
 		}
 		if device.ProviderState != "live" {


### PR DESCRIPTION
* Add the ability to type with your keyboard into focused fields on iOS in remote control
* Improve app uninstall in remote control
* Add generic api response to start streamlining api responses across the project
* Fix typing and getting clipboard on iOS after moving to custom WDA