### PR TITLE
Implements app lifecycle management for Tizen and webOS platforms

### DIFF
--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -1117,16 +1117,15 @@ func UpdateInstalledApps(device *models.Device) {
 }
 
 func UninstallApp(device *models.Device, app string) error {
-	if device.OS == "ios" {
-		err := uninstallAppIOS(device, app)
-		if err != nil {
-			return err
-		}
-	} else {
-		err := uninstallAppAndroid(device, app)
-		if err != nil {
-			return err
-		}
+	switch device.OS {
+	case "ios":
+		return uninstallAppIOS(device, app)
+	case "android":
+		return uninstallAppAndroid(device, app)
+	case "tizen":
+		return uninstallAppTizen(device, app)
+	case "webos":
+		return uninstallAppWebOS(device, app)
 	}
 
 	return nil

--- a/provider/devices/tizen.go
+++ b/provider/devices/tizen.go
@@ -383,3 +383,104 @@ func installAppTizen(device *models.Device, appName string) error {
 	logger.ProviderLogger.LogInfo("tizen_install_app", fmt.Sprintf("Successfully installed app on device %s", device.UDID))
 	return nil
 }
+
+type TizenApp struct {
+	AppID   string `json:"appId"`
+	Title   string `json:"title"`
+	Version string `json:"version"`
+}
+
+func GetInstalledAppsTizen(device *models.Device) []TizenApp {
+	apps := []TizenApp{}
+
+	cmd := exec.Command("sdb", "-s", device.UDID, "shell", "0", "vd_applist")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("tizen_list_apps", fmt.Sprintf("Failed to list apps for device %s: %v. Output: %s", device.UDID, err, string(output)))
+		return apps
+	}
+
+	lines := strings.Split(string(output), "\n")
+
+	var currentApp TizenApp
+	inAppBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "----") && len(trimmed) > 50 && !strings.Contains(line, "=") {
+			if inAppBlock && currentApp.AppID != "" {
+				apps = append(apps, currentApp)
+			}
+			currentApp = TizenApp{}
+			inAppBlock = true
+			continue
+		}
+
+		if inAppBlock && strings.Contains(line, "=") {
+			parts := strings.Split(line, "=")
+			if len(parts) >= 2 {
+				key := strings.TrimSpace(strings.ReplaceAll(parts[0], "-", ""))
+				value := strings.Trim(strings.TrimSpace(parts[1]), "-")
+
+				switch key {
+				case "app_tizen_id":
+					currentApp.AppID = value
+				case "app_title":
+					currentApp.Title = value
+				case "app_version":
+					currentApp.Version = value
+				}
+			}
+		}
+	}
+
+	if inAppBlock && currentApp.AppID != "" {
+		apps = append(apps, currentApp)
+	}
+
+	logger.ProviderLogger.LogInfo("tizen_list_apps", fmt.Sprintf("Found %d installed apps on device %s", len(apps), device.UDID))
+	return apps
+}
+
+func LaunchAppTizen(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("tizen_launch_app", fmt.Sprintf("Launching app %s on device %s", appID, device.UDID))
+
+	cmd := exec.Command("tizen", "run", "-s", device.UDID, "-p", appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("tizen_launch_app", fmt.Sprintf("Failed to launch app %s on device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to launch app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("tizen_launch_app", fmt.Sprintf("Successfully launched app %s on device %s", appID, device.UDID))
+	return nil
+}
+
+func CloseAppTizen(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("tizen_close_app", fmt.Sprintf("Closing app %s on device %s", appID, device.UDID))
+
+	cmd := exec.Command("sdb", "-s", device.UDID, "shell", "0", "was_kill", appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("tizen_close_app", fmt.Sprintf("Failed to close app %s on device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to close app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("tizen_close_app", fmt.Sprintf("Successfully closed app %s on device %s", appID, device.UDID))
+	return nil
+}
+
+func uninstallAppTizen(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("tizen_uninstall_app", fmt.Sprintf("Uninstalling app %s from device %s", appID, device.UDID))
+
+	cmd := exec.Command("tizen", "uninstall", "-s", device.UDID, "-p", appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("tizen_uninstall_app", fmt.Sprintf("Failed to uninstall app %s from device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to uninstall app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("tizen_uninstall_app", fmt.Sprintf("Successfully uninstalled app %s from device %s", appID, device.UDID))
+	return nil
+}

--- a/provider/devices/webos.go
+++ b/provider/devices/webos.go
@@ -184,3 +184,101 @@ func installAppWebOS(device *models.Device, appName string) error {
 	logger.ProviderLogger.LogInfo("webos_install_app", fmt.Sprintf("Successfully installed app on device %s", device.UDID))
 	return nil
 }
+
+type WebOSApp struct {
+	AppID   string `json:"appId"`
+	Title   string `json:"title"`
+	Version string `json:"version"`
+}
+
+func GetInstalledAppsWebOS(device *models.Device) []WebOSApp {
+	apps := []WebOSApp{}
+
+	cmd := exec.Command("ares-install", "--device", device.Name, "--listfull")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_list_apps", fmt.Sprintf("Failed to list apps for device %s: %v. Output: %s", device.UDID, err, string(output)))
+		return apps
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var currentApp WebOSApp
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			if currentApp.AppID != "" {
+				apps = append(apps, currentApp)
+				currentApp = WebOSApp{}
+			}
+			continue
+		}
+
+		if strings.Contains(line, " : ") {
+			parts := strings.SplitN(line, " : ", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+
+				switch key {
+				case "id":
+					currentApp.AppID = value
+				case "title":
+					currentApp.Title = value
+				case "version":
+					currentApp.Version = value
+				}
+			}
+		}
+	}
+
+	if currentApp.AppID != "" {
+		apps = append(apps, currentApp)
+	}
+
+	logger.ProviderLogger.LogInfo("webos_list_apps", fmt.Sprintf("Found %d installed apps on device %s", len(apps), device.UDID))
+	return apps
+}
+
+func LaunchAppWebOS(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("webos_launch_app", fmt.Sprintf("Launching app %s on device %s", appID, device.UDID))
+
+	cmd := exec.Command("ares-launch", "--device", device.Name, appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_launch_app", fmt.Sprintf("Failed to launch app %s on device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to launch app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("webos_launch_app", fmt.Sprintf("Successfully launched app %s on device %s", appID, device.UDID))
+	return nil
+}
+
+func CloseAppWebOS(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("webos_close_app", fmt.Sprintf("Closing app %s on device %s", appID, device.UDID))
+
+	cmd := exec.Command("ares-launch", "--device", device.Name, "--close", appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_close_app", fmt.Sprintf("Failed to close app %s on device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to close app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("webos_close_app", fmt.Sprintf("Successfully closed app %s on device %s", appID, device.UDID))
+	return nil
+}
+
+func uninstallAppWebOS(device *models.Device, appID string) error {
+	logger.ProviderLogger.LogInfo("webos_uninstall_app", fmt.Sprintf("Uninstalling app %s from device %s", appID, device.UDID))
+
+	cmd := exec.Command("ares-install", "--device", device.Name, "--remove", appID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.ProviderLogger.LogError("webos_uninstall_app", fmt.Sprintf("Failed to uninstall app %s from device %s: %v. Output: %s", appID, device.UDID, err, string(output)))
+		return fmt.Errorf("failed to uninstall app %s: %w", appID, err)
+	}
+
+	logger.ProviderLogger.LogInfo("webos_uninstall_app", fmt.Sprintf("Successfully uninstalled app %s from device %s", appID, device.UDID))
+	return nil
+}

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -75,6 +75,8 @@ func HandleRequests() *gin.Engine {
 		deviceGroup.GET("/ios-stream-mjpeg", IOSStreamMJPEGWda)
 	}
 	deviceGroup.POST("/uninstallApp", UninstallApp)
+	deviceGroup.POST("/launchApp", LaunchApp)
+	deviceGroup.POST("/closeApp", CloseApp)
 	deviceGroup.POST("/reset", ResetDevice)
 	deviceGroup.POST("/uploadAndInstallApp", UploadAndInstallApp)
 	deviceGroup.GET("/webrtc", DevicesWebRTCSocket)

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -254,18 +254,23 @@ func DeviceInfo(c *gin.Context) {
 
 func DeviceInstalledApps(c *gin.Context) {
 	udid := c.Param("udid")
-	var installedApps []string
+	var installedApps interface{}
 
 	if dev, ok := devices.DBDeviceMap[udid]; ok {
-		if dev.OS == "ios" {
+		switch dev.OS {
+		case "ios":
 			installedApps = devices.GetInstalledAppsIOS(dev)
-		} else {
+		case "android":
 			installedApps = devices.GetInstalledAppsAndroid(dev)
+		case "tizen":
+			installedApps = devices.GetInstalledAppsTizen(dev)
+		case "webos":
+			installedApps = devices.GetInstalledAppsWebOS(dev)
 		}
 		api.GenericResponse(c, http.StatusOK, "", installedApps)
 		return
 	}
-	api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Did not find device with udid `%s`", udid), installedApps)
+	api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Did not find device with udid `%s`", udid), nil)
 }
 
 func DevicesInfo(c *gin.Context) {
@@ -281,10 +286,32 @@ type ProcessApp struct {
 	App string `json:"app"`
 }
 
+func getInstalledAppIDs(device *models.Device) []string {
+	var installedApps []string
+
+	switch device.OS {
+	case "ios":
+		installedApps = devices.GetInstalledAppsIOS(device)
+	case "android":
+		installedApps = devices.GetInstalledAppsAndroid(device)
+	case "tizen":
+		tizenApps := devices.GetInstalledAppsTizen(device)
+		for _, app := range tizenApps {
+			installedApps = append(installedApps, app.AppID)
+		}
+	case "webos":
+		webosApps := devices.GetInstalledAppsWebOS(device)
+		for _, app := range webosApps {
+			installedApps = append(installedApps, app.AppID)
+		}
+	}
+
+	return installedApps
+}
+
 func UninstallApp(c *gin.Context) {
 	udid := c.Param("udid")
 
-	var installedApps []string
 	if dev, ok := devices.DBDeviceMap[udid]; ok {
 		payload, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -299,11 +326,7 @@ func UninstallApp(c *gin.Context) {
 			return
 		}
 
-		if dev.OS == "ios" {
-			installedApps = devices.GetInstalledAppsIOS(dev)
-		} else {
-			installedApps = devices.GetInstalledAppsAndroid(dev)
-		}
+		installedApps := getInstalledAppIDs(dev)
 
 		if slices.Contains(installedApps, payloadJson.App) {
 			err = devices.UninstallApp(dev, payloadJson.App)
@@ -319,6 +342,100 @@ func UninstallApp(c *gin.Context) {
 			return
 		}
 		api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("App `%s` is not installed on device", payloadJson.App), installedApps)
+		return
+	}
+
+	api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Did not find device with udid `%s`", udid), nil)
+}
+
+func LaunchApp(c *gin.Context) {
+	udid := c.Param("udid")
+
+	if dev, ok := devices.DBDeviceMap[udid]; ok {
+		payload, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
+			return
+		}
+
+		var payloadJson ProcessApp
+		err = json.Unmarshal(payload, &payloadJson)
+		if err != nil {
+			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
+			return
+		}
+
+		installedApps := getInstalledAppIDs(dev)
+
+		if !slices.Contains(installedApps, payloadJson.App) {
+			api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("App `%s` is not installed on device", payloadJson.App), installedApps)
+			return
+		}
+
+		var launchErr error
+		switch dev.OS {
+		case "tizen":
+			launchErr = devices.LaunchAppTizen(dev, payloadJson.App)
+		case "webos":
+			launchErr = devices.LaunchAppWebOS(dev, payloadJson.App)
+		default:
+			api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Launch app not supported for OS: %s", dev.OS), nil)
+			return
+		}
+
+		if launchErr != nil {
+			api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to launch app `%s`: %v", payloadJson.App, launchErr), nil)
+			return
+		}
+
+		api.GenericResponse(c, http.StatusOK, fmt.Sprintf("Successfully launched app `%s`", payloadJson.App), installedApps)
+		return
+	}
+
+	api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Did not find device with udid `%s`", udid), nil)
+}
+
+func CloseApp(c *gin.Context) {
+	udid := c.Param("udid")
+
+	if dev, ok := devices.DBDeviceMap[udid]; ok {
+		payload, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
+			return
+		}
+
+		var payloadJson ProcessApp
+		err = json.Unmarshal(payload, &payloadJson)
+		if err != nil {
+			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
+			return
+		}
+
+		installedApps := getInstalledAppIDs(dev)
+
+		if !slices.Contains(installedApps, payloadJson.App) {
+			api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("App `%s` is not installed on device", payloadJson.App), installedApps)
+			return
+		}
+
+		var closeErr error
+		switch dev.OS {
+		case "tizen":
+			closeErr = devices.CloseAppTizen(dev, payloadJson.App)
+		case "webos":
+			closeErr = devices.CloseAppWebOS(dev, payloadJson.App)
+		default:
+			api.GenericResponse(c, http.StatusBadRequest, fmt.Sprintf("Close app not supported for OS: %s", dev.OS), nil)
+			return
+		}
+
+		if closeErr != nil {
+			api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to close app `%s`: %v", payloadJson.App, closeErr), nil)
+			return
+		}
+
+		api.GenericResponse(c, http.StatusOK, fmt.Sprintf("Successfully closed app `%s`", payloadJson.App), installedApps)
 		return
 	}
 


### PR DESCRIPTION
  ### Changes

  **Core Functionality:**
  - ✅ List installed apps with metadata (app ID, title, version)
  - ✅ Launch apps on device
  - ✅ Close running apps
  - ✅ Uninstall apps from device

  **Platform Support:**
  - **Tizen**: Uses `sdb` and `tizen` CLI tools
  - **webOS**: Uses `ares-install` and `ares-launch` CLI tools

  **API Enhancements:**
  - New endpoints: `POST /device/:udid/launchApp` and `POST /device/:udid/closeApp`
  - Updated `GET /device/:udid/installedApps` to return structured app data for Tizen/webOS
  - Updated `POST /device/:udid/uninstallApp` to support all platforms