### PR TITLE
Add Support for LG WebOS TVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
   Title: GADS - Open Source Device Farm
-  Description: Self-hosted device farm and test automation platform for iOS, Android, and Samsung Tizen OS smart TVs. Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
+  Description: Self-hosted device farm and test automation platform for iOS, Android, and Smart TVs (Samsung Tizen OS, LG WebOS). Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
   Author: shamanec
   Tags: device-farm, mobile-testing, ios-testing, android-testing, appium, test-automation, qa-tools, continuous-testing, mobile-device-management, selenium-grid
   -->
@@ -24,7 +24,7 @@
 
 ## 🎯 What is GADS?
 
-**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (Samsung Tizen OS). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
+**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS and LG WebOS). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
 
 The platform architecture consists of two main components:
 - **Hub**: A web interface for remote device control and provider management.
@@ -32,7 +32,7 @@ The platform architecture consists of two main components:
 
 ### Why Choose GADS?
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
-- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Samsung Tizen OS smart TVs
+- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
 - 🔑 **Flexible Authentication**: Support for multiple JWT issuers with origin-based keys
@@ -79,17 +79,17 @@ The platform architecture consists of two main components:
 - 🧪 **Testing Integration**
   - Individual Appium server endpoints (optional)
   - Optional Selenium Grid 4 node registration
-  - Automated testing for Samsung Tizen OS smart TVs (no remote control, testing only)
+  - Automated testing for Smart TVs - currently supports Samsung Tizen OS and LG WebOS (no remote control, testing only)
 
 ## 💻 Platform Support
 
-| OS         | Android Support | iOS Support | Tizen OS Support    | Notes                                                             |
-|------------|----------------|-------------|----------------------|-------------------------------------------------------------------|
-| **macOS**  | ✅             | ✅           | ✅ (automation only) | Full support for mobile, Tizen OS supports only automated testing |
-| **Linux**  | ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency                       |
-| **Windows**| ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency                       |
+| OS         | Android Support | iOS Support | Smart TV Support    | Notes                                                                          |
+|------------|----------------|-------------|---------------------|--------------------------------------------------------------------------------|
+| **macOS**  | ✅             | ✅           | ✅ (automation only) | Full support for mobile, Smart TVs support only automated testing             |
+| **Linux**  | ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
+| **Windows**| ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
 
-**Important**: Tizen OS support is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
+**Important**: Smart TV support (Tizen OS and WebOS) is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
 
 ## License
 
@@ -227,7 +227,8 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 - **Device Lab Management**: Centralized management of your organization's mobile devices
 
 ### Smart TV Testing 📺
-- **Tizen OS App Testing**: Automated testing of applications for Samsung smart TVs
+- **Smart TV App Testing**: Automated testing for TV applications
+- **Currently Supported**: Samsung Tizen OS and LG WebOS
 - **TV-Specific Testing**: Validate TV app functionality, performance, and compatibility
 - **Remote-First Testing**: Test TV apps without physical access to devices
 
@@ -238,4 +239,4 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 
 ## 🔍 Keywords
 
-`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`
+`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`, `webos-testing`, `lg-tv-testing`

--- a/common/models/appium.go
+++ b/common/models/appium.go
@@ -71,6 +71,7 @@ type AppiumServerCapabilities struct {
 	WdaLaunchTimeout       string `json:"appium:wdaLaunchTimeout,omitempty"`
 	WdaConnectionTimeout   string `json:"appium:wdaConnectionTimeout,omitempty"`
 	DeviceAddress          string `json:"appium:deviceAddress,omitempty"`
+	DeviceHost             string `json:"appium:deviceHost,omitempty"`
 	ChromeDriverExecutable string `json:"appium:chromedriverExecutable,omitempty"`
 }
 

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -19,6 +19,7 @@ type Provider struct {
 	ProvideAndroid       bool   `json:"provide_android" bson:"provide_android"`
 	ProvideIOS           bool   `json:"provide_ios" bson:"provide_ios"`
 	ProvideTizen         bool   `json:"provide_tizen" bson:"provide_tizen"`
+	ProvideWebOS         bool   `json:"provide_webos" bson:"provide_webos"`
 	WdaBundleID          string `json:"wda_bundle_id" bson:"wda_bundle_id"`
 	SupervisionPassword  string `json:"supervision_password" bson:"supervision_password"`
 	ProviderFolder       string `json:"-" bson:"-"`
@@ -45,9 +46,10 @@ type HubConfig struct {
 }
 
 // RegularizeProviderState applies business rules to ensure provider configuration is consistent
-// If SetupAppiumServers is false, ProvideTizen must also be false since Tizen requires Appium servers
+// If SetupAppiumServers is false, ProvideTizen and ProvideWebOS must also be false since they require Appium servers
 func (p *Provider) RegularizeProviderState() {
 	if !p.SetupAppiumServers {
 		p.ProvideTizen = false
+		p.ProvideWebOS = false
 	}
 }

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -281,6 +281,13 @@ func ValidateDeviceUsageForOS(os, usage string) error {
 		}
 	}
 
+	// Validate WebOS devices can only be used for automation
+	if normalizedOS == "webos" {
+		if normalizedUsage != "automation" {
+			return fmt.Errorf("webos devices only support 'automation' usage. Current usage '%s' is not supported. WebOS devices can only be used for Appium testing and automation", usage)
+		}
+	}
+
 	return nil
 }
 

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -14,6 +14,7 @@ The provider component is responsible for setting up the Appium servers and mana
   - [iOS Phones](#ios-phones)
   - [Android](#android-phone)
   - [Tizen TV](#tizen-tv)
+  - [WebOS TV](#webos-tv)
 - [Starting Provider Instance](#starting-a-provider-instance)
 - [Logging](#logging)
 
@@ -53,6 +54,10 @@ To specify a folder, create it on your machine and provide it at startup using t
 - **Install** [SDB (Smart Development Bridge)](#sdb---tizen-only)
 - **Enable** [Developer Mode](#developer-mode-tizen) on each Tizen TV
 
+#### WebOS
+- **Install** [WebOS CLI](#webos-cli---webos-only)
+- **Enable** [Developer Mode](#developer-mode---webos) on each WebOS TV
+
 <br>
 
 ---
@@ -73,6 +78,10 @@ To specify a folder, create it on your machine and provide it at startup using t
 #### Tizen
 - **Install** [SDB (Smart Development Bridge)](#sdb---tizen-only)
 - **Enable** [Developer Mode](#developer-mode-tizen) on each Tizen TV
+
+#### WebOS
+- **Install** [WebOS CLI](#webos-cli---webos-only)
+- **Enable** [Developer Mode](#developer-mode---webos) on each WebOS TV
 
 #### ⚠️ Known Limitations - Linux, iOS
 1. The command **driver.executeScript("mobile: startPerfRecord")** cannot be executed due to the unavailability of Xcode tools.
@@ -100,6 +109,10 @@ To specify a folder, create it on your machine and provide it at startup using t
 - **Install** [SDB (Smart Development Bridge)](#sdb---tizen-only)
 - **Enable** [Developer Mode](#developer-mode-tizen) on each Tizen TV
 
+#### WebOS
+- **Install** [WebOS CLI](#webos-cli---webos-only)
+- **Enable** [Developer Mode](#developer-mode---webos) on each WebOS TV
+
 #### ⚠️ Known Limitations - Windows, iOS
 1. The command **driver.executeScript("mobile: startPerfRecord")** cannot be executed due to the unavailability of Xcode tools.
 2. Any functionality requiring Instruments or other Xcode/macOS-exclusive tools is limited.
@@ -117,6 +130,7 @@ Installation is pretty similar for all operating systems, you just have to find 
   - iOS - `appium driver install xcuitest`
   - Android - `appium driver install uiautomator2`
   - Tizen TV - `appium driver install --source=npm appium-tizen-tv-driver`
+  - WebOS TV - `appium driver install --source=npm appium-lg-webos-driver`
 - Add any additional Appium dependencies like `ANDROID_HOME`(Android SDK) environment variable, Java, etc.
 - Test with `appium driver doctor uiautomator2` and `appium driver doctor xcuitest` to check for errors with the setup.
 
@@ -283,4 +297,66 @@ They will also be stored in MongoDB in DB `logs` and collection corresponding to
 * Video streaming is not available for Tizen TV devices
 * Some remote control features may be limited due to TV-specific interactions
 * Screen dimensions are fixed based on TV resolution
+
+### WebOS CLI - WebOS Only
+`WebOS CLI` is mandatory when providing WebOS TV devices. You can skip installing it if no WebOS devices will be provided.
+- Download the [WebOS TV CLI](https://webostv.developer.lge.com/develop/tools/webos-tv-cli-installation) (v1.12.4 recommended)
+- Extract the downloaded CLI archive and place the extracted contents in `${LG_WEBOS_TV_SDK_HOME}/CLI`
+- Set up environment variables:
+  ```bash
+  # Add to your ~/.bashrc or equivalent
+  export LG_WEBOS_TV_SDK_HOME=/path/to/webOS_TV_SDK
+  export WEBOS_CLI_TV=${LG_WEBOS_TV_SDK_HOME}/CLI
+  export PATH=${PATH}:${WEBOS_CLI_TV}/bin
+  ```
+- Ensure `ares` commands are available in PATH by running `ares -V` in terminal
+- Restart your terminal or run `source ~/.bashrc` to apply changes
+
+**Note**: Replace `/path/to/webOS_TV_SDK` with your actual WebOS TV SDK installation path. Common locations are:
+- macOS: `/Users/<username>/webOS_TV_SDK`
+- Linux: `/home/<username>/webOS_TV_SDK`
+- Windows: `C:\webOS_TV_SDK`
+
+## WebOS TV
+### Developer Mode - WebOS
+* Install the Developer Mode app from LG Content Store
+* Sign in with your LG Developer account (create one at https://webostv.developer.lge.com if needed)
+* Enable Developer Mode by clicking the Dev Mode Status button
+* The TV will reboot automatically
+
+### Device Connection
+* Ensure the TV and the provider host machine are on the same network
+* Add the TV as a device using the WebOS CLI:
+  ```bash
+  ares-setup-device --add target -i "host=10.123.45.67" -i "port=9922" -i "username=prisoner" -i "default=true"
+  ```
+  > **⚠️ IMPORTANT**: The device name (e.g., `target` in the example above) must be:
+  > - Descriptive and meaningful for your setup
+  > - **EXACTLY the same** as the device name registered in GADS
+  > - If the names don't match, there will be configuration issues with the provisioned Appium server for the TV
+  
+  - Default port is 9922
+  - Default username is "prisoner"
+  - Leave password empty
+* For first-time connections, you'll need to accept the pairing request on the TV
+* Verify the connection by running:
+  ```bash
+  ares-setup-device --list
+  ```
+* The TV should appear in the list with its IP:PORT identifier
+
+### Chromedriver Requirements
+* WebOS TVs require Chromedriver 2.36 for compatibility
+* GADS will manage the Chromedriver installation automatically
+* The driver path will be configured in Appium capabilities
+
+### Device UDID Format
+* WebOS devices use the format `IP:PORT` as their UDID (e.g., `192.168.1.100:9922`)
+* This UDID must be registered in the GADS database before the device can be used
+
+### Known Limitations
+* Video streaming is not available for WebOS TV devices
+* Remote control features are limited compared to mobile devices
+* Only web-based TV apps can be automated (native apps have limited support)
+* Developer Mode has a 1000-hour time limit and needs periodic renewal
 

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -531,6 +531,11 @@ func getTargetOSFromCaps(caps models.CommonCapabilities) string {
 		return "tizen"
 	}
 
+	if strings.EqualFold(caps.PlatformName, "lgtv") ||
+		strings.EqualFold(caps.AutomationName, "webos") {
+		return "webos"
+	}
+
 	return ""
 }
 

--- a/provider/devices/webos.go
+++ b/provider/devices/webos.go
@@ -1,0 +1,115 @@
+package devices
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"GADS/common/cli"
+	"GADS/common/models"
+	"GADS/provider/logger"
+	"GADS/provider/providerutil"
+)
+
+// connectedWebOSDevice represents a WebOS device returned by ares-setup-device --list
+type connectedWebOSDevice struct {
+	name string
+	ip   string
+}
+
+func setupWebOSDevice(device *models.Device) {
+	device.SetupMutex.Lock()
+	defer device.SetupMutex.Unlock()
+
+	device.ProviderState = "preparing"
+	logger.ProviderLogger.LogInfo("webos_device_setup", fmt.Sprintf("Running setup for WebOS device `%v`", device.UDID))
+
+	err := cli.KillDeviceAppiumProcess(device.UDID)
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_device_setup", fmt.Sprintf("Failed attempt to kill existing Appium processes for device `%s` - %v", device.UDID, err))
+		ResetLocalDevice(device, "Failed to kill existing Appium processes.")
+		return
+	}
+
+	appiumPort, err := providerutil.GetFreePort()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_device_setup", fmt.Sprintf("Could not allocate free host port for Appium for device `%v` - %v", device.UDID, err))
+		ResetLocalDevice(device, "Failed to allocate free host port for Appium")
+		return
+	}
+	device.AppiumPort = appiumPort
+	device.IPAddress = device.UDID
+
+	go startAppium(device)
+
+	timeout := time.After(30 * time.Second)
+	tick := time.Tick(200 * time.Millisecond)
+AppiumLoop:
+	for {
+		select {
+		case <-timeout:
+			logger.ProviderLogger.LogError("webos_device_setup", fmt.Sprintf("Did not successfully start Appium for device `%v` in 30 seconds", device.UDID))
+			ResetLocalDevice(device, "Failed to start Appium for device.")
+			return
+		case <-tick:
+			if device.IsAppiumUp {
+				logger.ProviderLogger.LogInfo("webos_device_setup", fmt.Sprintf("Successfully started Appium for device `%v` on port %v", device.UDID, device.AppiumPort))
+				break AppiumLoop
+			}
+		}
+	}
+
+	device.ProviderState = "live"
+}
+
+// getConnectedDevicesWebOS gets the connected WebOS devices using ares-setup-device
+func getConnectedDevicesWebOS() []string {
+	cmd := exec.Command("ares-setup-device", "--list")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_device_detection", fmt.Sprintf("Failed to get WebOS devices: %s", err))
+		return []string{}
+	}
+
+	var connectedDevices []string
+	lines := strings.Split(string(output), "\n")
+
+	for _, line := range lines {
+		// Skip empty lines, header and emulator lines
+		if line == "" || strings.Contains(line, "name") || strings.Contains(line, "----") || strings.Contains(line, "emulator") {
+			continue
+		}
+
+		// ares-setup-device --list output format:
+		// name            deviceinfo                connection  profile
+		// TVLG (default)  prisoner@10.1.16.22:9922  ssh         tv
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			// Find the field that contains @ and : (deviceinfo field)
+			var deviceInfo string
+			for _, field := range fields {
+				if strings.Contains(field, "@") && strings.Contains(field, ":") {
+					deviceInfo = field
+					break
+				}
+			}
+
+			// Extract IP from deviceinfo if found
+			if deviceInfo != "" {
+				// Format is user@IP:PORT, extract just the IP
+				parts := strings.Split(deviceInfo, "@")
+				if len(parts) == 2 {
+					ipPort := parts[1]
+					ipParts := strings.Split(ipPort, ":")
+					if len(ipParts) >= 1 {
+						ip := ipParts[0]
+						connectedDevices = append(connectedDevices, ip)
+					}
+				}
+			}
+		}
+	}
+
+	return connectedDevices
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -165,6 +165,15 @@ func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 		}
 	}
 
+	// If we want to provide WebOS devices check if ares-setup-device is available on PATH
+	if config.ProviderConfig.ProvideWebOS {
+		if !providerutil.AresAvailable() {
+			logger.ProviderLogger.LogError("provider", "ares-setup-device is not available, you need to set up the host as explained in the readme")
+			fmt.Println("ares-setup-device is not available, you need to set up the host as explained in the readme")
+			os.Exit(1)
+		}
+	}
+
 	// Start a goroutine that will start updating devices on provider start
 	go devices.Listener()
 

--- a/provider/providerutil/providerutil.go
+++ b/provider/providerutil/providerutil.go
@@ -241,6 +241,19 @@ func SdbAvailable() bool {
 	return true
 }
 
+// Check if ares-setup-device is available on the host by checking its version
+func AresAvailable() bool {
+	logger.ProviderLogger.LogInfo("provider_setup", "Checking if ares-setup-device is set up and available on the host PATH")
+
+	cmd := exec.Command("ares", "-V")
+	err := cmd.Run()
+	if err != nil {
+		logger.ProviderLogger.LogDebug("provider_setup", fmt.Sprintf("aresAvailable: ares-setup-device is not available or command failed - %s", err))
+		return false
+	}
+	return true
+}
+
 // Check if chromedriver is located in the drivers provider folder
 func isChromeDriverAvailable() bool {
 	var chromedriverPath string


### PR DESCRIPTION

- Adds 'ProvideWebOS' to provider config and regularization logic
- Implements 'setupWebOSDevice' to start Appium server with WebOS-specific capabilities
- Includes device detection via 'ares-setup-device --list'
- Updates platform validation logic to restrict WebOS usage to automation only
- Extends documentation: installation, pairing, CLI setup, known limitations
- Updates Appium caps ('deviceHost') and routing detection for WebOS
- Syncs hub-ui submodule to include WebOS support in frontend