### PR TITLE
Add support for extracting clientSecret from W3C firstMatch capabilities

### DIFF
--- a/common/models/appium.go
+++ b/common/models/appium.go
@@ -127,11 +127,22 @@ type AppiumSession struct {
 
 // ExtractClientSecretFromSession extracts client secret from Appium session request
 func ExtractClientSecretFromSession(sessionReq map[string]interface{}, prefix string) string {
-	// Check capabilities.alwaysMatch (W3C format)
+	// Check capabilities (W3C format)
 	if caps, ok := sessionReq["capabilities"].(map[string]interface{}); ok {
+		// Check capabilities.alwaysMatch (W3C format)
 		if alwaysMatch, ok := caps["alwaysMatch"].(map[string]interface{}); ok {
 			if secret, ok := alwaysMatch[prefix+":clientSecret"].(string); ok {
 				return secret
+			}
+		}
+        // Check capabilities.firstMatch (W3C format)
+		if firstMatch, ok := caps["firstMatch"].([]interface{}); ok {
+			for _, item := range firstMatch {
+				if firstCaps, ok := item.(map[string]interface{}); ok {
+					if secret, ok := firstCaps[prefix+":clientSecret"].(string); ok {
+						return secret
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

This PR adds support for extracting the client secret from the firstMatch capabilities.

This is important because, due to the specifics of our testing project and their integration with various services, we need to independently control what is set in alwaysMatch and firstMatch. According to the W3C WebDriver specification, firstMatch may contain custom capabilities, including the client secret.

I have tested these changes with:

- **Appium 2.19.0**

- Appium Java Client 10.0.0

- Appium Python Client 2.11.0

using `UiAutomator2Options` and `XCUITestOptions` to build options within `firstMatch` via `AndroidDriver` and `IOSDriver` as remote connections.

Also tested with a modified version of this client: https://github.com/KazuCocoa/appium_dart/tree/main?tab=readme-ov-file

Please let me know if anything needs to be changed or improved.
Thank you!