### PR TITLE
Fix Race Condition by Setting LastActionTS in DeviceInUseWS

### DIFF
--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -652,6 +652,7 @@ func DeviceInUseWS(c *gin.Context) {
 	// This prevents another user from passing the verification while we are upgrading the WebSocket
 	devices.HubDevicesData.Devices[udid].InUseTS = time.Now().UnixMilli()
 	devices.HubDevicesData.Devices[udid].InUseBy = username
+	devices.HubDevicesData.Devices[udid].LastActionTS = time.Now().UnixMilli()
 	devices.HubDevicesData.Mu.Unlock()
 
 	conn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)


### PR DESCRIPTION
This PR resolves a race condition between DeviceInUseWS and DeviceProxyHandler where LastActionTS could be overwritten with an outdated value. By explicitly setting LastActionTS during the WebSocket claim, we ensure the device’s activity timestamp reflects the most recent user interaction reliably