### PR TITLE
feat(android): add ADB over TCP/IP support for remote debugging

### DIFF
--- a/common/models/models.go
+++ b/common/models/models.go
@@ -99,6 +99,7 @@ type Device struct {
 	SemVer                  *semver.Version    `json:"-" bson:"-"` // Semantic version of device for checks around the provider
 	InitialSetupDone        bool               `json:"-" bson:"-"` // On provider startup some data is prepared for devices like logger, Mongo collection, etc. This is true if all is done
 	DeviceAddress           string             `json:"-" bson:"-"`
+	AdbTcpIpTransitioning     bool   `json:"-" bson:"-"` // true while ADB daemon is restarting due to adb tcpip/usb switch; suppresses false device resets
 }
 
 // Device stream type - mjpeg, webrtc, etc

--- a/hub/router/proxy.go
+++ b/hub/router/proxy.go
@@ -12,6 +12,7 @@ package router
 import (
 	"GADS/common/db"
 	"GADS/hub/auth"
+	"GADS/hub/config"
 	"GADS/hub/devices"
 	"fmt"
 	"net/http"
@@ -91,7 +92,9 @@ func DeviceProxyHandler(c *gin.Context) {
 	device, ok := devices.HubDevicesData.Devices[udid]
 
 	// Verify if the device is already in use by another user
-	if ok && device != nil && device.InUseBy != "" &&
+	// Skip this check when auth is disabled — no concept of user ownership
+	if config.GlobalHubConfig.AuthEnabled &&
+		ok && device != nil && device.InUseBy != "" &&
 		(time.Now().UnixMilli()-device.InUseTS) < 3000 &&
 		(device.InUseBy != username || device.InUseByTenant != tenant) {
 
@@ -105,6 +108,38 @@ func DeviceProxyHandler(c *gin.Context) {
 	if !ok || device == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Device with UDID `%s` not found or is nil", udid)})
 		return
+	}
+
+	// ADB TCP/IP enable is only allowed while the device is actively in use (has a live control session).
+	// When auth is enabled, only the user who holds the session may enable it.
+	if c.Request.Method == "POST" && strings.HasSuffix(path, "/adb-tcpip/enable") {
+		devices.HubDevicesData.Mu.Lock()
+		inUseBy := devices.HubDevicesData.Devices[udid].InUseBy
+		inUseByTenant := devices.HubDevicesData.Devices[udid].InUseByTenant
+		devices.HubDevicesData.Mu.Unlock()
+		if inUseBy == "" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "ADB TCP/IP can only be enabled while the device is in use"})
+			return
+		}
+		if config.GlobalHubConfig.AuthEnabled && (inUseBy != username || inUseByTenant != tenant) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "ADB TCP/IP can only be enabled by the user who has the device in use"})
+			return
+		}
+	}
+
+	// ADB TCP/IP disable is only allowed by the user who holds the session.
+	// When auth is disabled or the device is not in use, any caller may disable (e.g. cleanup).
+	if c.Request.Method == "POST" && strings.HasSuffix(path, "/adb-tcpip/disable") {
+		if config.GlobalHubConfig.AuthEnabled {
+			devices.HubDevicesData.Mu.Lock()
+			inUseBy := devices.HubDevicesData.Devices[udid].InUseBy
+			inUseByTenant := devices.HubDevicesData.Devices[udid].InUseByTenant
+			devices.HubDevicesData.Mu.Unlock()
+			if inUseBy != "" && (inUseBy != username || inUseByTenant != tenant) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "ADB TCP/IP can only be disabled by the user who has the device in use"})
+				return
+			}
+		}
 	}
 
 	// Check if device is available before proceeding with proxy operations

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -573,7 +573,23 @@ func DeviceInUseWS(c *gin.Context) {
 			devices.HubDevicesData.Devices[udid].InUseBy = ""
 			devices.HubDevicesData.Devices[udid].InUseByTenant = ""
 		}
+		// Capture provider host before releasing the lock for ADB TCP/IP cleanup
+		var providerHost string
+		if devices.HubDevicesData.Devices[udid].Device.OS == "android" {
+			providerHost = devices.HubDevicesData.Devices[udid].Device.Host
+		}
 		devices.HubDevicesData.Mu.Unlock()
+
+		// Disable ADB over TCP/IP on session end for Android devices
+		if providerHost != "" {
+			go func() {
+				disableURL := fmt.Sprintf("http://%s/device/%s/adb-tcpip/disable", providerHost, udid)
+				resp, err := netClient.Post(disableURL, "application/json", nil)
+				if err == nil {
+					resp.Body.Close()
+				}
+			}()
+		}
 	}()
 
 	// Create a context with cancel to use in the goroutines

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -828,9 +828,29 @@ func EnableAdbTcpIp(device *models.Device) (string, error) {
 	return ip, nil
 }
 
+// isAdbTcpIpEnabled checks whether the device is currently connected via TCP/IP
+// by looking at the ADB transport. USB devices show up as just the serial number,
+// while TCP/IP devices show as ip:port.
+func isAdbTcpIpEnabled(device *models.Device) bool {
+	cmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "get-serialno")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	serial := strings.TrimSpace(string(out))
+	// TCP/IP connections show as "ip:port" (e.g. "192.168.1.5:5555")
+	return strings.Contains(serial, ":")
+}
+
 // DisableAdbTcpIp reverts the Android device from ADB over TCP/IP mode back to USB mode.
-// Safe to call even if the device is already in USB mode.
+// Skips the operation if the device is already in USB mode to avoid unnecessary daemon restarts.
 func DisableAdbTcpIp(device *models.Device) error {
+	// Check if TCP/IP is actually enabled before restarting the daemon
+	if !isAdbTcpIpEnabled(device) {
+		logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("Device `%s` is already in USB mode, skipping disable", device.UDID))
+		return nil
+	}
+
 	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("Disabling ADB over TCP/IP on device `%s`", device.UDID))
 
 	device.Mutex.Lock()

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -117,6 +117,30 @@ func startGadsRemoteControlServer(device *models.Device) {
 	}
 
 	if err := cmd.Wait(); err != nil {
+		// If this exit was caused by an intentional ADB daemon restart (tcpip/usb switch),
+		// wait for the transition to finish and restart the process instead of resetting the device.
+		device.Mutex.Lock()
+		transitioning := device.AdbTcpIpTransitioning
+		device.Mutex.Unlock()
+
+		if transitioning {
+			logger.ProviderLogger.LogInfo("device_setup", fmt.Sprintf("startGadsRemoteControlServer: process exited during ADB TCP/IP transition for device `%s`, will restart when done", device.UDID))
+			deadline := time.Now().Add(20 * time.Second)
+			for time.Now().Before(deadline) {
+				time.Sleep(500 * time.Millisecond)
+				device.Mutex.Lock()
+				transitioning = device.AdbTcpIpTransitioning
+				device.Mutex.Unlock()
+				if !transitioning {
+					break
+				}
+			}
+			if !transitioning {
+				startGadsRemoteControlServer(device)
+				return
+			}
+		}
+
 		logger.ProviderLogger.LogError("device_setup", fmt.Sprintf(
 			"startGadsRemoteControlServer: Error waiting for `%s` command to finish, it errored out or device `%v` was disconnected - %v",
 			cmd.Args, device.UDID, err))
@@ -151,6 +175,33 @@ func startGadsSettingsStream(device *models.Device) {
 	}
 
 	if err := cmd.Wait(); err != nil {
+		// If this exit was caused by an intentional ADB daemon restart (tcpip/usb switch),
+		// wait for the transition to finish and restart the process instead of resetting the device.
+		device.Mutex.Lock()
+		transitioning := device.AdbTcpIpTransitioning
+		device.Mutex.Unlock()
+
+		if transitioning {
+			logger.ProviderLogger.LogInfo("device_setup", fmt.Sprintf("startGadsSettingsStream: process exited during ADB TCP/IP transition for device `%s`, will restart when done", device.UDID))
+			deadline := time.Now().Add(20 * time.Second)
+			for time.Now().Before(deadline) {
+				time.Sleep(500 * time.Millisecond)
+				device.Mutex.Lock()
+				transitioning = device.AdbTcpIpTransitioning
+				device.Mutex.Unlock()
+				if !transitioning {
+					break
+				}
+			}
+			if !transitioning {
+				// Restart H264Server. The WebRTC session's writeFrames goroutine detects
+				// the stream disconnect and transparently reconnects once the new
+				// H264Server is ready, without closing the browser's WebRTC connection.
+				startGadsSettingsStream(device)
+				return
+			}
+		}
+
 		logger.ProviderLogger.LogError("device_setup", fmt.Sprintf(
 			"startGadsSettingsStream: Error waiting for `%s` command to finish, it errored out or device `%v` was disconnected - %v",
 			cmd.Args, device.UDID, err))
@@ -659,4 +710,162 @@ func addAndroidSharedStorageFilePathNode(root *models.AndroidFileNode, fullPath 
 
 		current = child
 	}
+}
+
+// getAndroidDeviceIP returns the device IP address by trying multiple ADB methods.
+// It first checks the stored IPAddress field, then scans all network interfaces.
+func getAndroidDeviceIP(device *models.Device) (string, error) {
+	if device.IPAddress != "" {
+		return device.IPAddress, nil
+	}
+
+	var outBuffer bytes.Buffer
+
+	// Method 1: ip -f inet addr (all interfaces, skip loopback) — modern Android
+	outBuffer.Reset()
+	cmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "shell", "ip", "-f", "inet", "addr")
+	cmd.Stdout = &outBuffer
+	if err := cmd.Run(); err == nil {
+		for _, line := range strings.Split(outBuffer.String(), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "inet ") {
+				parts := strings.Fields(line)
+				if len(parts) >= 2 {
+					ip := strings.Split(parts[1], "/")[0]
+					if ip != "" && ip != "127.0.0.1" {
+						return ip, nil
+					}
+				}
+			}
+		}
+	}
+
+	// Method 2: getprop — covers wlan0/wlan1/eth0 on various Android versions
+	for _, prop := range []string{
+		"dhcp.wlan0.ipaddress",
+		"dhcp.wlan1.ipaddress",
+		"net.wlan0.ipaddress",
+		"dhcp.eth0.ipaddress",
+	} {
+		outBuffer.Reset()
+		cmd = exec.CommandContext(device.Context, "adb", "-s", device.UDID, "shell", "getprop", prop)
+		cmd.Stdout = &outBuffer
+		if err := cmd.Run(); err == nil {
+			if ip := strings.TrimSpace(outBuffer.String()); ip != "" && ip != "0.0.0.0" {
+				return ip, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("getAndroidDeviceIP: could not determine device IP address via any method")
+}
+
+// reForwardAndroidDevicePorts re-establishes all ADB port forwards after a daemon restart.
+// The adb forward entries are lost whenever the ADB daemon restarts (adb tcpip / adb usb).
+func reForwardAndroidDevicePorts(device *models.Device) {
+	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("Re-establishing ADB port forwards for device `%s`", device.UDID))
+	if err := forwardGadsStream(device); err != nil {
+		logger.ProviderLogger.LogWarn("adb_tcpip", fmt.Sprintf("Failed to re-forward stream port for device `%s` - %s", device.UDID, err))
+	}
+	if err := forwardGadsAndroidIME(device); err != nil {
+		logger.ProviderLogger.LogWarn("adb_tcpip", fmt.Sprintf("Failed to re-forward IME port for device `%s` - %s", device.UDID, err))
+	}
+	if err := forwardGadsRemoteServer(device); err != nil {
+		logger.ProviderLogger.LogWarn("adb_tcpip", fmt.Sprintf("Failed to re-forward remote server port for device `%s` - %s", device.UDID, err))
+	}
+}
+
+// EnableAdbTcpIp switches the Android device to ADB over TCP/IP mode on port 5555
+// and returns the device IP address to use for connecting.
+// IP is retrieved BEFORE issuing `adb tcpip` because that command restarts the ADB
+// daemon on the device, which drops the USB connection temporarily.
+// After switching, we wait for USB to re-establish before returning to prevent
+// the provider's connectivity check from marking the device as offline.
+func EnableAdbTcpIp(device *models.Device) (string, error) {
+	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("Enabling ADB over TCP/IP on device `%s`", device.UDID))
+
+	// Get IP first — after `adb tcpip` the USB ADB connection drops temporarily
+	ip, err := getAndroidDeviceIP(device)
+	if err != nil {
+		return "", fmt.Errorf("EnableAdbTcpIp: Failed to get device IP - %s", err)
+	}
+
+	// Signal that a daemon restart is intentional so goroutines don't trigger ResetLocalDevice
+	device.Mutex.Lock()
+	device.AdbTcpIpTransitioning = true
+	device.Mutex.Unlock()
+
+	cmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "tcpip", "5555")
+	if err := cmd.Run(); err != nil {
+		device.Mutex.Lock()
+		device.AdbTcpIpTransitioning = false
+		device.Mutex.Unlock()
+		return "", fmt.Errorf("EnableAdbTcpIp: Error executing `%s` - %s", cmd.Args, err)
+	}
+
+	// Poll until USB ADB is back. Re-establish port forwards, then clear the flag
+	// so waiting goroutines restart their processes.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		stateCmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "get-state")
+		out, err := stateCmd.Output()
+		if err == nil && strings.TrimSpace(string(out)) == "device" {
+			logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("USB ADB re-established after tcpip switch for device `%s`", device.UDID))
+			reForwardAndroidDevicePorts(device)
+			device.Mutex.Lock()
+			device.AdbTcpIpTransitioning = false
+			device.Mutex.Unlock()
+			return ip, nil
+		}
+	}
+
+	reForwardAndroidDevicePorts(device)
+	device.Mutex.Lock()
+	device.AdbTcpIpTransitioning = false
+	device.Mutex.Unlock()
+	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("USB ADB did not re-establish within timeout for device `%s`, TCP/IP is still enabled", device.UDID))
+	return ip, nil
+}
+
+// DisableAdbTcpIp reverts the Android device from ADB over TCP/IP mode back to USB mode.
+// Safe to call even if the device is already in USB mode.
+func DisableAdbTcpIp(device *models.Device) error {
+	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("Disabling ADB over TCP/IP on device `%s`", device.UDID))
+
+	device.Mutex.Lock()
+	device.AdbTcpIpTransitioning = true
+	device.Mutex.Unlock()
+
+	cmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "usb")
+	if err := cmd.Run(); err != nil {
+		device.Mutex.Lock()
+		device.AdbTcpIpTransitioning = false
+		device.Mutex.Unlock()
+		return fmt.Errorf("DisableAdbTcpIp: Error executing `%s` - %s", cmd.Args, err)
+	}
+
+	// Wait for USB ADB to re-establish after daemon restart. Re-establish port forwards,
+	// then clear the flag so waiting goroutines restart their processes.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		stateCmd := exec.CommandContext(device.Context, "adb", "-s", device.UDID, "get-state")
+		out, err := stateCmd.Output()
+		if err == nil && strings.TrimSpace(string(out)) == "device" {
+			logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("USB ADB re-established after usb switch for device `%s`", device.UDID))
+			reForwardAndroidDevicePorts(device)
+			device.Mutex.Lock()
+			device.AdbTcpIpTransitioning = false
+			device.Mutex.Unlock()
+			return nil
+		}
+	}
+
+	reForwardAndroidDevicePorts(device)
+	device.Mutex.Lock()
+	device.AdbTcpIpTransitioning = false
+	device.Mutex.Unlock()
+	logger.ProviderLogger.LogInfo("adb_tcpip", fmt.Sprintf("USB ADB did not re-establish within timeout for device `%s` after disabling TCP/IP", device.UDID))
+	return nil
 }

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -1037,7 +1037,9 @@ func getConnectedDevicesAndroid() []string {
 func ResetLocalDevice(device *models.Device, reason string) {
 	device.Mutex.Lock()
 	defer device.Mutex.Unlock()
-	if !device.IsResetting && device.ProviderState != "init" {
+	// Suppress reset only when device is fully live AND an ADB daemon restart is in progress.
+	// During setup (ProviderState == "preparing"), allow the reset so the setup cycle can restart.
+	if !device.IsResetting && device.ProviderState != "init" && !(device.AdbTcpIpTransitioning && device.ProviderState == "live") {
 		logger.ProviderLogger.LogInfo("provider", fmt.Sprintf("Resetting LocalDevice for device `%v` with reason: %s. Cancelling context, setting ProviderState to `init`, Healthy to `false` and updating the DB", device.UDID, reason))
 
 		device.IsResetting = true

--- a/provider/router/android_stream_webrtc.go
+++ b/provider/router/android_stream_webrtc.go
@@ -133,7 +133,7 @@ func (s *AndroidWebRTCSession) Start() error {
 	logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Connected to Android H.264 stream for device %s", s.device.UDID))
 
 	// Start reading frames from WebSocket
-	go s.readFrames()
+	go s.readFrames(conn, s.frameChannel)
 
 	// Start writing frames to WebRTC track
 	go s.writeFrames()
@@ -141,10 +141,11 @@ func (s *AndroidWebRTCSession) Start() error {
 	return nil
 }
 
-// readFrames reads H.264 frames from WebSocket and sends to channel
-func (s *AndroidWebRTCSession) readFrames() {
-	defer close(s.frameChannel)
-	defer s.wsConn.Close()
+// readFrames reads H.264 frames from wsConn and sends to ch.
+// Parametrised so reconnectStream can start a fresh goroutine without touching struct fields.
+func (s *AndroidWebRTCSession) readFrames(wsConn io.ReadWriteCloser, ch chan AndroidH264Frame) {
+	defer close(ch)
+	defer wsConn.Close()
 
 	logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Starting frame reading for device %s", s.device.UDID))
 
@@ -159,7 +160,7 @@ func (s *AndroidWebRTCSession) readFrames() {
 
 		// Read H.264 frame from WebSocket
 		// Android sends: [8 bytes PTS][H.264 data]
-		msg, _, err := wsutil.ReadServerData(s.wsConn)
+		msg, _, err := wsutil.ReadServerData(wsConn)
 		if err != nil {
 			if err != io.EOF {
 				logger.ProviderLogger.LogError("stream_webrtc", fmt.Sprintf("Error reading from WebSocket for device %s: %s", s.device.UDID, err))
@@ -187,7 +188,7 @@ func (s *AndroidWebRTCSession) readFrames() {
 		}
 
 		select {
-		case s.frameChannel <- frame:
+		case ch <- frame:
 			// Successfully queued
 		case <-s.ctx.Done():
 			return
@@ -200,7 +201,39 @@ func (s *AndroidWebRTCSession) readFrames() {
 	}
 }
 
-// writeFrames reads frames from channel and writes to WebRTC track
+// reconnectStream polls for the H264 stream to come back and returns a new frame channel.
+// Used by writeFrames to transparently recover from H264Server restarts (e.g. adb tcpip)
+// without closing the WebRTC peer connection and interrupting the browser.
+func (s *AndroidWebRTCSession) reconnectStream() (chan AndroidH264Frame, bool) {
+	streamURL := "ws://localhost:" + s.device.StreamPort
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-s.ctx.Done():
+			return nil, false
+		default:
+		}
+		time.Sleep(500 * time.Millisecond)
+
+		conn, _, _, err := ws.Dial(s.ctx, streamURL)
+		if err != nil {
+			continue
+		}
+
+		logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Reconnected to Android H.264 stream for device %s", s.device.UDID))
+		newCh := make(chan AndroidH264Frame, 30)
+		s.mu.Lock()
+		s.wsConn = conn
+		s.mu.Unlock()
+		go s.readFrames(conn, newCh)
+		return newCh, true
+	}
+	return nil, false
+}
+
+// writeFrames reads frames from channel and writes to WebRTC track.
+// When the frame channel closes unexpectedly (H264Server restarted), it calls
+// reconnectStream to resume streaming without disconnecting the browser.
 func (s *AndroidWebRTCSession) writeFrames() {
 	fallbackDuration := time.Second / time.Duration(30) // Default 30fps
 	if s.device.StreamTargetFPS > 0 {
@@ -209,15 +242,38 @@ func (s *AndroidWebRTCSession) writeFrames() {
 
 	logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Starting frame writing for device %s", s.device.UDID))
 
+	currentCh := s.frameChannel
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Stopping frame writing for device %s", s.device.UDID))
 			return
-		case frame, ok := <-s.frameChannel:
+		case frame, ok := <-currentCh:
 			if !ok {
-				logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Frame channel closed for device %s", s.device.UDID))
-				return
+				// Check whether the close was intentional (context cancelled).
+				select {
+				case <-s.ctx.Done():
+					logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Frame channel closed for device %s", s.device.UDID))
+					return
+				default:
+				}
+
+				// H264Server died unexpectedly (e.g. adb tcpip daemon restart).
+				// Try to reconnect transparently so the browser keeps its WebRTC session.
+				logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("H264 stream disconnected for device %s, waiting for H264Server to restart...", s.device.UDID))
+				newCh, ok := s.reconnectStream()
+				if !ok {
+					logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Frame channel closed for device %s (reconnect timed out)", s.device.UDID))
+					return
+				}
+				currentCh = newCh
+				// Reset timestamp tracking so the new stream starts with a clean baseline
+				s.mu.Lock()
+				s.firstTimestamp = 0
+				s.lastTimestamp = 0
+				s.mu.Unlock()
+				continue
 			}
 
 			if len(frame.Data) < 5 {
@@ -246,13 +302,6 @@ func (s *AndroidWebRTCSession) writeFrames() {
 
 			track := s.videoTrack
 			s.mu.Unlock()
-
-			// Log every 30 frames
-			// Left for potential debugging
-			// frameNum := s.frameCount
-			// if frameNum%30 == 0 {
-			// 	logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Streaming frame #%d (%d bytes, duration=%v) for device %s", frameNum, len(frame.Data), duration, s.device.UDID))
-			// }
 
 			// Write to WebRTC track
 			if track != nil {

--- a/provider/router/device_routes.go
+++ b/provider/router/device_routes.go
@@ -396,3 +396,71 @@ func DeviceExecuteCustomAction(c *gin.Context) {
 
 	api.GenericResponse(c, actionResp.StatusCode, string(body), nil)
 }
+
+// DeviceEnableAdbTcpIp enables ADB over TCP/IP (port 5555) on an Android device
+// and returns the connection info needed to connect remotely.
+func DeviceEnableAdbTcpIp(c *gin.Context) {
+	udid := c.Param("udid")
+	device := devices.DBDeviceMap[udid]
+
+	if device.OS != "android" {
+		api.GenericResponse(c, http.StatusBadRequest, "ADB over TCP/IP is only supported for Android devices", nil)
+		return
+	}
+
+	// Only operate on live devices — skip silently if device is still setting up
+	if device.ProviderState != "live" {
+		api.GenericResponse(c, http.StatusOK, "Device is not yet live, ADB TCP/IP enable skipped", nil)
+		return
+	}
+
+	device.Logger.LogInfo("adb_tcpip", "Enabling ADB over TCP/IP")
+
+	ip, err := devices.EnableAdbTcpIp(device)
+	if err != nil {
+		device.Logger.LogError("adb_tcpip", fmt.Sprintf("Failed to enable ADB over TCP/IP - %s", err))
+		api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to enable ADB over TCP/IP - %s", err), nil)
+		return
+	}
+
+	result := struct {
+		IP             string `json:"ip"`
+		Port           int    `json:"port"`
+		ConnectCommand string `json:"connect_command"`
+	}{
+		IP:             ip,
+		Port:           5555,
+		ConnectCommand: fmt.Sprintf("adb connect %s:5555", ip),
+	}
+
+	api.GenericResponse(c, http.StatusOK, "", result)
+}
+
+// DeviceDisableAdbTcpIp reverts an Android device from ADB over TCP/IP mode back to USB mode.
+func DeviceDisableAdbTcpIp(c *gin.Context) {
+	udid := c.Param("udid")
+	device := devices.DBDeviceMap[udid]
+
+	if device.OS != "android" {
+		api.GenericResponse(c, http.StatusBadRequest, "ADB over TCP/IP is only supported for Android devices", nil)
+		return
+	}
+
+	// Only operate on live devices — skip silently if device is still setting up.
+	// The hub calls this on session end; if the provider just restarted and the device
+	// is in setup, there is nothing to revert.
+	if device.ProviderState != "live" {
+		api.GenericResponse(c, http.StatusOK, "Device is not yet live, ADB TCP/IP disable skipped", nil)
+		return
+	}
+
+	device.Logger.LogInfo("adb_tcpip", "Disabling ADB over TCP/IP")
+
+	if err := devices.DisableAdbTcpIp(device); err != nil {
+		device.Logger.LogError("adb_tcpip", fmt.Sprintf("Failed to disable ADB over TCP/IP - %s", err))
+		api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to disable ADB over TCP/IP - %s", err), nil)
+		return
+	}
+
+	api.GenericResponse(c, http.StatusOK, "ADB over TCP/IP disabled", nil)
+}

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -84,6 +84,8 @@ func HandleRequests() *gin.Engine {
 	deviceGroup.POST("/closeApp", CloseApp)
 	deviceGroup.POST("/reset", ResetDevice)
 	deviceGroup.POST("/uploadAndInstallApp", UploadAndInstallApp)
+	deviceGroup.POST("/adb-tcpip/enable", DeviceEnableAdbTcpIp)
+	deviceGroup.POST("/adb-tcpip/disable", DeviceDisableAdbTcpIp)
 	deviceGroup.GET("/webrtc", DevicesWebRTCSocket)
 	deviceAppiumPluginGroup := deviceGroup.Group("/appium-plugin")
 	deviceAppiumPluginGroup.POST("/log", AppiumPluginLog)


### PR DESCRIPTION
## Summary

Allow users to connect to Android devices directly via ADB over Wi-Fi while GADS manages the USB connection.

**Flow:** take device → enable ADB TCP/IP → get `adb connect IP:5555` command → work remotely → release device → provider auto-restores USB mode.

## Changes

- `POST /device/:udid/adb-tcpip/enable` — enables TCP/IP mode on port 5555, returns device IP and connect command
- `POST /device/:udid/adb-tcpip/disable` — restores USB-only mode
- Re-establishes ADB port forwards (stream, IME, remote server) after daemon restart caused by `adb tcpip` / `adb usb`
- `AdbTcpIpTransitioning` flag on device prevents false device resets while ADB daemon is intentionally restarting
- WebRTC H264 stream reconnects transparently without closing the browser peer connection (`reconnectStream` in `writeFrames`)
- Hub proxy: `enable` is gated — only works when device is actively in use by the requesting user
- Hub proxy: `disable` is gated — only the session owner can disable (or anyone when device is free)
- Hub: auto-disables ADB TCP/IP when the device control WebSocket session ends