### PR TITLE
Preserve Device Name in Tizen Info Update

### DIFF
--- a/provider/devices/tizen.go
+++ b/provider/devices/tizen.go
@@ -118,7 +118,6 @@ func getTizenTVInfo(device *models.Device) error {
 	}
 
 	// Update device information
-	device.Name = tvInfo.Device.Name
 	device.HardwareModel = tvInfo.Device.ModelName
 	device.OSVersion = tvInfo.Version
 	device.IPAddress = tvInfo.Device.IP


### PR DESCRIPTION
- Removed assignment of 'device.Name' from 'getTizenTVInfo'
- Prevents erasing user-defined or registered names with remote metadata