### PR TITLE
Ensure Clean Start of RemoteControlServer

### DIFF
--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -118,6 +118,12 @@ func pushGadsSettingsInTmpLocal(device *models.Device) error {
 // Starts the GADS-Settings remote control server as app_process from /data/local/tmp.
 // The remote control server provides endpoints for tapping/swiping and other interactions independent from Appium server
 func startGadsRemoteControlServer(device *models.Device) {
+	// Kill existing process first
+	killCmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "shell", "pkill -f RemoteControlServerKt")
+	_ = killCmd.Run() // Ignore error - process might not exist
+
+	time.Sleep(1 * time.Second)
+
 	cmd := exec.CommandContext(
 		device.Context,
 		"adb",


### PR DESCRIPTION
This prevents issues with multiple processes trying to bind to port 1994 and ensures only a single RemoteControlServer is active per Android device