### PR TITLE
Feat(hub): Add HTTP device lease locks and tighten session handling

### DIFF
--- a/common/models/models.go
+++ b/common/models/models.go
@@ -208,9 +208,10 @@ type LocalHubDevice struct {
 	InUseTS                  int64    `json:"in_use_ts"`
 	AppiumNewCommandTimeout  int64    `json:"appium_new_command_timeout"`
 	IsAvailableForAutomation bool     `json:"is_available_for_automation"`
-	Available                bool     `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
-	InUseWSConnection        net.Conn `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
-	LastActionTS             int64    `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
+	Available                bool     `json:"available" bson:"-"`              // if device is currently available - not only connected, but setup completed
+	InUseWSConnection        net.Conn `json:"-" bson:"-"`                      // stores the ws connection made when device is in use to send data from different sources
+	InUseHTTPExpiresAt       int64    `json:"in_use_http_expires_at" bson:"-"` // timestamp until which the device is considered in use based on HTTP requests - this is used to handle the case when a user has a session but didn't connect via WS for some reason, so we can still consider the device in use until this timestamp expires based on the last HTTP request made by the user for this device
+	LastActionTS             int64    `json:"-" bson:"-"`                      // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
 }
 
 type DeviceStreamSettings struct {
@@ -235,6 +236,10 @@ type UpdateStreamSettings struct {
 type DeviceInUseMessage struct {
 	Type    string      `json:"type"`
 	Payload interface{} `json:"payload"`
+}
+
+type DeviceLockRequest struct {
+	TimeoutMS int64 `json:"timeout_ms"`
 }
 
 type DBFile struct {

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -257,10 +257,11 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				foundDevice.IsRunningAutomation = false
 				if resp.StatusCode != http.StatusInternalServerError {
 					// Only clear user info if no manual session is active
-					if foundDevice.InUseWSConnection == nil {
+					if !hasActiveManualLockLocked(foundDevice, time.Now().UnixMilli()) {
 						foundDevice.InUseBy = ""
 						foundDevice.InUseByTenant = ""
 						foundDevice.InUseTS = 0
+						foundDevice.InUseHTTPExpiresAt = 0
 					}
 				}
 				devices.HubDevicesData.Mu.Unlock()
@@ -275,10 +276,11 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 							foundDevice.SessionID = ""
 							foundDevice.IsRunningAutomation = false
 							// Only clear user info if no manual session is active
-							if foundDevice.InUseWSConnection == nil {
+							if !hasActiveManualLockLocked(foundDevice, time.Now().UnixMilli()) {
 								foundDevice.InUseBy = ""
 								foundDevice.InUseByTenant = ""
 								foundDevice.InUseTS = 0
+								foundDevice.InUseHTTPExpiresAt = 0
 							}
 						}
 						devices.HubDevicesData.Mu.Unlock()
@@ -336,10 +338,11 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				automationUser = "unknown"
 			}
 			// Only update InUseBy if no manual session is active
-			if foundDevice.InUseWSConnection == nil {
+			if !hasActiveManualLockLocked(foundDevice, time.Now().UnixMilli()) {
 				foundDevice.InUseBy = automationUser
 				foundDevice.InUseByTenant = credential.Tenant
 				foundDevice.InUseTS = time.Now().UnixMilli()
+				foundDevice.InUseHTTPExpiresAt = 0
 			}
 			devices.HubDevicesData.Mu.Unlock()
 		} else {
@@ -439,10 +442,11 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 						foundDevice.SessionID = ""
 						foundDevice.IsRunningAutomation = false
 						// Only clear user info if no manual session is active
-						if foundDevice.InUseWSConnection == nil {
+						if !hasActiveManualLockLocked(foundDevice, time.Now().UnixMilli()) {
 							foundDevice.InUseBy = ""
 							foundDevice.InUseByTenant = ""
 							foundDevice.InUseTS = 0
+							foundDevice.InUseHTTPExpiresAt = 0
 						}
 					}
 					devices.HubDevicesData.Mu.Unlock()
@@ -459,10 +463,11 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 						foundDevice.IsAvailableForAutomation = true
 						foundDevice.IsRunningAutomation = false
 						// Only clear user info if no manual session is active
-						if foundDevice.InUseWSConnection == nil {
+						if !hasActiveManualLockLocked(foundDevice, time.Now().UnixMilli()) {
 							foundDevice.InUseBy = ""
 							foundDevice.InUseByTenant = ""
 							foundDevice.InUseTS = 0
+							foundDevice.InUseHTTPExpiresAt = 0
 						}
 					}
 					devices.HubDevicesData.Mu.Unlock()

--- a/hub/router/handler.go
+++ b/hub/router/handler.go
@@ -99,6 +99,8 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	authGroup.GET("/appium-logs", GetAppiumLogs)
 	authGroup.GET("/health", HealthCheck)
 	authGroup.POST("/logout", auth.LogoutHandler)
+	authGroup.POST("/devices/control/:udid/lock", LockDeviceHTTP)
+	authGroup.POST("/devices/control/:udid/unlock", UnlockDeviceHTTP)
 	authGroup.Any("/device/:udid/*path", DeviceProxyHandler)
 	authGroup.Any("/provider/:name/*path", ProviderProxyHandler)
 	authGroup.GET("/admin/providers", GetProviders)

--- a/hub/router/proxy.go
+++ b/hub/router/proxy.go
@@ -11,9 +11,13 @@ package router
 
 import (
 	"GADS/common/db"
+	"GADS/common/models"
 	"GADS/hub/auth"
 	"GADS/hub/devices"
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -87,12 +91,44 @@ func DeviceProxyHandler(c *gin.Context) {
 		}
 	}
 
+	if c.Request.Method == http.MethodPost && strings.HasSuffix(path, "/session") && authToken == "" {
+		requestBody, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read session request body"})
+			return
+		}
+
+		// Restore request body so the downstream proxy can read it.
+		c.Request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
+
+		var sessionRequest map[string]interface{}
+		err = json.Unmarshal(requestBody, &sessionRequest)
+		if err == nil {
+			clientSecret := models.ExtractClientSecretFromSession(sessionRequest, capabilityPrefix)
+			if clientSecret == "" {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"value": gin.H{
+						"error":      "invalid argument",
+						"message":    fmt.Sprintf("Client credentials are required. Provide %s:clientSecret in the capabilities.", capabilityPrefix),
+						"stacktrace": "",
+					},
+				})
+				return
+			}
+		}
+	}
+
+	now := time.Now().UnixMilli()
+
 	devices.HubDevicesData.Mu.Lock()
 	device, ok := devices.HubDevicesData.Devices[udid]
+	if ok && device != nil {
+		clearExpiredHTTPLeaseLocked(device, now)
+	}
 
 	// Verify if the device is already in use by another user
 	if ok && device != nil && device.InUseBy != "" &&
-		(time.Now().UnixMilli()-device.InUseTS) < 3000 &&
+		(device.InUseWSConnection != nil || hasActiveHTTPLeaseLocked(device, now) || (now-device.InUseTS) < 3000) &&
 		(device.InUseBy != username || device.InUseByTenant != tenant) {
 
 		devices.HubDevicesData.Mu.Unlock()

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -160,6 +160,38 @@ func TestDeviceProxyHandler(t *testing.T) {
 		devices.HubDevicesData.Mu.Unlock()
 	})
 
+	t.Run("HTTP Lease Lock By Another User - Should Return 409", func(t *testing.T) {
+		udid := "test-device-http-lease-in-use"
+		currentTime := time.Now().UnixMilli()
+		devices.HubDevicesData.Mu.Lock()
+		devices.HubDevicesData.Devices[udid] = &models.LocalHubDevice{
+			Device: models.Device{
+				UDID: udid,
+				Host: "localhost:8080",
+			},
+			Available:          true,
+			InUseBy:            "another-user",
+			InUseByTenant:      "tenant-a",
+			InUseTS:            currentTime,
+			InUseHTTPExpiresAt: currentTime + 60000,
+		}
+		devices.HubDevicesData.Mu.Unlock()
+
+		router := gin.New()
+		router.GET("/device/:udid/*path", DeviceProxyHandler)
+
+		req, _ := http.NewRequest("GET", "/device/"+udid+"/status", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+
+		devices.HubDevicesData.Mu.Lock()
+		delete(devices.HubDevicesData.Devices, udid)
+		devices.HubDevicesData.Mu.Unlock()
+	})
+
 	t.Run("Missing Client Credentials - Should Return W3C Error Format", func(t *testing.T) {
 		// Setup a device
 		udid := "test-device-no-credentials"

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -37,6 +37,88 @@ var netClient = &http.Client{
 	Timeout: time.Second * 120,
 }
 
+const (
+	minDeviceLockTimeoutMS int64 = 1000
+	maxDeviceLockTimeoutMS int64 = 6 * 60 * 60 * 1000
+)
+
+func clearManualLockFields(device *models.LocalHubDevice) {
+	device.InUseTS = 0
+	device.InUseBy = ""
+	device.InUseByTenant = ""
+	device.InUseHTTPExpiresAt = 0
+}
+
+func clearExpiredHTTPLeaseLocked(device *models.LocalHubDevice, now int64) {
+	if device == nil || device.InUseWSConnection != nil {
+		return
+	}
+
+	if device.InUseHTTPExpiresAt > 0 && device.InUseHTTPExpiresAt <= now {
+		device.InUseHTTPExpiresAt = 0
+		if !device.IsRunningAutomation {
+			clearManualLockFields(device)
+		}
+	}
+}
+
+func hasActiveHTTPLeaseLocked(device *models.LocalHubDevice, now int64) bool {
+	if device == nil || device.InUseWSConnection != nil {
+		return false
+	}
+
+	return device.InUseHTTPExpiresAt > now && device.InUseBy != ""
+}
+
+func hasActiveManualLockLocked(device *models.LocalHubDevice, now int64) bool {
+	if device == nil {
+		return false
+	}
+
+	if device.InUseWSConnection != nil {
+		return true
+	}
+
+	return hasActiveHTTPLeaseLocked(device, now)
+}
+
+func scheduleHTTPLeaseRelease(udid string, username string, tenant string, expiresAt int64) {
+	delay := time.Until(time.UnixMilli(expiresAt))
+	if delay < 0 {
+		delay = 0
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	<-timer.C
+
+	now := time.Now().UnixMilli()
+
+	devices.HubDevicesData.Mu.Lock()
+	defer devices.HubDevicesData.Mu.Unlock()
+
+	device, exists := devices.HubDevicesData.Devices[udid]
+	if !exists || device == nil {
+		return
+	}
+
+	if device.InUseWSConnection != nil {
+		return
+	}
+
+	if device.InUseBy == username &&
+		device.InUseByTenant == tenant &&
+		device.InUseHTTPExpiresAt == expiresAt &&
+		device.InUseHTTPExpiresAt <= now {
+		if !device.IsRunningAutomation {
+			clearManualLockFields(device)
+			return
+		}
+
+		device.InUseHTTPExpiresAt = 0
+	}
+}
+
 // HealthCheck godoc
 // @Summary      Health check endpoint
 // @Description  Check if the GADS hub is running and healthy
@@ -449,6 +531,176 @@ func ProviderInfoSSE(c *gin.Context) {
 	})
 }
 
+// LockDeviceHTTP godoc
+// @Summary      Lock device for manual control
+// @Description  Acquire a timeout-based lock for a device without websocket heartbeat
+// @Tags         Devices Control
+// @Accept       json
+// @Produce      json
+// @Param        udid  path      string                    true  "Device UDID"
+// @Param        body  body      models.DeviceLockRequest  true  "Lock timeout in milliseconds"
+// @Success      200   {object}  map[string]interface{}
+// @Failure      400   {object}  models.ErrorResponse
+// @Failure      401   {object}  models.ErrorResponse
+// @Failure      404   {object}  models.ErrorResponse
+// @Failure      409   {object}  models.ErrorResponse
+// @Failure      422   {object}  models.ErrorResponse
+// @Security     BearerAuth
+// @Router       /devices/control/{udid}/lock [post]
+func LockDeviceHTTP(c *gin.Context) {
+	udid := c.Param("udid")
+	if udid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing device udid"})
+		return
+	}
+
+	usernameValue, usernameExists := c.Get("username")
+	if !usernameExists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	username := fmt.Sprintf("%v", usernameValue)
+
+	tenant := ""
+	if tenantValue, tenantExists := c.Get("tenant"); tenantExists {
+		tenant = fmt.Sprintf("%v", tenantValue)
+	}
+
+	var lockRequest models.DeviceLockRequest
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse request body"})
+		return
+	}
+
+	err = json.Unmarshal(body, &lockRequest)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON body"})
+		return
+	}
+
+	if lockRequest.TimeoutMS < minDeviceLockTimeoutMS || lockRequest.TimeoutMS > maxDeviceLockTimeoutMS {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("timeout_ms must be between %d and %d", minDeviceLockTimeoutMS, maxDeviceLockTimeoutMS)})
+		return
+	}
+
+	now := time.Now().UnixMilli()
+	leaseExpiresAt := now + lockRequest.TimeoutMS
+
+	devices.HubDevicesData.Mu.Lock()
+	device, exists := devices.HubDevicesData.Devices[udid]
+	if !exists || device == nil {
+		devices.HubDevicesData.Mu.Unlock()
+		c.JSON(http.StatusNotFound, gin.H{"error": "device not found"})
+		return
+	}
+
+	clearExpiredHTTPLeaseLocked(device, now)
+
+	if !device.Available {
+		devices.HubDevicesData.Mu.Unlock()
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": fmt.Sprintf("Device `%s` is not available", udid)})
+		return
+	}
+
+	isSameUser := device.InUseBy == username && device.InUseByTenant == tenant
+	if device.InUseBy != "" && !isSameUser {
+		if device.InUseWSConnection != nil || hasActiveHTTPLeaseLocked(device, now) || (now-device.InUseTS) < 3000 {
+			devices.HubDevicesData.Mu.Unlock()
+			c.JSON(http.StatusConflict, gin.H{"error": "This device is already linked to another user with an active session"})
+			return
+		}
+	}
+
+	device.InUseBy = username
+	device.InUseByTenant = tenant
+	device.InUseTS = now
+	device.LastActionTS = now
+	device.InUseHTTPExpiresAt = leaseExpiresAt
+	devices.HubDevicesData.Mu.Unlock()
+
+	go scheduleHTTPLeaseRelease(udid, username, tenant, leaseExpiresAt)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":    "Device lock acquired",
+		"udid":       udid,
+		"in_use_by":  username,
+		"expires_at": leaseExpiresAt,
+	})
+}
+
+// UnlockDeviceHTTP godoc
+// @Summary      Unlock device for manual control
+// @Description  Release a timeout-based lock before it expires
+// @Tags         Devices Control
+// @Accept       json
+// @Produce      json
+// @Param        udid  path      string  true  "Device UDID"
+// @Success      200   {object}  models.SuccessResponse
+// @Failure      401   {object}  models.ErrorResponse
+// @Failure      403   {object}  models.ErrorResponse
+// @Failure      404   {object}  models.ErrorResponse
+// @Failure      409   {object}  models.ErrorResponse
+// @Security     BearerAuth
+// @Router       /devices/control/{udid}/unlock [post]
+func UnlockDeviceHTTP(c *gin.Context) {
+	udid := c.Param("udid")
+	if udid == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing device udid"})
+		return
+	}
+
+	usernameValue, usernameExists := c.Get("username")
+	if !usernameExists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	username := fmt.Sprintf("%v", usernameValue)
+
+	tenant := ""
+	if tenantValue, tenantExists := c.Get("tenant"); tenantExists {
+		tenant = fmt.Sprintf("%v", tenantValue)
+	}
+
+	role := ""
+	if roleValue, roleExists := c.Get("role"); roleExists {
+		role = fmt.Sprintf("%v", roleValue)
+	}
+
+	now := time.Now().UnixMilli()
+
+	devices.HubDevicesData.Mu.Lock()
+	defer devices.HubDevicesData.Mu.Unlock()
+
+	device, exists := devices.HubDevicesData.Devices[udid]
+	if !exists || device == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "device not found"})
+		return
+	}
+
+	clearExpiredHTTPLeaseLocked(device, now)
+
+	if device.InUseWSConnection != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "device has active websocket lock"})
+		return
+	}
+
+	if !hasActiveHTTPLeaseLocked(device, now) {
+		c.JSON(http.StatusOK, gin.H{"message": "Device is not locked by HTTP lease"})
+		return
+	}
+
+	isAdmin := role == "admin"
+	isOwner := device.InUseBy == username && device.InUseByTenant == tenant
+	if !isAdmin && !isOwner {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only lock owner or admin can unlock this device"})
+		return
+	}
+
+	clearManualLockFields(device)
+	c.JSON(http.StatusOK, gin.H{"message": "Device lock released"})
+}
+
 // DeviceInUseWS godoc
 // @Summary      Device in-use WebSocket
 // @Description  WebSocket connection to manage device usage status and control
@@ -501,6 +753,8 @@ func DeviceInUseWS(c *gin.Context) {
 		userTenant = claims.Tenant
 	}
 
+	now := time.Now().UnixMilli()
+
 	// Verify if the device is already in use by another user
 	devices.HubDevicesData.Mu.Lock()
 	device, exists := devices.HubDevicesData.Devices[udid]
@@ -509,6 +763,8 @@ func DeviceInUseWS(c *gin.Context) {
 		c.Status(http.StatusNotFound)
 		return
 	}
+
+	clearExpiredHTTPLeaseLocked(device, now)
 
 	// Check if device is in use by another user
 	if device.InUseBy != "" {
@@ -523,7 +779,14 @@ func DeviceInUseWS(c *gin.Context) {
 		}
 
 		// If not the same user and device was used recently, also deny
-		if !isSameUser && (time.Now().UnixMilli()-device.InUseTS) < 3000 {
+		if !isSameUser && hasActiveHTTPLeaseLocked(device, now) {
+			devices.HubDevicesData.Mu.Unlock()
+			c.Status(http.StatusConflict)
+			return
+		}
+
+		// If not the same user and device was used recently, also deny
+		if !isSameUser && (now-device.InUseTS) < 3000 {
 			devices.HubDevicesData.Mu.Unlock()
 			c.Status(http.StatusConflict)
 			return
@@ -536,6 +799,7 @@ func DeviceInUseWS(c *gin.Context) {
 	devices.HubDevicesData.Devices[udid].InUseBy = username
 	devices.HubDevicesData.Devices[udid].InUseByTenant = userTenant
 	devices.HubDevicesData.Devices[udid].LastActionTS = time.Now().UnixMilli()
+	devices.HubDevicesData.Devices[udid].InUseHTTPExpiresAt = 0
 	devices.HubDevicesData.Mu.Unlock()
 
 	conn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
@@ -570,6 +834,7 @@ func DeviceInUseWS(c *gin.Context) {
 			devices.HubDevicesData.Devices[udid].InUseTS = 0
 			devices.HubDevicesData.Devices[udid].InUseBy = ""
 			devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+			devices.HubDevicesData.Devices[udid].InUseHTTPExpiresAt = 0
 		}
 		devices.HubDevicesData.Mu.Unlock()
 	}()
@@ -677,9 +942,7 @@ func DeviceInUseWS(c *gin.Context) {
 			devices.HubDevicesData.Mu.Lock()
 			// Only clear user info if not running automation
 			if !devices.HubDevicesData.Devices[udid].IsRunningAutomation {
-				devices.HubDevicesData.Devices[udid].InUseTS = 0
-				devices.HubDevicesData.Devices[udid].InUseBy = ""
-				devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+				clearManualLockFields(devices.HubDevicesData.Devices[udid])
 			}
 			devices.HubDevicesData.Mu.Unlock()
 			return
@@ -712,6 +975,7 @@ func AvailableDevicesSSE(c *gin.Context) {
 	c.Stream(func(w io.Writer) bool {
 
 		devices.HubDevicesData.Mu.Lock()
+		now := time.Now().UnixMilli()
 		// Extract the keys from the map and order them
 		var hubDeviceMapKeys []string
 		for key := range devices.HubDevicesData.Devices {
@@ -722,13 +986,14 @@ func AvailableDevicesSSE(c *gin.Context) {
 		var deviceList = []*models.LocalHubDevice{}
 		for _, key := range hubDeviceMapKeys {
 			device := devices.HubDevicesData.Devices[key]
+			clearExpiredHTTPLeaseLocked(device, now)
 
 			// Filter by workspace
 			if device.Device.WorkspaceID != workspaceID {
 				continue
 			}
 
-			if device.Device.LastUpdatedTimestamp < (time.Now().UnixMilli()-3000) && device.Device.Connected {
+			if device.Device.LastUpdatedTimestamp < (now-3000) && device.Device.Connected {
 				device.Available = false
 			} else if device.Device.ProviderState != "live" {
 				device.Available = false
@@ -736,7 +1001,8 @@ func AvailableDevicesSSE(c *gin.Context) {
 				device.Available = true
 			}
 
-			if device.InUseTS > (time.Now().UnixMilli() - 3000) {
+			isInUseNow := hasActiveManualLockLocked(device, now) || device.InUseTS > (now-3000)
+			if isInUseNow {
 				if !device.InUse {
 					device.InUse = true
 				}
@@ -1016,25 +1282,50 @@ func GetDevices(c *gin.Context) {
 // @Router       /admin/device/{udid}/release [post]
 func ReleaseUsedDevice(c *gin.Context) {
 	udid := c.Param("udid")
+	now := time.Now().UnixMilli()
+
+	devices.HubDevicesData.Mu.Lock()
+	defer devices.HubDevicesData.Mu.Unlock()
+
+	device, exists := devices.HubDevicesData.Devices[udid]
+	if !exists || device == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "device not found"})
+		return
+	}
+
+	clearExpiredHTTPLeaseLocked(device, now)
+
+	if device.InUseWSConnection == nil {
+		if hasActiveHTTPLeaseLocked(device, now) {
+			clearManualLockFields(device)
+			c.JSON(http.StatusOK, gin.H{"message": "Device HTTP lock was successfully released"})
+			return
+		}
+
+		if device.InUseBy != "" && !device.IsRunningAutomation {
+			clearManualLockFields(device)
+			c.JSON(http.StatusOK, gin.H{"message": "Device lock was successfully released"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "Device is not currently locked"})
+		return
+	}
 
 	// Send a release device message on the device in use websocket connection
 	deviceInUseMessage := models.DeviceInUseMessage{
 		Type: "releaseDevice",
 	}
 	deviceInUseMessageJson, _ := json.Marshal(deviceInUseMessage)
-
-	devices.HubDevicesData.Mu.Lock()
-	defer devices.HubDevicesData.Mu.Unlock()
-	err := wsutil.WriteServerText(devices.HubDevicesData.Devices[udid].InUseWSConnection, deviceInUseMessageJson)
+	err := wsutil.WriteServerText(device.InUseWSConnection, deviceInUseMessageJson)
 	if err != nil {
 		c.JSON(500, gin.H{"error": "Failed to send release device message - " + err.Error()})
 		return
 	}
 
-	devices.HubDevicesData.Devices[udid].InUseWSConnection.Close()
-	devices.HubDevicesData.Devices[udid].InUseTS = 0
-	devices.HubDevicesData.Devices[udid].InUseBy = ""
-	devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+	device.InUseWSConnection.Close()
+	device.InUseWSConnection = nil
+	clearManualLockFields(device)
 
 	c.JSON(200, gin.H{"message": "Message to release device was successfully sent"})
 }

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -201,7 +201,7 @@ func GetInstalledAppsIOS(device *models.Device) []string {
 func uninstallAppIOS(device *models.Device, bundleID string) error {
 	svc, err := installationproxy.New(device.GoIOSDeviceEntry)
 	if err != nil {
-		device.Logger.LogError("uninstall_app", fmt.Sprintf("uninstallAppIOS: Failed creating installation proxy connection - %v", bundleID, err))
+		device.Logger.LogError("uninstall_app", fmt.Sprintf("uninstallAppIOS: Failed creating installation proxy connection for bundleID `%s` - %v", bundleID, err))
 		return err
 	}
 	err = svc.Uninstall(bundleID)
@@ -239,7 +239,7 @@ func installAppIOS(device *models.Device, appPath string) error {
 func launchAppIOS(device *models.Device, bundleID string, killExisting bool) error {
 	pControl, err := instruments.NewProcessControl(device.GoIOSDeviceEntry)
 	if err != nil {
-		return fmt.Errorf("launchAppIOS: Failed to initiate process control launching app with bundleID `$s` - %s", bundleID, err)
+		return fmt.Errorf("launchAppIOS: Failed to initiate process control launching app with bundleID `%s` - %s", bundleID, err)
 	}
 
 	opts := map[string]any{}

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -695,7 +695,7 @@ func PushFileToSharedStorage(c *gin.Context) {
 		// Remove the temporary file, we don't want to keep it on long running hosts
 		defer os.Remove(tempPath)
 		if err := c.SaveUploadedFile(file, tempPath); err != nil {
-			api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to save file `%s` to temp dir `%s` - %s", file.Filename, tempPath, err.Error), nil)
+			api.GenericResponse(c, http.StatusInternalServerError, fmt.Sprintf("Failed to save file `%s` to temp dir `%s` - %s", file.Filename, tempPath, err.Error()), nil)
 			return
 		}
 


### PR DESCRIPTION
### Goal
Introduce a reliable HTTP-based device lease lock mechanism (independent from WebSocket heartbeat) to prevent concurrent access conflicts and keep device usage state consistent across Hub flows.

### Summary of Changes

- Added new HTTP endpoints to lock and unlock devices with a lease timeout.
- Extended device runtime state with HTTP lease expiration tracking.
- Added shared helpers to:
     - detect active HTTP/manual locks,
     - clear expired leases,
     - centralize lock field cleanup.
- Updated device in-use logic across critical paths:
     - device proxy access checks,
- WebSocket in-use flow,
- Appium Grid cleanup transitions,
- SSE availability/in-use status,
      - admin forced device release.
- Added session payload validation for Appium session creation (requires clientSecret capability when no auth token is provided).
- Added test coverage for conflict behavior when another user holds an active HTTP lease.
- Included minor provider-side reliability fixes (error/log formatting).