### PR TITLE
Resolve pagination bug when filtering by tenant

### DIFF
--- a/common/db/workspace.go
+++ b/common/db/workspace.go
@@ -150,7 +150,7 @@ func (m *MongoStore) GetUserWorkspaces(username string) []models.Workspace {
 	return userWorkspaces
 }
 
-func (m *MongoStore) GetWorkspacesWithDeviceCount(page, limit int, search string) ([]models.WorkspaceWithDeviceCount, int64, error) {
+func (m *MongoStore) GetWorkspacesWithDeviceCount(page, limit int, search, tenant string) ([]models.WorkspaceWithDeviceCount, int64, error) {
 	if page < 1 || limit < 1 || limit > 1000 {
 		return nil, 0, ErrInvalidPagination
 	}
@@ -166,6 +166,10 @@ func (m *MongoStore) GetWorkspacesWithDeviceCount(page, limit int, search string
 			{"description": regex},
 			{"tenant": regex},
 		}
+	}
+
+	if tenant != "" {
+		matchFilter["tenant"] = tenant
 	}
 
 	pipeline := []bson.M{

--- a/hub/router/workspace.go
+++ b/hub/router/workspace.go
@@ -188,7 +188,7 @@ func GetWorkspaces(c *gin.Context) {
 		limit = 10 // Default limit
 	}
 
-	workspaces, totalCount, err := db.GlobalMongoStore.GetWorkspacesWithDeviceCount(page, limit, searchStr)
+	workspaces, totalCount, err := db.GlobalMongoStore.GetWorkspacesWithDeviceCount(page, limit, searchStr, tenantStr)
 
 	if err != nil {
 		if err == db.ErrInvalidPagination {
@@ -199,18 +199,6 @@ func GetWorkspaces(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get workspaces"})
 		}
 		return
-	}
-
-	// Filter by tenant if specified
-	if tenantStr != "" {
-		var filteredWorkspaces []models.WorkspaceWithDeviceCount = make([]models.WorkspaceWithDeviceCount, 0)
-		for _, ws := range workspaces {
-			if ws.Tenant == tenantStr {
-				filteredWorkspaces = append(filteredWorkspaces, ws)
-			}
-		}
-		workspaces = filteredWorkspaces
-		totalCount = int64(len(filteredWorkspaces))
 	}
 
 	c.JSON(http.StatusOK, gin.H{"workspaces": workspaces, "total": totalCount})


### PR DESCRIPTION
The GetWorkspaces() endpoint had a pagination bug when filtering by tenant:
  - Tenant filtering was happening AFTER pagination instead of before
  - This caused missing results when tenant workspaces were distributed across multiple pages
  - Example: 6 total workspaces, 3 for specific tenant, with 5 items per page
    - One tenant workspace on page 2 would be missing when requesting page 1 with tenant filter
    - Only showed 2 workspaces instead of all 3 for that tenant

  ## Solution
  - Move tenant filtering to database level (MongoDB aggregation pipeline)
  - Add `tenant` parameter to `GetWorkspacesWithDeviceCount()` function
  - Remove post-query filtering logic from router
  - Ensure correct pagination and total count calculation

  ## Changes
  - **common/db/workspace.go**: Add tenant parameter and database-level filtering
  - **hub/router/workspace.go**: Pass tenant parameter to database function, remove post-query filtering

  ## Impact
  - Fixes incorrect pagination results when filtering by tenant
  - Improves query performance by filtering at database level
  - Ensures accurate total count for pagination