### PR TITLE
Resolve data inconsistency between hub and provider

### DIFF
--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1029,26 +1029,20 @@ func ReleaseUsedDevice(c *gin.Context) {
 	c.JSON(200, gin.H{"message": "Message to release device was successfully sent"})
 }
 
-// syncDeviceFields synchronizes device fields from source to target device
+// syncDeviceFields synchronizes operational fields from provider to hub device
 // Only updates fields that are different between the two devices
 func syncDeviceFields(target *models.Device, source *models.Device) {
-	if target.Usage != source.Usage {
-		target.Usage = source.Usage
+	if target.Connected != source.Connected {
+		target.Connected = source.Connected
 	}
-	if target.Name != source.Name {
-		target.Name = source.Name
+	if target.ProviderState != source.ProviderState {
+		target.ProviderState = source.ProviderState
 	}
-	if target.OSVersion != source.OSVersion {
-		target.OSVersion = source.OSVersion
+	if target.LastUpdatedTimestamp != source.LastUpdatedTimestamp {
+		target.LastUpdatedTimestamp = source.LastUpdatedTimestamp
 	}
-	if target.ScreenWidth != source.ScreenWidth {
-		target.ScreenWidth = source.ScreenWidth
-	}
-	if target.ScreenHeight != source.ScreenHeight {
-		target.ScreenHeight = source.ScreenHeight
-	}
-	if target.Provider != source.Provider {
-		target.Provider = source.Provider
+	if target.Host != source.Host {
+		target.Host = source.Host
 	}
 }
 
@@ -1092,21 +1086,8 @@ func ProviderUpdate(c *gin.Context) {
 			// Set a timestamp to indicate last time info about the device was updated from the provider
 			providerDevice.LastUpdatedTimestamp = time.Now().UnixMilli()
 
-			providerDeviceHasChanged := providerDevice.Provider != hubDevice.Device.Provider
-
-			// If device is "live" on provider, provider data takes precedence for operational fields
-			// Otherwise, DB data takes precedence to prevent incorrect overrides
-			if providerDevice.ProviderState == "live" && !providerDeviceHasChanged {
-				// For live devices, provider operational data takes precedence
-				// Keep provider values for Usage and Provider fields
-				// But still respect DB configuration for device metadata
-				syncDeviceFields(&hubDevice.Device, &providerDevice)
-			} else if !providerDeviceHasChanged {
-				// For non-live devices, DB data takes precedence for all fields
-				syncDeviceFields(&providerDevice, &hubDevice.Device)
-			}
-
-			hubDevice.Device = providerDevice
+			// Update only operational fields from provider
+			syncDeviceFields(&hubDevice.Device, &providerDevice)
 		}
 		devices.HubDevicesData.Mu.Unlock()
 	}

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -51,7 +51,11 @@ import (
 var netClient = &http.Client{
 	Timeout: time.Second * 120,
 }
-var DBDeviceMap = make(map[string]*models.Device)
+
+var (
+	DBDeviceMap      = make(map[string]*models.Device)
+	DbDeviceMapMutex sync.RWMutex
+)
 
 func Listener() {
 	DBDeviceMap = getDBProviderDevices()
@@ -70,7 +74,6 @@ func updateProviderHub() {
 		Timeout: 5 * time.Second,
 	}
 	var updateFailureCounter = 1
-	var mu sync.Mutex
 
 	for {
 		if updateFailureCounter >= 30 {
@@ -78,16 +81,49 @@ func updateProviderHub() {
 		}
 		time.Sleep(1 * time.Second)
 
-		mu.Lock()
-
 		updatedDevices := getDBProviderDevices()
 
-		var properJson models.ProviderData
-		for _, dbDevice := range DBDeviceMap {
+		DbDeviceMapMutex.Lock()
 
-			// Update the WorkspaceID in dbDevice from the updatedDevices map
-			if updatedDevice, ok := updatedDevices[dbDevice.UDID]; ok {
-				dbDevice.WorkspaceID = updatedDevice.WorkspaceID
+		// Track devices to remove (deleted from DB)
+		var devicesToRemove []string
+
+		var properJson models.ProviderData
+		for udid, dbDevice := range DBDeviceMap {
+			// Check if device still exists in DB
+			if updatedDevice, ok := updatedDevices[udid]; ok {
+				// Update configuration fields from DB
+				if dbDevice.ScreenWidth != updatedDevice.ScreenWidth {
+					dbDevice.ScreenWidth = updatedDevice.ScreenWidth
+				}
+				if dbDevice.ScreenHeight != updatedDevice.ScreenHeight {
+					dbDevice.ScreenHeight = updatedDevice.ScreenHeight
+				}
+				if dbDevice.Name != updatedDevice.Name {
+					dbDevice.Name = updatedDevice.Name
+				}
+				if dbDevice.OSVersion != updatedDevice.OSVersion {
+					dbDevice.OSVersion = updatedDevice.OSVersion
+				}
+				if dbDevice.Usage != updatedDevice.Usage {
+					dbDevice.Usage = updatedDevice.Usage
+				}
+				if dbDevice.WorkspaceID != updatedDevice.WorkspaceID {
+					dbDevice.WorkspaceID = updatedDevice.WorkspaceID
+				}
+				webrtcChanged := false
+				if dbDevice.UseWebRTCVideo != updatedDevice.UseWebRTCVideo {
+					dbDevice.UseWebRTCVideo = updatedDevice.UseWebRTCVideo
+					webrtcChanged = true
+				}
+				if dbDevice.WebRTCVideoCodec != updatedDevice.WebRTCVideoCodec {
+					dbDevice.WebRTCVideoCodec = updatedDevice.WebRTCVideoCodec
+					webrtcChanged = true
+				}
+				if webrtcChanged {
+					ResetLocalDevice(dbDevice, "WebRTC configuration changed, reprovisioning device")
+				}
+
 				// If the provider does not set up Appium servers
 				// Always return device usage as `control`
 				if !config.ProviderConfig.SetupAppiumServers {
@@ -95,12 +131,25 @@ func updateProviderHub() {
 						dbDevice.Usage = "control"
 					}
 				}
+
+				properJson.DeviceData = append(properJson.DeviceData, *dbDevice)
+			} else {
+				// Device no longer exists in DB, mark for removal
+				devicesToRemove = append(devicesToRemove, udid)
 			}
 
-			properJson.DeviceData = append(properJson.DeviceData, *dbDevice)
 			properJson.ProviderData = *config.ProviderConfig
 		}
-		mu.Unlock()
+
+		// Remove devices that no longer exist in DB
+		for _, udid := range devicesToRemove {
+			if device, ok := DBDeviceMap[udid]; ok {
+				ResetLocalDevice(device, "Device removed from DB")
+				delete(DBDeviceMap, udid)
+			}
+		}
+
+		DbDeviceMapMutex.Unlock()
 		jsonData, err := json.Marshal(properJson)
 		if err != nil {
 			updateFailureCounter++
@@ -220,8 +269,16 @@ func updateDevices() {
 		case <-ticker.C:
 			connectedDevices := GetConnectedDevicesCommon()
 
+			// Create a copy of devices to iterate over (with read lock)
+			DbDeviceMapMutex.RLock()
+			devicesCopy := make(map[string]*models.Device, len(DBDeviceMap))
+			for udid, device := range DBDeviceMap {
+				devicesCopy[udid] = device
+			}
+			DbDeviceMapMutex.RUnlock()
+
 		DEVICE_MAP_LOOP:
-			for dbDeviceUDID, dbDevice := range DBDeviceMap {
+			for dbDeviceUDID, dbDevice := range devicesCopy {
 				if dbDevice.Usage == "disabled" {
 					continue DEVICE_MAP_LOOP
 				}

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -107,7 +107,11 @@ func UploadAndInstallApp(c *gin.Context) {
 
 	udid := c.Param("udid")
 	// Check if the target device is currently provisioned
-	if dev, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	dev, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		// If the uploaded file is not a zip archive
 		if ext != ".zip" {
 			// Create file destination based on the provider dir and file name
@@ -230,10 +234,12 @@ func UploadAndInstallApp(c *gin.Context) {
 func GetProviderData(c *gin.Context) {
 	var providerData models.ProviderData
 
+	devices.DbDeviceMapMutex.RLock()
 	deviceData := []models.Device{}
 	for _, device := range devices.DBDeviceMap {
 		deviceData = append(deviceData, *device)
 	}
+	devices.DbDeviceMapMutex.RUnlock()
 
 	providerData.ProviderData = *config.ProviderConfig
 	providerData.DeviceData = deviceData
@@ -244,7 +250,11 @@ func GetProviderData(c *gin.Context) {
 func DeviceInfo(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if dev, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	dev, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		devices.UpdateInstalledApps(dev)
 		api.GenericResponse(c, http.StatusOK, "", dev)
 		return
@@ -276,9 +286,12 @@ func DeviceInstalledApps(c *gin.Context) {
 func DevicesInfo(c *gin.Context) {
 	deviceList := []*models.Device{}
 
+	devices.DbDeviceMapMutex.RLock()
 	for _, device := range devices.DBDeviceMap {
 		deviceList = append(deviceList, device)
 	}
+	devices.DbDeviceMapMutex.RUnlock()
+
 	api.GenericResponse(c, http.StatusOK, "", deviceList)
 }
 
@@ -312,7 +325,12 @@ func getInstalledAppIDs(device *models.Device) []string {
 func UninstallApp(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if dev, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	dev, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	var installedApps []string
+	if ok {
 		payload, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
@@ -326,7 +344,7 @@ func UninstallApp(c *gin.Context) {
 			return
 		}
 
-		installedApps := getInstalledAppIDs(dev)
+		installedApps = getInstalledAppIDs(dev)
 
 		if slices.Contains(installedApps, payloadJson.App) {
 			err = devices.UninstallApp(dev, payloadJson.App)
@@ -445,7 +463,11 @@ func CloseApp(c *gin.Context) {
 func ResetDevice(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		if device.IsResetting {
 			api.GenericResponse(c, http.StatusConflict, "Device setup is already being reset", nil)
 			return
@@ -467,7 +489,11 @@ func ResetDevice(c *gin.Context) {
 func UpdateDeviceStreamSettings(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		payload, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			api.GenericResponse(c, http.StatusBadRequest, "Invalid payload", nil)
@@ -540,7 +566,11 @@ func UpdateDeviceStreamSettings(c *gin.Context) {
 func DeviceFiles(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		if device.OS == "android" {
 			filesResp, err := androidRemoteServerRequest(device, http.MethodGet, "files", nil)
 			if err != nil {
@@ -574,7 +604,11 @@ func DeviceFiles(c *gin.Context) {
 func PushFileToSharedStorage(c *gin.Context) {
 	udid := c.Param("udid")
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		if device.OS == "ios" {
 			api.GenericResponse(c, http.StatusBadRequest, "Functionality not supported for iOS devices", nil)
 			return
@@ -619,7 +653,11 @@ func DeleteFileFromSharedStorage(c *gin.Context) {
 		return
 	}
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		if device.OS == "ios" {
 			api.GenericResponse(c, http.StatusBadRequest, "Functionality not supported for iOS devices", nil)
 			return
@@ -657,7 +695,11 @@ func PullFileFromSharedStorage(c *gin.Context) {
 	}
 	fileName := filepath.Base(filePath)
 
-	if device, ok := devices.DBDeviceMap[udid]; ok {
+	devices.DbDeviceMapMutex.RLock()
+	device, ok := devices.DBDeviceMap[udid]
+	devices.DbDeviceMapMutex.RUnlock()
+
+	if ok {
 		if device.OS == "ios" {
 			api.GenericResponse(c, http.StatusBadRequest, "Functionality not supported for iOS devices", nil)
 			return


### PR DESCRIPTION
## Summary

 Fixes critical data synchronization issues in the GADS mobile device management system where the SSE endpoint and provider's `/info` endpoint were returning stale or incorrect device data due to conflicting updates between hub database and provider state.

## Problem

- Provider was overwriting database configuration fields with stale local data
- Hub was syncing all fields from provider, losing DB configuration updates
- Concurrent access to `DBDeviceMap` without proper synchronization caused race conditions
- WebRTC configuration changes required manual device reprovisioning


 ## Technical Details

**Data Flow Architecture:**

Database (Source of Truth for Config)
      ↓
Hub syncs config to Provider
      ↓
Provider manages operational state
      ↓
Provider reports operational state back to Hub
      ↓
Hub updates only operational fields in DB

**Thread Safety:**
- All reads from `DBDeviceMap` now protected by `RLock()`
- All writes to `DBDeviceMap` protected by `Lock()`
- Copy-on-read pattern ensures goroutines work with safe data snapshots

**Auto-Reprovisioning Logic:**
- Compares WebRTC settings (`UseWebRTCVideo`, `WebRTCVideoCodec`) between DB and provider
- Automatically calls `ResetLocalDevice()` when changes detected
- Eliminates need for manual reprovisioning after WebRTC configuration updates