### PR TITLE
Fix WorkspaceID Sync in Provider Device Update Process

### DIFF
--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -69,8 +69,16 @@ func updateProviderHub() {
 
 		mu.Lock()
 
+		updatedDevices := getDBProviderDevices()
+
 		var properJson models.ProviderData
 		for _, dbDevice := range DBDeviceMap {
+
+			// Update the WorkspaceID in dbDevice from the updatedDevices map
+			if updatedDevice, ok := updatedDevices[dbDevice.UDID]; ok {
+				dbDevice.WorkspaceID = updatedDevice.WorkspaceID
+			}
+
 			properJson.DeviceData = append(properJson.DeviceData, *dbDevice)
 			properJson.ProviderData = *config.ProviderConfig
 		}


### PR DESCRIPTION
This PR ensures that the WorkspaceID field in device records is accurately updated during the updateProviderHub process. It fetches the latest device records from the database and synchronizes the WorkspaceID for each device in DBDeviceMap before sending the updated device data to the hub. This fix guarantees consistency between the stored device data and the provider state.

fixes #186 