### PR TITLE
Refactor LocalHubDevice and add additional endpoints for reserving and releasing devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ provider.log
 GADS
 hub/gads-ui/build/*
 hub/gads-ui/node_modules
-device_*
+# device_*
 .idea
 .DS_Store
 server.crt

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -216,11 +216,6 @@ type UpdateStreamSettings struct {
 	ScalingFactor int `json:"scaling_factor,omitempty"`
 }
 
-type DeviceInUseMessage struct {
-	Type    string      `json:"type"`
-	Payload interface{} `json:"payload"`
-}
-
 type DBFile struct {
 	FileName   string             `json:"name" bson:"filename"`
 	UploadDate primitive.DateTime `json:"upload_date" bson:"uploadDate"`

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -198,8 +198,9 @@ func StreamTypesForOS(os string) []StreamType {
 }
 
 type LocalHubDevice struct {
-	Device                   Device   `json:"info"`
-	SessionID                string   `json:"-"`
+	Mu                       sync.RWMutex `json:"-" bson:"-"` // protects this device's fields
+	Device                   Device       `json:"info"`
+	SessionID                string       `json:"-"`
 	IsRunningAutomation      bool     `json:"is_running_automation"`
 	LastAutomationActionTS   int64    `json:"last_automation_action_ts"`
 	InUse                    bool     `json:"in_use"`

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -197,22 +196,6 @@ func StreamTypesForOS(os string) []StreamType {
 	}
 }
 
-type LocalHubDevice struct {
-	Mu                       sync.RWMutex `json:"-" bson:"-"` // protects this device's fields
-	Device                   Device       `json:"info"`
-	SessionID                string       `json:"-"`
-	IsRunningAutomation      bool     `json:"is_running_automation"`
-	LastAutomationActionTS   int64    `json:"last_automation_action_ts"`
-	InUse                    bool     `json:"in_use"`
-	InUseBy                  string   `json:"in_use_by"`
-	InUseByTenant            string   `json:"in_use_by_tenant"`
-	InUseTS                  int64    `json:"in_use_ts"`
-	AppiumNewCommandTimeout  int64    `json:"appium_new_command_timeout"`
-	IsAvailableForAutomation bool     `json:"is_available_for_automation"`
-	Available                bool     `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
-	InUseWSConnection        net.Conn `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
-	LastActionTS             int64    `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
-}
 
 type DeviceStreamSettings struct {
 	UDID                string `json:"udid" bson:"udid"`                                             // device UDID

--- a/hub/devices/device_store.go
+++ b/hub/devices/device_store.go
@@ -10,7 +10,6 @@
 package devices
 
 import (
-	"GADS/common/models"
 	"sort"
 	"sync"
 )
@@ -20,12 +19,12 @@ import (
 // while each device has its own Mu for protecting its fields.
 type DeviceStore struct {
 	mu      sync.RWMutex
-	devices map[string]*models.LocalHubDevice
+	devices map[string]*LocalHubDevice
 }
 
 func NewDeviceStore() *DeviceStore {
 	return &DeviceStore{
-		devices: make(map[string]*models.LocalHubDevice),
+		devices: make(map[string]*LocalHubDevice),
 	}
 }
 
@@ -33,7 +32,7 @@ func NewDeviceStore() *DeviceStore {
 var HubDeviceStore = NewDeviceStore()
 
 // Get returns the device for the given UDID and whether it was found.
-func (s *DeviceStore) Get(udid string) (*models.LocalHubDevice, bool) {
+func (s *DeviceStore) Get(udid string) (*LocalHubDevice, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	d, ok := s.devices[udid]
@@ -41,7 +40,7 @@ func (s *DeviceStore) Get(udid string) (*models.LocalHubDevice, bool) {
 }
 
 // Set adds or replaces the device for the given UDID.
-func (s *DeviceStore) Set(udid string, d *models.LocalHubDevice) {
+func (s *DeviceStore) Set(udid string, d *LocalHubDevice) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.devices[udid] = d
@@ -56,10 +55,10 @@ func (s *DeviceStore) Delete(udid string) {
 
 // All returns a snapshot slice of all devices. Callers may iterate freely;
 // use each device's own Mu to protect field access.
-func (s *DeviceStore) All() []*models.LocalHubDevice {
+func (s *DeviceStore) All() []*LocalHubDevice {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	result := make([]*models.LocalHubDevice, 0, len(s.devices))
+	result := make([]*LocalHubDevice, 0, len(s.devices))
 	for _, d := range s.devices {
 		result = append(result, d)
 	}
@@ -68,7 +67,7 @@ func (s *DeviceStore) All() []*models.LocalHubDevice {
 
 // AllSorted returns a snapshot slice of all devices ordered by UDID.
 // Callers may iterate freely; use each device's own Mu to protect field access.
-func (s *DeviceStore) AllSorted() []*models.LocalHubDevice {
+func (s *DeviceStore) AllSorted() []*LocalHubDevice {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	keys := make([]string, 0, len(s.devices))
@@ -76,7 +75,7 @@ func (s *DeviceStore) AllSorted() []*models.LocalHubDevice {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	result := make([]*models.LocalHubDevice, 0, len(keys))
+	result := make([]*LocalHubDevice, 0, len(keys))
 	for _, k := range keys {
 		result = append(result, s.devices[k])
 	}

--- a/hub/devices/device_store.go
+++ b/hub/devices/device_store.go
@@ -1,0 +1,91 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import (
+	"GADS/common/models"
+	"sort"
+	"sync"
+)
+
+// DeviceStore is a concurrent-safe store for LocalHubDevice values.
+// It uses a single RWMutex to protect the map (allowing concurrent reads),
+// while each device has its own Mu for protecting its fields.
+type DeviceStore struct {
+	mu      sync.RWMutex
+	devices map[string]*models.LocalHubDevice
+}
+
+func NewDeviceStore() *DeviceStore {
+	return &DeviceStore{
+		devices: make(map[string]*models.LocalHubDevice),
+	}
+}
+
+// HubDeviceStore is the package-level singleton used by hub components.
+var HubDeviceStore = NewDeviceStore()
+
+// Get returns the device for the given UDID and whether it was found.
+func (s *DeviceStore) Get(udid string) (*models.LocalHubDevice, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.devices[udid]
+	return d, ok
+}
+
+// Set adds or replaces the device for the given UDID.
+func (s *DeviceStore) Set(udid string, d *models.LocalHubDevice) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.devices[udid] = d
+}
+
+// Delete removes the device with the given UDID from the store.
+func (s *DeviceStore) Delete(udid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.devices, udid)
+}
+
+// All returns a snapshot slice of all devices. Callers may iterate freely;
+// use each device's own Mu to protect field access.
+func (s *DeviceStore) All() []*models.LocalHubDevice {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*models.LocalHubDevice, 0, len(s.devices))
+	for _, d := range s.devices {
+		result = append(result, d)
+	}
+	return result
+}
+
+// AllSorted returns a snapshot slice of all devices ordered by UDID.
+// Callers may iterate freely; use each device's own Mu to protect field access.
+func (s *DeviceStore) AllSorted() []*models.LocalHubDevice {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]string, 0, len(s.devices))
+	for k := range s.devices {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	result := make([]*models.LocalHubDevice, 0, len(keys))
+	for _, k := range keys {
+		result = append(result, s.devices[k])
+	}
+	return result
+}
+
+// Len returns the number of devices in the store.
+func (s *DeviceStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.devices)
+}

--- a/hub/devices/devices.go
+++ b/hub/devices/devices.go
@@ -14,7 +14,6 @@ import (
 	"GADS/common/models"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 )
 
@@ -35,17 +34,8 @@ func CalculateCanvasDimensions(device *models.Device) (canvasWidth string, canva
 	return
 }
 
-type HubDevices struct {
-	Mu      sync.Mutex
-	Devices map[string]*models.LocalHubDevice
-}
-
-var HubDevicesData HubDevices
-
 func InitHubDevicesData() {
-	HubDevicesData = HubDevices{
-		Devices: make(map[string]*models.LocalHubDevice),
-	}
+	HubDeviceStore = NewDeviceStore()
 }
 
 // Get the latest devices information from MongoDB each second
@@ -55,26 +45,29 @@ func GetLatestDBDevices() {
 	for {
 		latestDBDevices, _ = db.GlobalMongoStore.GetDevices()
 
-		HubDevicesData.Mu.Lock()
-		for udid, _ := range HubDevicesData.Devices {
+		// Remove devices from the store that are no longer in the DB
+		var toDelete []string
+		for _, hubDevice := range HubDeviceStore.All() {
 			found := false
 			for _, dbDevice := range latestDBDevices {
-				if dbDevice.UDID == udid {
+				if dbDevice.UDID == hubDevice.Device.UDID {
 					found = true
 					break
 				}
 			}
 			if !found {
-				delete(HubDevicesData.Devices, udid)
+				toDelete = append(toDelete, hubDevice.Device.UDID)
 			}
 		}
-		HubDevicesData.Mu.Unlock()
+		for _, udid := range toDelete {
+			HubDeviceStore.Delete(udid)
+		}
 
-		for _, dbDevice := range latestDBDevices {
-			HubDevicesData.Mu.Lock()
-			hubDevice, ok := HubDevicesData.Devices[dbDevice.UDID]
+		for i := range latestDBDevices {
+			dbDevice := &latestDBDevices[i]
+			hubDevice, ok := HubDeviceStore.Get(dbDevice.UDID)
 			if ok {
-				// Update data only if needed
+				hubDevice.Mu.Lock()
 				if hubDevice.Device.OSVersion != dbDevice.OSVersion {
 					hubDevice.Device.OSVersion = dbDevice.OSVersion
 				}
@@ -96,32 +89,26 @@ func GetLatestDBDevices() {
 				if hubDevice.Device.WorkspaceID != dbDevice.WorkspaceID {
 					hubDevice.Device.WorkspaceID = dbDevice.WorkspaceID
 				}
+				hubDevice.Mu.Unlock()
 			} else {
 				dbDevice.InstalledApps = make([]string, 0)
 				dbDevice.SupportedStreamTypes = models.StreamTypesForOS(dbDevice.OS)
-				HubDevicesData.Devices[dbDevice.UDID] = &models.LocalHubDevice{
-					Device:                   dbDevice,
+				HubDeviceStore.Set(dbDevice.UDID, &models.LocalHubDevice{
+					Device:                   *dbDevice,
 					IsRunningAutomation:      false,
 					IsAvailableForAutomation: true,
 					LastAutomationActionTS:   0,
-				}
+				})
 			}
-			HubDevicesData.Mu.Unlock()
 		}
 		time.Sleep(1 * time.Second)
 	}
 }
 
-var getDeviceMu sync.RWMutex
-
 func GetHubDeviceByUDID(udid string) *models.LocalHubDevice {
-	getDeviceMu.Lock()
-	defer getDeviceMu.Unlock()
-	for _, hubDevice := range HubDevicesData.Devices {
-		if hubDevice.Device.UDID == udid {
-			return hubDevice
-		}
+	device, ok := HubDeviceStore.Get(udid)
+	if ok {
+		return device
 	}
-
 	return nil
 }

--- a/hub/devices/devices.go
+++ b/hub/devices/devices.go
@@ -93,7 +93,7 @@ func GetLatestDBDevices() {
 			} else {
 				dbDevice.InstalledApps = make([]string, 0)
 				dbDevice.SupportedStreamTypes = models.StreamTypesForOS(dbDevice.OS)
-				HubDeviceStore.Set(dbDevice.UDID, &models.LocalHubDevice{
+				HubDeviceStore.Set(dbDevice.UDID, &LocalHubDevice{
 					Device:                   *dbDevice,
 					IsRunningAutomation:      false,
 					IsAvailableForAutomation: true,
@@ -105,7 +105,7 @@ func GetLatestDBDevices() {
 	}
 }
 
-func GetHubDeviceByUDID(udid string) *models.LocalHubDevice {
+func GetHubDeviceByUDID(udid string) *LocalHubDevice {
 	device, ok := HubDeviceStore.Get(udid)
 	if ok {
 		return device

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -77,11 +77,7 @@ func (d *LocalHubDevice) ReleaseLockIfNotHeld() {
 	if d.HasUISession() || d.HasActiveLease() {
 		return
 	}
-	d.InUseBy = ""
-	d.InUseByTenant = ""
-	d.InUseTS = 0
-	d.LockSource = ""
-	d.LeaseExpiresAt = 0
+	d.ReleaseLock()
 }
 
 // IsLocked reports whether the device is currently locked by any means:

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -25,22 +25,22 @@ const (
 // LocalHubDevice represents a device as tracked by the hub at runtime.
 // All field access must be protected by Mu.
 type LocalHubDevice struct {
-	Mu                       sync.RWMutex `json:"-" bson:"-"` // protects this device's fields
+	Mu                       sync.RWMutex  `json:"-" bson:"-"` // protects this device's fields
 	Device                   models.Device `json:"info"`
-	SessionID                string       `json:"-"`
-	IsRunningAutomation      bool         `json:"is_running_automation"`
-	LastAutomationActionTS   int64        `json:"last_automation_action_ts"`
-	InUse                    bool         `json:"in_use"`
-	InUseBy                  string       `json:"in_use_by"`
-	InUseByTenant            string       `json:"in_use_by_tenant"`
-	InUseTS                  int64        `json:"in_use_ts"`
-	LockSource               string       `json:"lock_source" bson:"-"` // "ui", "api", or ""
-	LeaseExpiresAt           int64        `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
-	AppiumNewCommandTimeout  int64        `json:"appium_new_command_timeout"`
-	IsAvailableForAutomation bool         `json:"is_available_for_automation"`
-	Available                bool         `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
-	InUseWSConnection        net.Conn     `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
-	LastActionTS             int64        `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
+	SessionID                string        `json:"-"`
+	IsRunningAutomation      bool          `json:"is_running_automation"`
+	LastAutomationActionTS   int64         `json:"last_automation_action_ts"`
+	InUse                    bool          `json:"in_use"`
+	InUseBy                  string        `json:"in_use_by"`
+	InUseByTenant            string        `json:"in_use_by_tenant"`
+	InUseTS                  int64         `json:"in_use_ts"`
+	LockSource               string        `json:"lock_source" bson:"-"` // "ui", "api", or ""
+	LeaseExpiresAt           int64         `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
+	AppiumNewCommandTimeout  int64         `json:"appium_new_command_timeout"`
+	IsAvailableForAutomation bool          `json:"is_available_for_automation"`
+	Available                bool          `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
+	InUseWSConnection        net.Conn      `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
+	LastActionTS             int64         `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
 }
 
 // All methods below assume the caller holds device.Mu.

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -1,0 +1,136 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import (
+	"GADS/common/models"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	LockSourceUI  = "ui"
+	LockSourceAPI = "api" // REST API lock — can be used by CI, scripts, or any non-UI client
+)
+
+// LocalHubDevice represents a device as tracked by the hub at runtime.
+// All field access must be protected by Mu.
+type LocalHubDevice struct {
+	Mu                       sync.RWMutex `json:"-" bson:"-"` // protects this device's fields
+	Device                   models.Device `json:"info"`
+	SessionID                string       `json:"-"`
+	IsRunningAutomation      bool         `json:"is_running_automation"`
+	LastAutomationActionTS   int64        `json:"last_automation_action_ts"`
+	InUse                    bool         `json:"in_use"`
+	InUseBy                  string       `json:"in_use_by"`
+	InUseByTenant            string       `json:"in_use_by_tenant"`
+	InUseTS                  int64        `json:"in_use_ts"`
+	LockSource               string       `json:"lock_source" bson:"-"` // "ui", "api", or ""
+	LeaseExpiresAt           int64        `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
+	AppiumNewCommandTimeout  int64        `json:"appium_new_command_timeout"`
+	IsAvailableForAutomation bool         `json:"is_available_for_automation"`
+	Available                bool         `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
+	InUseWSConnection        net.Conn     `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
+	LastActionTS             int64        `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
+}
+
+// All methods below assume the caller holds device.Mu.
+
+// AcquireLock reserves the device for a user. Returns an error if already locked by another user.
+func (d *LocalHubDevice) AcquireLock(user, tenant, source string) error {
+	if d.IsLockedByOther(user, tenant) {
+		return fmt.Errorf("device is already locked by another user")
+	}
+	d.InUseBy = user
+	d.InUseByTenant = tenant
+	d.InUseTS = time.Now().UnixMilli()
+	d.LockSource = source
+	d.LastActionTS = time.Now().UnixMilli()
+	return nil
+}
+
+// ReleaseLock clears all lock fields unconditionally and closes the WebSocket connection if present.
+func (d *LocalHubDevice) ReleaseLock() {
+	if d.InUseWSConnection != nil {
+		d.InUseWSConnection.Close()
+		d.InUseWSConnection = nil
+	}
+	d.InUseBy = ""
+	d.InUseByTenant = ""
+	d.InUseTS = 0
+	d.LockSource = ""
+	d.LeaseExpiresAt = 0
+}
+
+// ReleaseLockIfNotHeld clears the lock only when no UI WebSocket and no active API lease are present.
+// Used by automation cleanup to avoid releasing a manually-held device.
+func (d *LocalHubDevice) ReleaseLockIfNotHeld() {
+	if d.HasUISession() || d.HasActiveLease() {
+		return
+	}
+	d.InUseBy = ""
+	d.InUseByTenant = ""
+	d.InUseTS = 0
+	d.LockSource = ""
+	d.LeaseExpiresAt = 0
+}
+
+// IsLocked reports whether the device is currently locked by any means:
+// an active UI WebSocket, an active API lease, or a recent InUseTS timestamp.
+func (d *LocalHubDevice) IsLocked() bool {
+	if d.InUseWSConnection != nil {
+		return true
+	}
+	if d.LockSource == LockSourceAPI && d.LeaseExpiresAt > time.Now().UnixMilli() {
+		return true
+	}
+	if d.InUseTS > 0 && (time.Now().UnixMilli()-d.InUseTS) < 3000 {
+		return true
+	}
+	return false
+}
+
+// IsLockedByOther reports whether the device is locked by a different user/tenant combination.
+func (d *LocalHubDevice) IsLockedByOther(user, tenant string) bool {
+	if d.InUseBy == "" {
+		return false
+	}
+	if d.InUseBy == user && d.InUseByTenant == tenant {
+		return false
+	}
+	return d.IsLocked()
+}
+
+// HasUISession reports whether a UI WebSocket connection is active on the device.
+func (d *LocalHubDevice) HasUISession() bool {
+	return d.InUseWSConnection != nil
+}
+
+// HasActiveLease reports whether an API-sourced lease is currently valid.
+func (d *LocalHubDevice) HasActiveLease() bool {
+	return d.LockSource == LockSourceAPI && d.LeaseExpiresAt > time.Now().UnixMilli()
+}
+
+// RefreshLock updates InUseTS to now, keeping the lock alive.
+func (d *LocalHubDevice) RefreshLock() {
+	d.InUseTS = time.Now().UnixMilli()
+}
+
+// SetWSConnection stores the WebSocket connection on the device.
+func (d *LocalHubDevice) SetWSConnection(conn net.Conn) {
+	d.InUseWSConnection = conn
+}
+
+// ClearWSConnection nils the WebSocket connection field without closing it.
+func (d *LocalHubDevice) ClearWSConnection() {
+	d.InUseWSConnection = nil
+}

--- a/hub/devices/hub_device_test.go
+++ b/hub/devices/hub_device_test.go
@@ -1,0 +1,342 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeConn is a minimal net.Conn that tracks whether Close was called.
+type fakeConn struct {
+	closed bool
+}
+
+func (f *fakeConn) Close() error                       { f.closed = true; return nil }
+func (f *fakeConn) Read(b []byte) (int, error)         { return 0, nil }
+func (f *fakeConn) Write(b []byte) (int, error)        { return 0, nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr               { return nil }
+func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// --- AcquireLock / ReleaseLock ---
+
+func TestAcquireLock_Success(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.Mu.Lock()
+	err := d.AcquireLock("alice", "tenantA", LockSourceUI)
+	d.Mu.Unlock()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if d.InUseBy != "alice" || d.InUseByTenant != "tenantA" || d.LockSource != LockSourceUI {
+		t.Error("lock fields not set correctly")
+	}
+	if d.InUseTS == 0 {
+		t.Error("InUseTS should be set")
+	}
+}
+
+func TestAcquireLock_FailsWhenLockedByOther(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseWSConnection = &fakeConn{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseTS = time.Now().UnixMilli()
+
+	d.Mu.Lock()
+	err := d.AcquireLock("bob", "tenantA", LockSourceUI)
+	d.Mu.Unlock()
+
+	if err == nil {
+		t.Fatal("expected error when device locked by another user")
+	}
+}
+
+func TestAcquireLock_SameUserSucceeds(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseTS = time.Now().UnixMilli()
+
+	d.Mu.Lock()
+	err := d.AcquireLock("alice", "tenantA", LockSourceUI)
+	d.Mu.Unlock()
+
+	if err != nil {
+		t.Fatalf("same user should be allowed to re-acquire, got: %v", err)
+	}
+}
+
+func TestReleaseLock_ClearsAllFields(t *testing.T) {
+	d := &LocalHubDevice{}
+	conn := &fakeConn{}
+	d.InUseWSConnection = conn
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseTS = time.Now().UnixMilli()
+	d.LockSource = LockSourceUI
+	d.LeaseExpiresAt = time.Now().Add(10 * time.Minute).UnixMilli()
+
+	d.Mu.Lock()
+	d.ReleaseLock()
+	d.Mu.Unlock()
+
+	if d.InUseBy != "" || d.InUseByTenant != "" || d.InUseTS != 0 {
+		t.Error("user fields should be cleared")
+	}
+	if d.LockSource != "" || d.LeaseExpiresAt != 0 {
+		t.Error("lease fields should be cleared")
+	}
+	if d.InUseWSConnection != nil {
+		t.Error("WS connection should be nil")
+	}
+	if !conn.closed {
+		t.Error("WS connection should have been closed")
+	}
+}
+
+// --- IsLocked ---
+
+func TestIsLocked_UISession(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseWSConnection = &fakeConn{}
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if !locked {
+		t.Error("should be locked when WS connection present")
+	}
+}
+
+func TestIsLocked_APILease(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.LockSource = LockSourceAPI
+	d.LeaseExpiresAt = time.Now().Add(5 * time.Minute).UnixMilli()
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if !locked {
+		t.Error("should be locked with active API lease")
+	}
+}
+
+func TestIsLocked_ExpiredAPILease(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.LockSource = LockSourceAPI
+	d.LeaseExpiresAt = time.Now().Add(-1 * time.Minute).UnixMilli()
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if locked {
+		t.Error("should not be locked with expired API lease")
+	}
+}
+
+func TestIsLocked_RecentTimestamp(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseTS = time.Now().UnixMilli()
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if !locked {
+		t.Error("should be locked with recent InUseTS")
+	}
+}
+
+func TestIsLocked_StaleTimestamp(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseTS = time.Now().Add(-10 * time.Second).UnixMilli()
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if locked {
+		t.Error("should not be locked with stale InUseTS")
+	}
+}
+
+func TestIsLocked_ZeroTimestamp(t *testing.T) {
+	d := &LocalHubDevice{}
+
+	d.Mu.RLock()
+	locked := d.IsLocked()
+	d.Mu.RUnlock()
+
+	if locked {
+		t.Error("should not be locked when InUseTS is zero")
+	}
+}
+
+// --- IsLockedByOther ---
+
+func TestIsLockedByOther_NotLocked(t *testing.T) {
+	d := &LocalHubDevice{}
+
+	d.Mu.RLock()
+	result := d.IsLockedByOther("alice", "tenantA")
+	d.Mu.RUnlock()
+
+	if result {
+		t.Error("should not be locked by other when InUseBy is empty")
+	}
+}
+
+func TestIsLockedByOther_SameUser(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseWSConnection = &fakeConn{}
+
+	d.Mu.RLock()
+	result := d.IsLockedByOther("alice", "tenantA")
+	d.Mu.RUnlock()
+
+	if result {
+		t.Error("should not report locked by other when same user")
+	}
+}
+
+func TestIsLockedByOther_DifferentUser(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseWSConnection = &fakeConn{}
+
+	d.Mu.RLock()
+	result := d.IsLockedByOther("bob", "tenantA")
+	d.Mu.RUnlock()
+
+	if !result {
+		t.Error("should be locked by other when different user holds WS session")
+	}
+}
+
+func TestIsLockedByOther_DifferentTenant(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseWSConnection = &fakeConn{}
+
+	d.Mu.RLock()
+	result := d.IsLockedByOther("alice", "tenantB")
+	d.Mu.RUnlock()
+
+	if !result {
+		t.Error("should be locked by other when same user but different tenant")
+	}
+}
+
+// --- ReleaseLockIfNotHeld ---
+
+func TestReleaseLockIfNotHeld_WithUISession(t *testing.T) {
+	d := &LocalHubDevice{}
+	conn := &fakeConn{}
+	d.InUseWSConnection = conn
+	d.InUseBy = "alice"
+	d.InUseTS = time.Now().UnixMilli()
+
+	d.Mu.Lock()
+	d.ReleaseLockIfNotHeld()
+	d.Mu.Unlock()
+
+	if d.InUseBy == "" {
+		t.Error("should not clear user when UI session is active")
+	}
+	if conn.closed {
+		t.Error("should not close WS connection")
+	}
+}
+
+func TestReleaseLockIfNotHeld_WithActiveLease(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.LockSource = LockSourceAPI
+	d.LeaseExpiresAt = time.Now().Add(5 * time.Minute).UnixMilli()
+	d.InUseBy = "alice"
+	d.InUseTS = time.Now().UnixMilli()
+
+	d.Mu.Lock()
+	d.ReleaseLockIfNotHeld()
+	d.Mu.Unlock()
+
+	if d.InUseBy == "" {
+		t.Error("should not clear user when API lease is active")
+	}
+}
+
+func TestReleaseLockIfNotHeld_NoHold(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseBy = "alice"
+	d.InUseByTenant = "tenantA"
+	d.InUseTS = time.Now().Add(-10 * time.Second).UnixMilli()
+
+	d.Mu.Lock()
+	d.ReleaseLockIfNotHeld()
+	d.Mu.Unlock()
+
+	if d.InUseBy != "" || d.InUseByTenant != "" {
+		t.Error("should clear user fields when not held by UI or API")
+	}
+}
+
+// --- RefreshLock ---
+
+func TestRefreshLock_UpdatesTimestamp(t *testing.T) {
+	d := &LocalHubDevice{}
+	d.InUseTS = 1000
+
+	before := time.Now().UnixMilli()
+	d.Mu.Lock()
+	d.RefreshLock()
+	d.Mu.Unlock()
+
+	if d.InUseTS < before {
+		t.Error("RefreshLock should update InUseTS to now")
+	}
+}
+
+// --- SetWSConnection / ClearWSConnection ---
+
+func TestSetAndClearWSConnection(t *testing.T) {
+	d := &LocalHubDevice{}
+	conn := &fakeConn{}
+
+	d.Mu.Lock()
+	d.SetWSConnection(conn)
+	d.Mu.Unlock()
+
+	if d.InUseWSConnection == nil {
+		t.Error("connection should be set")
+	}
+
+	d.Mu.Lock()
+	d.ClearWSConnection()
+	d.Mu.Unlock()
+
+	if d.InUseWSConnection != nil {
+		t.Error("connection should be nil after clear")
+	}
+	if conn.closed {
+		t.Error("ClearWSConnection should not close the connection")
+	}
+}

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -58,11 +58,7 @@ func UpdateExpiredGridSessions() {
 				hubDevice.IsRunningAutomation = false
 				hubDevice.IsAvailableForAutomation = true
 				hubDevice.SessionID = ""
-				if hubDevice.InUseBy != "" {
-					hubDevice.InUseBy = ""
-					hubDevice.InUseByTenant = ""
-					hubDevice.InUseTS = 0
-				}
+				hubDevice.ReleaseLockIfNotHeld()
 			}
 			hubDevice.Mu.Unlock()
 		}
@@ -157,7 +153,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 
 			// Check for available device
-			var foundDevice *models.LocalHubDevice
+			var foundDevice *devices.LocalHubDevice
 			var deviceErr error
 
 			foundDevice, deviceErr = findAvailableDevice(capsToUse, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
@@ -261,12 +257,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
 				if resp.StatusCode != http.StatusInternalServerError {
-					// Only clear user info if no manual session is active
-					if foundDevice.InUseWSConnection == nil {
-						foundDevice.InUseBy = ""
-						foundDevice.InUseByTenant = ""
-						foundDevice.InUseTS = 0
-					}
+					foundDevice.ReleaseLockIfNotHeld()
 				}
 				foundDevice.Mu.Unlock()
 
@@ -279,12 +270,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 							foundDevice.IsAvailableForAutomation = true
 							foundDevice.SessionID = ""
 							foundDevice.IsRunningAutomation = false
-							// Only clear user info if no manual session is active
-							if foundDevice.InUseWSConnection == nil {
-								foundDevice.InUseBy = ""
-								foundDevice.InUseByTenant = ""
-								foundDevice.InUseTS = 0
-							}
+							foundDevice.ReleaseLockIfNotHeld()
 						}
 						foundDevice.Mu.Unlock()
 					}()
@@ -341,8 +327,8 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			if automationUser == "" {
 				automationUser = "unknown"
 			}
-			// Only update InUseBy if no manual session is active
-			if foundDevice.InUseWSConnection == nil {
+			// Only update InUseBy if no UI or API session is active
+			if !foundDevice.HasUISession() && !foundDevice.HasActiveLease() {
 				foundDevice.InUseBy = automationUser
 				foundDevice.InUseByTenant = credential.Tenant
 				foundDevice.InUseTS = time.Now().UnixMilli()
@@ -449,12 +435,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 					if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 1000) {
 						foundDevice.SessionID = ""
 						foundDevice.IsRunningAutomation = false
-						// Only clear user info if no manual session is active
-						if foundDevice.InUseWSConnection == nil {
-							foundDevice.InUseBy = ""
-							foundDevice.InUseByTenant = ""
-							foundDevice.InUseTS = 0
-						}
+						foundDevice.ReleaseLockIfNotHeld()
 					}
 					foundDevice.Mu.Unlock()
 				}()
@@ -469,12 +450,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 						foundDevice.SessionID = ""
 						foundDevice.IsAvailableForAutomation = true
 						foundDevice.IsRunningAutomation = false
-						// Only clear user info if no manual session is active
-						if foundDevice.InUseWSConnection == nil {
-							foundDevice.InUseBy = ""
-							foundDevice.InUseByTenant = ""
-							foundDevice.InUseTS = 0
-						}
+						foundDevice.ReleaseLockIfNotHeld()
 					}
 					foundDevice.Mu.Unlock()
 				}()
@@ -512,7 +488,7 @@ func readBody(r io.Reader) ([]byte, error) {
 	return body, nil
 }
 
-func getDeviceBySessionID(sessionID string) (*models.LocalHubDevice, error) {
+func getDeviceBySessionID(sessionID string) (*devices.LocalHubDevice, error) {
 	for _, localDevice := range devices.HubDeviceStore.All() {
 		localDevice.Mu.RLock()
 		sid := localDevice.SessionID
@@ -524,7 +500,7 @@ func getDeviceBySessionID(sessionID string) (*models.LocalHubDevice, error) {
 	return nil, fmt.Errorf("No device with session ID `%s` was found", sessionID)
 }
 
-func getDeviceByUDID(udid string) (*models.LocalHubDevice, error) {
+func getDeviceByUDID(udid string) (*devices.LocalHubDevice, error) {
 	// Try direct lookup first (O(1))
 	if d, ok := devices.HubDeviceStore.Get(udid); ok {
 		return d, nil
@@ -562,8 +538,8 @@ func getTargetOSFromCaps(caps models.CommonCapabilities) string {
 	return ""
 }
 
-func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []string, userID string, userTenant string) (*models.LocalHubDevice, error) {
-	var foundDevice *models.LocalHubDevice
+func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []string, userID string, userTenant string) (*devices.LocalHubDevice, error) {
+	var foundDevice *devices.LocalHubDevice
 
 	var deviceUDID = ""
 	if caps.DeviceUDID != "" {
@@ -606,7 +582,7 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 		return nil, fmt.Errorf("Device is currently not available for automation")
 	}
 
-	var availableDevices []*models.LocalHubDevice
+	var availableDevices []*devices.LocalHubDevice
 
 	targetOS := getTargetOSFromCaps(caps)
 	if targetOS != "" {
@@ -619,8 +595,7 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 			available := localDevice.IsAvailableForAutomation
 			usage := localDevice.Device.Usage
 			wsID := localDevice.Device.WorkspaceID
-			inUseBy := localDevice.InUseBy
-			inUseByTenant := localDevice.InUseByTenant
+			isLockedByOther := localDevice.IsLockedByOther(userID, userTenant)
 			localDevice.Mu.RUnlock()
 
 			if !strings.EqualFold(os, targetOS) ||
@@ -644,14 +619,8 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 				continue
 			}
 
-			if inUseBy != "" && inUseByTenant != "" {
-				currentUser := userID
-				if currentUser == "" {
-					currentUser = "unknown"
-				}
-				if inUseBy != currentUser || inUseByTenant != userTenant {
-					continue
-				}
+			if isLockedByOther {
+				continue
 			}
 
 			availableDevices = append(availableDevices, localDevice)

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -47,8 +47,8 @@ type SeleniumSessionErrorResponseValue struct {
 // And clean the automation session if no action was taken in the timeout limit
 func UpdateExpiredGridSessions() {
 	for {
-		devices.HubDevicesData.Mu.Lock()
-		for _, hubDevice := range devices.HubDevicesData.Devices {
+		for _, hubDevice := range devices.HubDeviceStore.All() {
+			hubDevice.Mu.Lock()
 			// Reset device if its not connected
 			// Or it hasn't received any Appium requests in the command timeout and is running automation
 			// Or if its provider state is not "live" - device was re-provisioned for example
@@ -64,8 +64,8 @@ func UpdateExpiredGridSessions() {
 					hubDevice.InUseTS = 0
 				}
 			}
+			hubDevice.Mu.Unlock()
 		}
-		devices.HubDevicesData.Mu.Unlock()
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -205,7 +205,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				return
 			}
 
-			devices.HubDevicesData.Mu.Lock()
+			foundDevice.Mu.Lock()
 			// Set device found as running automation and is not available for automation
 			// Before even starting the Appium session creation request
 			// Also set an automation action timestamp so that the goroutine does not reset it while session is being created
@@ -218,16 +218,21 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			} else {
 				foundDevice.AppiumNewCommandTimeout = 60000
 			}
-			devices.HubDevicesData.Mu.Unlock()
+			foundDevice.Mu.Unlock()
 
 			updatedSessionBody, _ := json.Marshal(sessionReq)
 			// Create a new request to the device target URL
-			proxyReq, err := http.NewRequest(c.Request.Method, fmt.Sprintf("http://%s/device/%s/appium%s", foundDevice.Device.Host, foundDevice.Device.UDID, strings.Replace(c.Request.URL.Path, "/grid", "", -1)), bytes.NewBuffer(updatedSessionBody))
+			foundDevice.Mu.RLock()
+			deviceHost := foundDevice.Device.Host
+			deviceUDID := foundDevice.Device.UDID
+			foundDevice.Mu.RUnlock()
+
+			proxyReq, err := http.NewRequest(c.Request.Method, fmt.Sprintf("http://%s/device/%s/appium%s", deviceHost, deviceUDID, strings.Replace(c.Request.URL.Path, "/grid", "", -1)), bytes.NewBuffer(updatedSessionBody))
 			if err != nil {
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to create http request to proxy the call to the device respective provider Appium session endpoint", "session not created", err.Error()))
 				return
 			}
@@ -241,10 +246,10 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			client := &http.Client{}
 			resp, err := client.Do(proxyReq)
 			if err != nil {
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium session endpoint", "session not created", err.Error()))
 				return
 			}
@@ -252,7 +257,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 			if resp.StatusCode >= 400 {
 				// Release device for any error status
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
 				if resp.StatusCode != http.StatusInternalServerError {
@@ -263,13 +268,13 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 						foundDevice.InUseTS = 0
 					}
 				}
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 
 				// For 500 errors, keep the existing behavior with goroutine
 				if resp.StatusCode == http.StatusInternalServerError {
 					go func() {
 						time.Sleep(10 * time.Second)
-						devices.HubDevicesData.Mu.Lock()
+						foundDevice.Mu.Lock()
 						if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 5000) {
 							foundDevice.IsAvailableForAutomation = true
 							foundDevice.SessionID = ""
@@ -281,7 +286,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 								foundDevice.InUseTS = 0
 							}
 						}
-						devices.HubDevicesData.Mu.Unlock()
+						foundDevice.Mu.Unlock()
 					}()
 				}
 
@@ -298,10 +303,10 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			// Read the response sessionRequestBody from the proxied request
 			proxiedSessionResponseBody, err := readBody(resp.Body)
 			if err != nil {
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
 				return
 			}
@@ -310,17 +315,17 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			var proxySessionResponse AppiumSessionResponse
 			err = json.Unmarshal(proxiedSessionResponseBody, &proxySessionResponse)
 			if err != nil {
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.IsRunningAutomation = false
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to unmarshal the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
 				return
 			}
 
-			devices.HubDevicesData.Mu.Lock()
+			foundDevice.Mu.Lock()
 			foundDevice.SessionID = proxySessionResponse.Value.SessionID
-			devices.HubDevicesData.Mu.Unlock()
+			foundDevice.Mu.Unlock()
 
 			// Copy the response back to the original client
 			for k, v := range resp.Header {
@@ -328,7 +333,8 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 			c.Writer.WriteHeader(resp.StatusCode)
 			c.Writer.Write(proxiedSessionResponseBody)
-			devices.HubDevicesData.Mu.Lock()
+
+			foundDevice.Mu.Lock()
 			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
 			// Set InUseBy with user ID and tenant for tracking
 			automationUser := credential.UserID
@@ -341,7 +347,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				foundDevice.InUseByTenant = credential.Tenant
 				foundDevice.InUseTS = time.Now().UnixMilli()
 			}
-			devices.HubDevicesData.Mu.Unlock()
+			foundDevice.Mu.Unlock()
 		} else {
 			// If this is not a request for a new session
 			var sessionID = ""
@@ -385,9 +391,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			defer c.Request.Body.Close()
 
 			// Check if there is a device in the local session map for that session ID
-			devices.HubDevicesData.Mu.Lock()
 			foundDevice, err := getDeviceBySessionID(sessionID)
-			devices.HubDevicesData.Mu.Unlock()
 			if err != nil {
 				c.JSON(http.StatusNotFound, createErrorResponse(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID), "", ""))
 				return
@@ -395,15 +399,22 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 			// Set the device last automation action timestamp when call returns
 			defer func() {
+				foundDevice.Mu.Lock()
 				foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
+				foundDevice.Mu.Unlock()
 			}()
+
+			foundDevice.Mu.RLock()
+			deviceHost := foundDevice.Device.Host
+			deviceUDID := foundDevice.Device.UDID
+			foundDevice.Mu.RUnlock()
 
 			// Create a new request to the device target URL on its provider instance
 			proxyReq, err := http.NewRequest(
 				c.Request.Method,
 				fmt.Sprintf("http://%s/device/%s/appium%s",
-					foundDevice.Device.Host,
-					foundDevice.Device.UDID,
+					deviceHost,
+					deviceUDID,
 					strings.Replace(c.Request.URL.Path, "/grid", "", -1)),
 				bytes.NewBuffer(origRequestBody),
 			)
@@ -428,13 +439,13 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 			// If the request succeeded and was a delete request, remove the session ID from the map
 			if c.Request.Method == http.MethodDelete {
-				devices.HubDevicesData.Mu.Lock()
+				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
-				devices.HubDevicesData.Mu.Unlock()
+				foundDevice.Mu.Unlock()
 				// Start a goroutine that will release the device after 1 second if no other actions were taken
 				go func() {
 					time.Sleep(1 * time.Second)
-					devices.HubDevicesData.Mu.Lock()
+					foundDevice.Mu.Lock()
 					if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 1000) {
 						foundDevice.SessionID = ""
 						foundDevice.IsRunningAutomation = false
@@ -445,7 +456,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 							foundDevice.InUseTS = 0
 						}
 					}
-					devices.HubDevicesData.Mu.Unlock()
+					foundDevice.Mu.Unlock()
 				}()
 			}
 
@@ -453,7 +464,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				// Start a goroutine that will release the device after 10 seconds if no other actions were taken
 				go func() {
 					time.Sleep(10 * time.Second)
-					devices.HubDevicesData.Mu.Lock()
+					foundDevice.Mu.Lock()
 					if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 10000) {
 						foundDevice.SessionID = ""
 						foundDevice.IsAvailableForAutomation = true
@@ -465,7 +476,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 							foundDevice.InUseTS = 0
 						}
 					}
-					devices.HubDevicesData.Mu.Unlock()
+					foundDevice.Mu.Unlock()
 				}()
 				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS got an internal server error from the proxy request to the device respective provider Appium endpoint", "", ""))
 				return
@@ -484,7 +495,10 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 			c.Writer.WriteHeader(resp.StatusCode)
 			c.Writer.Write(proxiedRequestBody)
+
+			foundDevice.Mu.Lock()
 			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
+			foundDevice.Mu.Unlock()
 		}
 	}
 }
@@ -499,8 +513,11 @@ func readBody(r io.Reader) ([]byte, error) {
 }
 
 func getDeviceBySessionID(sessionID string) (*models.LocalHubDevice, error) {
-	for _, localDevice := range devices.HubDevicesData.Devices {
-		if localDevice.SessionID == sessionID {
+	for _, localDevice := range devices.HubDeviceStore.All() {
+		localDevice.Mu.RLock()
+		sid := localDevice.SessionID
+		localDevice.Mu.RUnlock()
+		if sid == sessionID {
 			return localDevice, nil
 		}
 	}
@@ -508,7 +525,12 @@ func getDeviceBySessionID(sessionID string) (*models.LocalHubDevice, error) {
 }
 
 func getDeviceByUDID(udid string) (*models.LocalHubDevice, error) {
-	for _, localDevice := range devices.HubDevicesData.Devices {
+	// Try direct lookup first (O(1))
+	if d, ok := devices.HubDeviceStore.Get(udid); ok {
+		return d, nil
+	}
+	// Fall back to case-insensitive search
+	for _, localDevice := range devices.HubDeviceStore.All() {
 		if strings.EqualFold(localDevice.Device.UDID, udid) {
 			return localDevice, nil
 		}
@@ -541,9 +563,6 @@ func getTargetOSFromCaps(caps models.CommonCapabilities) string {
 }
 
 func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []string, userID string, userTenant string) (*models.LocalHubDevice, error) {
-	devices.HubDevicesData.Mu.Lock()
-	defer devices.HubDevicesData.Mu.Unlock()
-
 	var foundDevice *models.LocalHubDevice
 
 	var deviceUDID = ""
@@ -556,15 +575,19 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 	}
 
 	if deviceUDID != "" {
-		foundDevice, err := getDeviceByUDID(deviceUDID)
+		d, err := getDeviceByUDID(deviceUDID)
 		if err != nil {
 			return nil, err
 		}
 
 		// Check if device is in allowed workspaces
+		d.Mu.RLock()
+		wsID := d.Device.WorkspaceID
+		d.Mu.RUnlock()
+
 		deviceAllowed := false
-		for _, wsID := range allowedWorkspaceIDs {
-			if foundDevice.Device.WorkspaceID == wsID {
+		for _, allowedWsID := range allowedWorkspaceIDs {
+			if wsID == allowedWsID {
 				deviceAllowed = true
 				break
 			}
@@ -573,94 +596,122 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 			return nil, fmt.Errorf("No device with udid `%s` was found", deviceUDID)
 		}
 
-		if foundDevice.IsAvailableForAutomation {
-			foundDevice.IsAvailableForAutomation = false
-			return foundDevice, nil
-		} else {
-			return nil, fmt.Errorf("Device is currently not available for automation")
+		d.Mu.Lock()
+		if d.IsAvailableForAutomation {
+			d.IsAvailableForAutomation = false
+			d.Mu.Unlock()
+			return d, nil
 		}
+		d.Mu.Unlock()
+		return nil, fmt.Errorf("Device is currently not available for automation")
+	}
 
-	} else {
-		var availableDevices []*models.LocalHubDevice
+	var availableDevices []*models.LocalHubDevice
 
-		targetOS := getTargetOSFromCaps(caps)
-		if targetOS != "" {
-			// Loop through all latest devices looking for a device that is not currently `being prepared` for automation and the last time it was updated from provider was less than 3 seconds ago
-			// Also device should not be disabled or for remote control only
-			for _, localDevice := range devices.HubDevicesData.Devices {
-				if strings.EqualFold(localDevice.Device.OS, targetOS) &&
-					localDevice.Device.Connected &&
-					localDevice.Device.ProviderState == "live" &&
-					localDevice.Device.LastUpdatedTimestamp >= (time.Now().UnixMilli()-3000) &&
-					localDevice.IsAvailableForAutomation &&
-					localDevice.Device.Usage != "control" &&
-					localDevice.Device.Usage != "disabled" {
+	targetOS := getTargetOSFromCaps(caps)
+	if targetOS != "" {
+		for _, localDevice := range devices.HubDeviceStore.All() {
+			localDevice.Mu.RLock()
+			os := localDevice.Device.OS
+			connected := localDevice.Device.Connected
+			state := localDevice.Device.ProviderState
+			lastUpdated := localDevice.Device.LastUpdatedTimestamp
+			available := localDevice.IsAvailableForAutomation
+			usage := localDevice.Device.Usage
+			wsID := localDevice.Device.WorkspaceID
+			inUseBy := localDevice.InUseBy
+			inUseByTenant := localDevice.InUseByTenant
+			localDevice.Mu.RUnlock()
 
-					// Check if device is in allowed workspaces
-					deviceAllowed := false
-					for _, wsID := range allowedWorkspaceIDs {
-						if localDevice.Device.WorkspaceID == wsID {
-							deviceAllowed = true
-							break
-						}
-					}
-					if !deviceAllowed {
-						continue
-					}
+			if !strings.EqualFold(os, targetOS) ||
+				!connected ||
+				state != "live" ||
+				lastUpdated < (time.Now().UnixMilli()-3000) ||
+				!available ||
+				usage == "control" ||
+				usage == "disabled" {
+				continue
+			}
 
-					// Check if device is in use by another user
-					if localDevice.InUseBy != "" && localDevice.InUseByTenant != "" {
-						currentUser := userID
-						if currentUser == "" {
-							currentUser = "unknown"
-						}
-						if localDevice.InUseBy != currentUser || localDevice.InUseByTenant != userTenant {
-							continue
-						}
-					}
-
-					availableDevices = append(availableDevices, localDevice)
+			deviceAllowed := false
+			for _, wsID2 := range allowedWorkspaceIDs {
+				if wsID == wsID2 {
+					deviceAllowed = true
+					break
 				}
+			}
+			if !deviceAllowed {
+				continue
+			}
+
+			if inUseBy != "" && inUseByTenant != "" {
+				currentUser := userID
+				if currentUser == "" {
+					currentUser = "unknown"
+				}
+				if inUseBy != currentUser || inUseByTenant != userTenant {
+					continue
+				}
+			}
+
+			availableDevices = append(availableDevices, localDevice)
+		}
+	}
+
+	if caps.PlatformVersion != "" {
+		// First try exact version match
+		for _, device := range availableDevices {
+			device.Mu.RLock()
+			osVersion := device.Device.OSVersion
+			device.Mu.RUnlock()
+
+			if osVersion == caps.PlatformVersion {
+				device.Mu.Lock()
+				if device.IsAvailableForAutomation {
+					device.IsAvailableForAutomation = false
+					device.Mu.Unlock()
+					foundDevice = device
+					break
+				}
+				device.Mu.Unlock()
 			}
 		}
 
-		// If we have `appium:platformVersion` capability provided, then we want to filter out the devices even more
-		// Loop through the accumulated available devices slice and get a device that matches the platform version
-		if caps.PlatformVersion != "" {
-			// First check if device completely matches the required version
-			if len(availableDevices) != 0 {
-				for _, device := range availableDevices {
-					if device.Device.OSVersion == caps.PlatformVersion {
+		// Fall back to major version match
+		if foundDevice == nil {
+			v, _ := semver.NewVersion(caps.PlatformVersion)
+			requestedMajorVersion := fmt.Sprintf("%d", v.Major())
+			constraint, _ := semver.NewConstraint(fmt.Sprintf("^%s.0.0", requestedMajorVersion))
+
+			for _, device := range availableDevices {
+				device.Mu.RLock()
+				osVersion := device.Device.OSVersion
+				device.Mu.RUnlock()
+
+				deviceV, _ := semver.NewVersion(osVersion)
+				if constraint.Check(deviceV) {
+					device.Mu.Lock()
+					if device.IsAvailableForAutomation {
+						device.IsAvailableForAutomation = false
+						device.Mu.Unlock()
 						foundDevice = device
-						foundDevice.IsAvailableForAutomation = false
 						break
 					}
+					device.Mu.Unlock()
 				}
 			}
-			// If no device completely matches the required version try a major version
-			if foundDevice == nil {
-				v, _ := semver.NewVersion(caps.PlatformVersion)
-				requestedMajorVersion := fmt.Sprintf("%d", v.Major())
-				// Create a constraint for the requested version
-				constraint, _ := semver.NewConstraint(fmt.Sprintf("^%s.0.0", requestedMajorVersion))
-
-				if len(availableDevices) != 0 {
-					for _, device := range availableDevices {
-						deviceV, _ := semver.NewVersion(device.Device.OSVersion)
-						if constraint.Check(deviceV) {
-							foundDevice = device
-							foundDevice.IsAvailableForAutomation = false
-							break
-						}
-					}
-				}
+		}
+	} else {
+		// No platform version requested — take the first available
+		for _, device := range availableDevices {
+			device.Mu.Lock()
+			if device.IsAvailableForAutomation {
+				device.IsAvailableForAutomation = false
+				device.Mu.Unlock()
+				foundDevice = device
+				break
 			}
-		} else {
-			// If no platform version capability is provided, get the first device from the available list
-			if len(availableDevices) != 0 {
-				foundDevice = availableDevices[0]
-				foundDevice.IsAvailableForAutomation = false
-			}
+			device.Mu.Unlock()
 		}
 	}
 

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -47,8 +47,13 @@ type SeleniumSessionErrorResponseValue struct {
 // And clean the automation session if no action was taken in the timeout limit
 func UpdateExpiredGridSessions() {
 	for {
+		now := time.Now().UnixMilli()
 		for _, hubDevice := range devices.HubDeviceStore.All() {
 			hubDevice.Mu.Lock()
+			// Release expired API leases
+			if hubDevice.LockSource == devices.LockSourceAPI && hubDevice.LeaseExpiresAt > 0 && hubDevice.LeaseExpiresAt < now {
+				hubDevice.ReleaseLock()
+			}
 			// Reset device if its not connected
 			// Or it hasn't received any Appium requests in the command timeout and is running automation
 			// Or if its provider state is not "live" - device was re-provisioned for example

--- a/hub/router/handler.go
+++ b/hub/router/handler.go
@@ -88,6 +88,8 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	authGroup.GET("/available-devices", AvailableDevicesSSE)
 	authGroup.GET("/admin/provider/:nickname/info", ProviderInfoSSE)
 	authGroup.GET("/devices/control/:udid/in-use", DeviceInUseWS)
+	authGroup.POST("/devices/control/:udid/lock", LockDevice)
+	authGroup.POST("/devices/control/:udid/unlock", UnlockDevice)
 	authGroup.POST("/provider-update", ProviderUpdate)
 	// OAuth2 endpoints (unauthenticated)
 	authGroup.POST("/oauth/token", OAuth2TokenEndpoint)

--- a/hub/router/proxy.go
+++ b/hub/router/proxy.go
@@ -93,17 +93,12 @@ func DeviceProxyHandler(c *gin.Context) {
 		return
 	}
 
-	// Verify if the device is already in use by another user
 	device.Mu.RLock()
-	inUseBy := device.InUseBy
-	inUseByTenant := device.InUseByTenant
-	inUseTS := device.InUseTS
 	isAvailable := device.Available
+	isLockedByOther := device.IsLockedByOther(username, tenant)
 	device.Mu.RUnlock()
 
-	if inUseBy != "" &&
-		(time.Now().UnixMilli()-inUseTS) < 3000 &&
-		(inUseBy != username || inUseByTenant != tenant) {
+	if isLockedByOther {
 		c.JSON(http.StatusConflict, gin.H{"error": "This device is already linked to another user with an active session"})
 		return
 	}
@@ -149,9 +144,10 @@ func DeviceProxyHandler(c *gin.Context) {
 		},
 	}
 
-	// Set the last action performed timestamp through the proxy
+	// Keep the lock alive and record the action timestamp
 	device.Mu.Lock()
 	device.LastActionTS = time.Now().UnixMilli()
+	device.RefreshLock()
 	device.Mu.Unlock()
 
 	// Forward the request which in this case accepts the Gin ResponseWriter and Request objects

--- a/hub/router/proxy.go
+++ b/hub/router/proxy.go
@@ -87,30 +87,26 @@ func DeviceProxyHandler(c *gin.Context) {
 		}
 	}
 
-	devices.HubDevicesData.Mu.Lock()
-	device, ok := devices.HubDevicesData.Devices[udid]
-
-	// Verify if the device is already in use by another user
-	if ok && device != nil && device.InUseBy != "" &&
-		(time.Now().UnixMilli()-device.InUseTS) < 3000 &&
-		(device.InUseBy != username || device.InUseByTenant != tenant) {
-
-		devices.HubDevicesData.Mu.Unlock()
-		c.JSON(http.StatusConflict, gin.H{"error": "This device is already linked to another user with an active session"})
-		return
-	}
-
-	devices.HubDevicesData.Mu.Unlock()
-
+	device, ok := devices.HubDeviceStore.Get(udid)
 	if !ok || device == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Device with UDID `%s` not found or is nil", udid)})
 		return
 	}
 
-	// Check if device is available before proceeding with proxy operations
-	devices.HubDevicesData.Mu.Lock()
-	isAvailable := devices.HubDevicesData.Devices[udid].Available
-	devices.HubDevicesData.Mu.Unlock()
+	// Verify if the device is already in use by another user
+	device.Mu.RLock()
+	inUseBy := device.InUseBy
+	inUseByTenant := device.InUseByTenant
+	inUseTS := device.InUseTS
+	isAvailable := device.Available
+	device.Mu.RUnlock()
+
+	if inUseBy != "" &&
+		(time.Now().UnixMilli()-inUseTS) < 3000 &&
+		(inUseBy != username || inUseByTenant != tenant) {
+		c.JSON(http.StatusConflict, gin.H{"error": "This device is already linked to another user with an active session"})
+		return
+	}
 
 	if !isAvailable {
 		if c.Request.Method == "POST" && strings.HasSuffix(path, "/session") {
@@ -136,9 +132,9 @@ func DeviceProxyHandler(c *gin.Context) {
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = "http"
-			devices.HubDevicesData.Mu.Lock()
-			req.URL.Host = devices.HubDevicesData.Devices[udid].Device.Host
-			devices.HubDevicesData.Mu.Unlock()
+			device.Mu.RLock()
+			req.URL.Host = device.Device.Host
+			device.Mu.RUnlock()
 			req.URL.Path = "/device/" + udid + path
 		},
 		Transport: proxyTransport,
@@ -154,9 +150,9 @@ func DeviceProxyHandler(c *gin.Context) {
 	}
 
 	// Set the last action performed timestamp through the proxy
-	devices.HubDevicesData.Mu.Lock()
-	devices.HubDevicesData.Devices[udid].LastActionTS = time.Now().UnixMilli()
-	devices.HubDevicesData.Mu.Unlock()
+	device.Mu.Lock()
+	device.LastActionTS = time.Now().UnixMilli()
+	device.Mu.Unlock()
 
 	// Forward the request which in this case accepts the Gin ResponseWriter and Request objects
 	proxy.ServeHTTP(c.Writer, c.Request)

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -28,23 +28,16 @@ func TestDeviceProxyHandler(t *testing.T) {
 	// Set Gin to test mode
 	gin.SetMode(gin.TestMode)
 
-	// Initialize the global devices data structure if not already done
-	if devices.HubDevicesData.Devices == nil {
-		devices.HubDevicesData.Devices = make(map[string]*models.LocalHubDevice)
-	}
-
 	t.Run("Available Device - Should Proxy Normally", func(t *testing.T) {
 		// Setup an available device
 		udid := "test-device-available"
-		devices.HubDevicesData.Mu.Lock()
-		devices.HubDevicesData.Devices[udid] = &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
 			},
 			Available: true,
-		}
-		devices.HubDevicesData.Mu.Unlock()
+		})
 
 		// Create request
 		router := gin.New()
@@ -61,23 +54,19 @@ func TestDeviceProxyHandler(t *testing.T) {
 		assert.NotEqual(t, http.StatusUnprocessableEntity, w.Code)
 
 		// Cleanup
-		devices.HubDevicesData.Mu.Lock()
-		delete(devices.HubDevicesData.Devices, udid)
-		devices.HubDevicesData.Mu.Unlock()
+		devices.HubDeviceStore.Delete(udid)
 	})
 
 	t.Run("Unavailable Device - Should Return 422", func(t *testing.T) {
 		// Setup an unavailable device
 		udid := "test-device-unavailable"
-		devices.HubDevicesData.Mu.Lock()
-		devices.HubDevicesData.Devices[udid] = &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
 			},
 			Available: false,
-		}
-		devices.HubDevicesData.Mu.Unlock()
+		})
 
 		// Create request
 		router := gin.New()
@@ -99,9 +88,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 		assert.Equal(t, "Device `test-device-unavailable` is not available", response["error"])
 
 		// Cleanup
-		devices.HubDevicesData.Mu.Lock()
-		delete(devices.HubDevicesData.Devices, udid)
-		devices.HubDevicesData.Mu.Unlock()
+		devices.HubDeviceStore.Delete(udid)
 	})
 
 	t.Run("Non-existent Device - Should Return 400", func(t *testing.T) {
@@ -129,8 +116,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 		// Setup a device in use by another user
 		udid := "test-device-in-use"
 		currentTime := time.Now().UnixMilli()
-		devices.HubDevicesData.Mu.Lock()
-		devices.HubDevicesData.Devices[udid] = &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
@@ -138,8 +124,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 			Available: true,
 			InUseBy:   "another-user",
 			InUseTS:   currentTime, // Use current time to simulate active session
-		}
-		devices.HubDevicesData.Mu.Unlock()
+		})
 
 		// Create request
 		router := gin.New()
@@ -155,23 +140,19 @@ func TestDeviceProxyHandler(t *testing.T) {
 		assert.Equal(t, http.StatusConflict, w.Code)
 
 		// Cleanup
-		devices.HubDevicesData.Mu.Lock()
-		delete(devices.HubDevicesData.Devices, udid)
-		devices.HubDevicesData.Mu.Unlock()
+		devices.HubDeviceStore.Delete(udid)
 	})
 
 	t.Run("Missing Client Credentials - Should Return W3C Error Format", func(t *testing.T) {
 		// Setup a device
 		udid := "test-device-no-credentials"
-		devices.HubDevicesData.Mu.Lock()
-		devices.HubDevicesData.Devices[udid] = &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
 			},
 			Available: true,
-		}
-		devices.HubDevicesData.Mu.Unlock()
+		})
 
 		// Create request WITHOUT credentials
 		router := gin.New()
@@ -213,9 +194,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 		assert.Equal(t, "", value["stacktrace"])
 
 		// Cleanup
-		devices.HubDevicesData.Mu.Lock()
-		delete(devices.HubDevicesData.Devices, udid)
-		devices.HubDevicesData.Mu.Unlock()
+		devices.HubDeviceStore.Delete(udid)
 	})
 
 }

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -31,7 +31,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 	t.Run("Available Device - Should Proxy Normally", func(t *testing.T) {
 		// Setup an available device
 		udid := "test-device-available"
-		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
@@ -60,7 +60,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 	t.Run("Unavailable Device - Should Return 422", func(t *testing.T) {
 		// Setup an unavailable device
 		udid := "test-device-unavailable"
-		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
@@ -116,7 +116,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 		// Setup a device in use by another user
 		udid := "test-device-in-use"
 		currentTime := time.Now().UnixMilli()
-		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",
@@ -146,7 +146,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 	t.Run("Missing Client Credentials - Should Return W3C Error Format", func(t *testing.T) {
 		// Setup a device
 		udid := "test-device-no-credentials"
-		devices.HubDeviceStore.Set(udid, &models.LocalHubDevice{
+		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
 			Device: models.Device{
 				UDID: udid,
 				Host: "localhost:8080",

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -497,41 +497,22 @@ func DeviceInUseWS(c *gin.Context) {
 
 	device.Mu.Lock()
 
-	// Check if device is in use by another user
-	if device.InUseBy != "" {
-		// Check if it's the same user (including tenant)
-		isSameUser := device.InUseBy == username && device.InUseByTenant == userTenant
-
-		// If not the same user AND there's an active WebSocket connection, always deny
-		if !isSameUser && device.InUseWSConnection != nil {
-			device.Mu.Unlock()
-			c.Status(http.StatusConflict)
-			return
-		}
-
-		// If not the same user and device was used recently, also deny
-		if !isSameUser && (time.Now().UnixMilli()-device.InUseTS) < 3000 {
-			device.Mu.Unlock()
-			c.Status(http.StatusConflict)
-			return
-		}
+	if device.IsLockedByOther(username, userTenant) {
+		device.Mu.Unlock()
+		c.Status(http.StatusConflict)
+		return
 	}
 
 	// Reserve the device BEFORE upgrading the WebSocket
 	// This prevents another user from passing the verification while we are upgrading the WebSocket
-	device.InUseTS = time.Now().UnixMilli()
-	device.InUseBy = username
-	device.InUseByTenant = userTenant
-	device.LastActionTS = time.Now().UnixMilli()
+	device.AcquireLock(username, userTenant, devices.LockSourceUI) //nolint:errcheck — AcquireLock only fails when locked by other, already checked above
 	device.Mu.Unlock()
 
 	conn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
 	if err != nil {
 		// Clear the reservation if the upgrade fails
 		device.Mu.Lock()
-		device.InUseTS = 0
-		device.InUseBy = ""
-		device.InUseByTenant = ""
+		device.ReleaseLock()
 		device.Mu.Unlock()
 
 		logger.ProviderLogger.LogError("device_in_use_ws", fmt.Sprintf("Failed upgrading device in-use websocket - %s", err))
@@ -541,7 +522,7 @@ func DeviceInUseWS(c *gin.Context) {
 	// Add the created connection to the respective device in the map
 	// So we can send different messages to it from other sources
 	device.Mu.Lock()
-	device.InUseWSConnection = conn
+	device.SetWSConnection(conn)
 	device.Mu.Unlock()
 
 	// If this function returns then we close the connection
@@ -549,14 +530,9 @@ func DeviceInUseWS(c *gin.Context) {
 	defer func() {
 		conn.Close()
 		device.Mu.Lock()
-		// Clear the connection
-		device.InUseWSConnection = nil
-
-		// Only clear user info if not running automation
+		device.ClearWSConnection()
 		if !device.IsRunningAutomation {
-			device.InUseTS = 0
-			device.InUseBy = ""
-			device.InUseByTenant = ""
+			device.ReleaseLock()
 		}
 		device.Mu.Unlock()
 	}()
@@ -602,13 +578,9 @@ func DeviceInUseWS(c *gin.Context) {
 							}
 							sessionExpiredJson, _ := json.Marshal(sessionExpiredMessage)
 							wsutil.WriteServerText(conn, sessionExpiredJson)
-							// Update the hub device to no longer be in use
 							device.Mu.Lock()
-							device.InUseTS = 0
-							device.InUseBy = ""
-							device.InUseByTenant = ""
+							device.ReleaseLock()
 							device.Mu.Unlock()
-							// Cancel the current websocket goroutines and stuff
 							cancel()
 							return
 						}
@@ -652,11 +624,9 @@ func DeviceInUseWS(c *gin.Context) {
 		// If a message is received over the channel with the username of the user occupying the device
 		// We set the last timestamp for in use and set the name of the person using it
 		// We reset the timer each time a message was received
-		case userName := <-messageReceived:
+		case <-messageReceived:
 			device.Mu.Lock()
-			device.InUseTS = time.Now().UnixMilli()
-			device.InUseBy = userName
-			device.InUseByTenant = userTenant
+			device.RefreshLock()
 			device.Mu.Unlock()
 			if !timer.Stop() {
 				<-timer.C
@@ -667,11 +637,8 @@ func DeviceInUseWS(c *gin.Context) {
 		// And remove the name of the person that was using it
 		case <-timer.C:
 			device.Mu.Lock()
-			// Only clear user info if not running automation
 			if !device.IsRunningAutomation {
-				device.InUseTS = 0
-				device.InUseBy = ""
-				device.InUseByTenant = ""
+				device.ReleaseLock()
 			}
 			device.Mu.Unlock()
 			return
@@ -690,7 +657,7 @@ func DeviceInUseWS(c *gin.Context) {
 // @Accept       json
 // @Produce      text/event-stream
 // @Param        workspaceId  query  string  true  "Workspace ID"
-// @Success      200          {object}  []models.LocalHubDevice
+// @Success      200          {object}  []devices.LocalHubDevice
 // @Failure      400          {object}  models.ErrorResponse
 // @Router       /available-devices [get]
 func AvailableDevicesSSE(c *gin.Context) {
@@ -702,7 +669,7 @@ func AvailableDevicesSSE(c *gin.Context) {
 	}
 
 	c.Stream(func(w io.Writer) bool {
-		var deviceList []*models.LocalHubDevice
+		var deviceList []*devices.LocalHubDevice
 
 		for _, d := range devices.HubDeviceStore.AllSorted() {
 			d.Mu.Lock()
@@ -1019,10 +986,7 @@ func ReleaseUsedDevice(c *gin.Context) {
 		return
 	}
 
-	releaseDevice.InUseWSConnection.Close()
-	releaseDevice.InUseTS = 0
-	releaseDevice.InUseBy = ""
-	releaseDevice.InUseByTenant = ""
+	releaseDevice.ReleaseLock()
 
 	api.OKMessage(c, "Message to release device was successfully sent")
 }
@@ -1079,7 +1043,7 @@ func ProviderUpdate(c *gin.Context) {
 		if !providerDevice.Connected {
 			hubDevice.IsAvailableForAutomation = false
 			hubDevice.IsRunningAutomation = false
-			hubDevice.InUseBy = ""
+			hubDevice.ReleaseLockIfNotHeld()
 			hubDevice.SessionID = ""
 			hubDevice.Mu.Unlock()
 			continue

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -537,116 +537,47 @@ func DeviceInUseWS(c *gin.Context) {
 		device.Mu.Unlock()
 	}()
 
-	// Create a context with cancel to use in the goroutines
+	// Create a context with cancel to use in the goroutine
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Create a channel to send data from the goroutine listening for messages coming from the client(UI)
-	// And then we receive from the channel in the for loop that sets the device in-use status
-	messageReceived := make(chan string)
-	defer close(messageReceived)
-
-	// Loop getting messages from the client
-	// To keep device in use
+	// Goroutine: send pings every 5s and check for 30-min inactivity
 	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done(): // If context was cancelled in the other goroutine or the for loop we return to stop the current goroutine
+			case <-ctx.Done():
 				return
-			default:
-				data, code, err := wsutil.ReadClientData(conn)
-				if err != nil || code == 8 { // 8 is close code
-					cancel() // Trigger context cancellation for all goroutines and the for loop if we got an error from the websocket/client and return to stop the current goroutine
+			case <-ticker.C:
+				device.Mu.RLock()
+				lastActionTS := device.LastActionTS
+				device.Mu.RUnlock()
+
+				if (time.Now().UnixMilli() - lastActionTS) > (1800 * 1000) {
+					ws.WriteFrame(conn, ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusCode(4001), "session expired"))) //nolint:errcheck
+					cancel()
 					return
 				}
 
-				// If we got any data from the client that is not an empty string - this is the nickname of the person using the device
-				// So we send it to the messageReceived channel
-				if string(data) != "" {
-					// Check if device is currently being used by someone
-					device.Mu.RLock()
-					inUseBy := device.InUseBy
-					lastActionTS := device.LastActionTS
-					device.Mu.RUnlock()
-
-					if inUseBy != "" {
-						// If it is being used check if any action was performed in the last 30 minutes
-						if (time.Now().UnixMilli() - lastActionTS) > (1800 * 1000) {
-							// Send to the websocket a message that the session expired
-							sessionExpiredMessage := models.DeviceInUseMessage{
-								Type: "sessionExpired",
-							}
-							sessionExpiredJson, _ := json.Marshal(sessionExpiredMessage)
-							wsutil.WriteServerText(conn, sessionExpiredJson)
-							device.Mu.Lock()
-							device.ReleaseLock()
-							device.Mu.Unlock()
-							cancel()
-							return
-						}
-					}
-					messageReceived <- string(data)
+				if err := wsutil.WriteServerText(conn, []byte("ping")); err != nil {
+					cancel()
+					return
 				}
 			}
 		}
 	}()
 
-	// Loop sending messages to client to keep the connection - like ping/pong
-	go func() {
-		for {
-			select {
-			case <-ctx.Done(): // If context was cancelled in the other goroutine or the for loop we return to stop the current goroutine
-				return
-			default:
-				// Send a ping message to the client(UI) using the DeviceInUseMessage struct as json string
-				deviceInUseMessage := models.DeviceInUseMessage{
-					Type: "ping",
-				}
-				deviceInUseMessageJson, _ := json.Marshal(deviceInUseMessage)
-				err := wsutil.WriteServerText(conn, deviceInUseMessageJson)
-				if err != nil {
-					cancel() // Trigger context cancellation for all goroutines and the for loop if we got an error from the websocket/client and return to stop the current goroutine
-					return
-				}
-				// Wait 1 second between pings
-				time.Sleep(1 * time.Second)
-			}
-		}
-	}()
-
-	// Create a new timer for the loop below
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
-
-	// We loop over the messageReceived channel, timer and the context cancellation signal
+	// Main loop: read client responses to keep the lock alive
 	for {
-		select {
-		// If a message is received over the channel with the username of the user occupying the device
-		// We set the last timestamp for in use and set the name of the person using it
-		// We reset the timer each time a message was received
-		case <-messageReceived:
-			device.Mu.Lock()
-			device.RefreshLock()
-			device.Mu.Unlock()
-			if !timer.Stop() {
-				<-timer.C
-			}
-			timer.Reset(2 * time.Second)
-		// If the timer limit is reached and the device is not in use by automation but a person
-		// We reset the in use timestamp
-		// And remove the name of the person that was using it
-		case <-timer.C:
-			device.Mu.Lock()
-			if !device.IsRunningAutomation {
-				device.ReleaseLock()
-			}
-			device.Mu.Unlock()
-			return
-		// If the context was cancelled from the read/write goroutines
-		// We return to exit the loop
-		case <-ctx.Done():
+		conn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
+		_, _, err := wsutil.ReadClientData(conn)
+		if err != nil {
 			return
 		}
+		device.Mu.Lock()
+		device.RefreshLock()
+		device.Mu.Unlock()
 	}
 }
 
@@ -687,11 +618,7 @@ func AvailableDevicesSSE(c *gin.Context) {
 				d.Available = true
 			}
 
-			if d.InUseTS > (time.Now().UnixMilli() - 3000) {
-				d.InUse = true
-			} else {
-				d.InUse = false
-			}
+			d.InUse = d.IsLocked()
 
 			d.Mu.Unlock()
 			deviceList = append(deviceList, d)
@@ -966,12 +893,6 @@ func GetDevices(c *gin.Context) {
 func ReleaseUsedDevice(c *gin.Context) {
 	udid := c.Param("udid")
 
-	// Send a release device message on the device in use websocket connection
-	deviceInUseMessage := models.DeviceInUseMessage{
-		Type: "releaseDevice",
-	}
-	deviceInUseMessageJson, _ := json.Marshal(deviceInUseMessage)
-
 	releaseDevice, ok := devices.HubDeviceStore.Get(udid)
 	if !ok {
 		api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))
@@ -980,15 +901,14 @@ func ReleaseUsedDevice(c *gin.Context) {
 
 	releaseDevice.Mu.Lock()
 	defer releaseDevice.Mu.Unlock()
-	err := wsutil.WriteServerText(releaseDevice.InUseWSConnection, deviceInUseMessageJson)
-	if err != nil {
-		api.InternalError(c, "Failed to send release device message - "+err.Error())
-		return
+
+	if releaseDevice.InUseWSConnection != nil {
+		ws.WriteFrame(releaseDevice.InUseWSConnection, ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusCode(4000), "released by admin"))) //nolint:errcheck
 	}
 
 	releaseDevice.ReleaseLock()
 
-	api.OKMessage(c, "Message to release device was successfully sent")
+	api.OKMessage(c, "Device was successfully released")
 }
 
 // syncDeviceFields synchronizes operational fields from provider to hub device

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -503,9 +503,14 @@ func DeviceInUseWS(c *gin.Context) {
 		return
 	}
 
-	// Reserve the device BEFORE upgrading the WebSocket
-	// This prevents another user from passing the verification while we are upgrading the WebSocket
-	device.AcquireLock(username, userTenant, devices.LockSourceUI) //nolint:errcheck — AcquireLock only fails when locked by other, already checked above
+	// If the device is already held via an API lease by this user, preserve the API lock.
+	// Calling AcquireLock here would overwrite LockSource to "ui", which would cause
+	// HasActiveLease() to return false and the API lock to be released on WS disconnect.
+	// For a pure UI session (no prior lock), reserve the device now to prevent a race
+	// between passing the check above and completing the WebSocket upgrade below.
+	if !device.HasActiveLease() {
+		device.AcquireLock(username, userTenant, devices.LockSourceUI) //nolint:errcheck — AcquireLock only fails when locked by other, already checked above
+	}
 	device.Mu.Unlock()
 
 	conn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
@@ -531,7 +536,10 @@ func DeviceInUseWS(c *gin.Context) {
 		conn.Close()
 		device.Mu.Lock()
 		device.ClearWSConnection()
-		if !device.IsRunningAutomation {
+		// Do not release the lock if automation is still running or if an API lease is still active.
+		// The user intentionally locked the device via API (or owns the automation session)
+		// and must remain the lock holder after closing remote control.
+		if !device.IsRunningAutomation && !device.HasActiveLease() {
 			device.ReleaseLock()
 		}
 		device.Mu.Unlock()

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strconv"
 	"time"
 
@@ -490,13 +489,13 @@ func DeviceInUseWS(c *gin.Context) {
 	}
 
 	// Verify if the device is already in use by another user
-	devices.HubDevicesData.Mu.Lock()
-	device, exists := devices.HubDevicesData.Devices[udid]
+	device, exists := devices.HubDeviceStore.Get(udid)
 	if !exists {
-		devices.HubDevicesData.Mu.Unlock()
 		c.Status(http.StatusNotFound)
 		return
 	}
+
+	device.Mu.Lock()
 
 	// Check if device is in use by another user
 	if device.InUseBy != "" {
@@ -505,14 +504,14 @@ func DeviceInUseWS(c *gin.Context) {
 
 		// If not the same user AND there's an active WebSocket connection, always deny
 		if !isSameUser && device.InUseWSConnection != nil {
-			devices.HubDevicesData.Mu.Unlock()
+			device.Mu.Unlock()
 			c.Status(http.StatusConflict)
 			return
 		}
 
 		// If not the same user and device was used recently, also deny
 		if !isSameUser && (time.Now().UnixMilli()-device.InUseTS) < 3000 {
-			devices.HubDevicesData.Mu.Unlock()
+			device.Mu.Unlock()
 			c.Status(http.StatusConflict)
 			return
 		}
@@ -520,20 +519,20 @@ func DeviceInUseWS(c *gin.Context) {
 
 	// Reserve the device BEFORE upgrading the WebSocket
 	// This prevents another user from passing the verification while we are upgrading the WebSocket
-	devices.HubDevicesData.Devices[udid].InUseTS = time.Now().UnixMilli()
-	devices.HubDevicesData.Devices[udid].InUseBy = username
-	devices.HubDevicesData.Devices[udid].InUseByTenant = userTenant
-	devices.HubDevicesData.Devices[udid].LastActionTS = time.Now().UnixMilli()
-	devices.HubDevicesData.Mu.Unlock()
+	device.InUseTS = time.Now().UnixMilli()
+	device.InUseBy = username
+	device.InUseByTenant = userTenant
+	device.LastActionTS = time.Now().UnixMilli()
+	device.Mu.Unlock()
 
 	conn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
 	if err != nil {
 		// Clear the reservation if the upgrade fails
-		devices.HubDevicesData.Mu.Lock()
-		devices.HubDevicesData.Devices[udid].InUseTS = 0
-		devices.HubDevicesData.Devices[udid].InUseBy = ""
-		devices.HubDevicesData.Devices[udid].InUseByTenant = ""
-		devices.HubDevicesData.Mu.Unlock()
+		device.Mu.Lock()
+		device.InUseTS = 0
+		device.InUseBy = ""
+		device.InUseByTenant = ""
+		device.Mu.Unlock()
 
 		logger.ProviderLogger.LogError("device_in_use_ws", fmt.Sprintf("Failed upgrading device in-use websocket - %s", err))
 		return
@@ -541,25 +540,25 @@ func DeviceInUseWS(c *gin.Context) {
 
 	// Add the created connection to the respective device in the map
 	// So we can send different messages to it from other sources
-	devices.HubDevicesData.Mu.Lock()
-	devices.HubDevicesData.Devices[udid].InUseWSConnection = conn
-	devices.HubDevicesData.Mu.Unlock()
+	device.Mu.Lock()
+	device.InUseWSConnection = conn
+	device.Mu.Unlock()
 
 	// If this function returns then we close the connection
 	// And also set it to nil for the respective device in the map
 	defer func() {
 		conn.Close()
-		devices.HubDevicesData.Mu.Lock()
+		device.Mu.Lock()
 		// Clear the connection
-		devices.HubDevicesData.Devices[udid].InUseWSConnection = nil
+		device.InUseWSConnection = nil
 
 		// Only clear user info if not running automation
-		if !devices.HubDevicesData.Devices[udid].IsRunningAutomation {
-			devices.HubDevicesData.Devices[udid].InUseTS = 0
-			devices.HubDevicesData.Devices[udid].InUseBy = ""
-			devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+		if !device.IsRunningAutomation {
+			device.InUseTS = 0
+			device.InUseBy = ""
+			device.InUseByTenant = ""
 		}
-		devices.HubDevicesData.Mu.Unlock()
+		device.Mu.Unlock()
 	}()
 
 	// Create a context with cancel to use in the goroutines
@@ -589,9 +588,14 @@ func DeviceInUseWS(c *gin.Context) {
 				// So we send it to the messageReceived channel
 				if string(data) != "" {
 					// Check if device is currently being used by someone
-					if devices.HubDevicesData.Devices[udid].InUseBy != "" {
-						// If it is being used check if the any action was performed in the last 30 minutes
-						if (time.Now().UnixMilli() - devices.HubDevicesData.Devices[udid].LastActionTS) > (1800 * 1000) {
+					device.Mu.RLock()
+					inUseBy := device.InUseBy
+					lastActionTS := device.LastActionTS
+					device.Mu.RUnlock()
+
+					if inUseBy != "" {
+						// If it is being used check if any action was performed in the last 30 minutes
+						if (time.Now().UnixMilli() - lastActionTS) > (1800 * 1000) {
 							// Send to the websocket a message that the session expired
 							sessionExpiredMessage := models.DeviceInUseMessage{
 								Type: "sessionExpired",
@@ -599,11 +603,11 @@ func DeviceInUseWS(c *gin.Context) {
 							sessionExpiredJson, _ := json.Marshal(sessionExpiredMessage)
 							wsutil.WriteServerText(conn, sessionExpiredJson)
 							// Update the hub device to no longer be in use
-							devices.HubDevicesData.Mu.Lock()
-							devices.HubDevicesData.Devices[udid].InUseTS = 0
-							devices.HubDevicesData.Devices[udid].InUseBy = ""
-							devices.HubDevicesData.Devices[udid].InUseByTenant = ""
-							devices.HubDevicesData.Mu.Unlock()
+							device.Mu.Lock()
+							device.InUseTS = 0
+							device.InUseBy = ""
+							device.InUseByTenant = ""
+							device.Mu.Unlock()
 							// Cancel the current websocket goroutines and stuff
 							cancel()
 							return
@@ -649,11 +653,11 @@ func DeviceInUseWS(c *gin.Context) {
 		// We set the last timestamp for in use and set the name of the person using it
 		// We reset the timer each time a message was received
 		case userName := <-messageReceived:
-			devices.HubDevicesData.Mu.Lock()
-			devices.HubDevicesData.Devices[udid].InUseTS = time.Now().UnixMilli()
-			devices.HubDevicesData.Devices[udid].InUseBy = userName
-			devices.HubDevicesData.Devices[udid].InUseByTenant = userTenant
-			devices.HubDevicesData.Mu.Unlock()
+			device.Mu.Lock()
+			device.InUseTS = time.Now().UnixMilli()
+			device.InUseBy = userName
+			device.InUseByTenant = userTenant
+			device.Mu.Unlock()
 			if !timer.Stop() {
 				<-timer.C
 			}
@@ -662,14 +666,14 @@ func DeviceInUseWS(c *gin.Context) {
 		// We reset the in use timestamp
 		// And remove the name of the person that was using it
 		case <-timer.C:
-			devices.HubDevicesData.Mu.Lock()
+			device.Mu.Lock()
 			// Only clear user info if not running automation
-			if !devices.HubDevicesData.Devices[udid].IsRunningAutomation {
-				devices.HubDevicesData.Devices[udid].InUseTS = 0
-				devices.HubDevicesData.Devices[udid].InUseBy = ""
-				devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+			if !device.IsRunningAutomation {
+				device.InUseTS = 0
+				device.InUseBy = ""
+				device.InUseByTenant = ""
 			}
-			devices.HubDevicesData.Mu.Unlock()
+			device.Mu.Unlock()
 			return
 		// If the context was cancelled from the read/write goroutines
 		// We return to exit the loop
@@ -698,44 +702,33 @@ func AvailableDevicesSSE(c *gin.Context) {
 	}
 
 	c.Stream(func(w io.Writer) bool {
+		var deviceList []*models.LocalHubDevice
 
-		devices.HubDevicesData.Mu.Lock()
-		// Extract the keys from the map and order them
-		var hubDeviceMapKeys []string
-		for key := range devices.HubDevicesData.Devices {
-			hubDeviceMapKeys = append(hubDeviceMapKeys, key)
-		}
-		sort.Strings(hubDeviceMapKeys)
+		for _, d := range devices.HubDeviceStore.AllSorted() {
+			d.Mu.Lock()
 
-		var deviceList = []*models.LocalHubDevice{}
-		for _, key := range hubDeviceMapKeys {
-			device := devices.HubDevicesData.Devices[key]
-
-			// Filter by workspace
-			if device.Device.WorkspaceID != workspaceID {
+			if d.Device.WorkspaceID != workspaceID {
+				d.Mu.Unlock()
 				continue
 			}
 
-			if device.Device.LastUpdatedTimestamp < (time.Now().UnixMilli()-3000) && device.Device.Connected {
-				device.Available = false
-			} else if device.Device.ProviderState != "live" {
-				device.Available = false
+			if d.Device.LastUpdatedTimestamp < (time.Now().UnixMilli()-3000) && d.Device.Connected {
+				d.Available = false
+			} else if d.Device.ProviderState != "live" {
+				d.Available = false
 			} else {
-				device.Available = true
+				d.Available = true
 			}
 
-			if device.InUseTS > (time.Now().UnixMilli() - 3000) {
-				if !device.InUse {
-					device.InUse = true
-				}
+			if d.InUseTS > (time.Now().UnixMilli() - 3000) {
+				d.InUse = true
 			} else {
-				if device.InUse {
-					device.InUse = false
-				}
+				d.InUse = false
 			}
-			deviceList = append(deviceList, device)
+
+			d.Mu.Unlock()
+			deviceList = append(deviceList, d)
 		}
-		devices.HubDevicesData.Mu.Unlock()
 
 		jsonData, _ := json.Marshal(deviceList)
 		c.SSEvent("", string(jsonData))
@@ -1012,18 +1005,24 @@ func ReleaseUsedDevice(c *gin.Context) {
 	}
 	deviceInUseMessageJson, _ := json.Marshal(deviceInUseMessage)
 
-	devices.HubDevicesData.Mu.Lock()
-	defer devices.HubDevicesData.Mu.Unlock()
-	err := wsutil.WriteServerText(devices.HubDevicesData.Devices[udid].InUseWSConnection, deviceInUseMessageJson)
+	releaseDevice, ok := devices.HubDeviceStore.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))
+		return
+	}
+
+	releaseDevice.Mu.Lock()
+	defer releaseDevice.Mu.Unlock()
+	err := wsutil.WriteServerText(releaseDevice.InUseWSConnection, deviceInUseMessageJson)
 	if err != nil {
 		api.InternalError(c, "Failed to send release device message - "+err.Error())
 		return
 	}
 
-	devices.HubDevicesData.Devices[udid].InUseWSConnection.Close()
-	devices.HubDevicesData.Devices[udid].InUseTS = 0
-	devices.HubDevicesData.Devices[udid].InUseBy = ""
-	devices.HubDevicesData.Devices[udid].InUseByTenant = ""
+	releaseDevice.InUseWSConnection.Close()
+	releaseDevice.InUseTS = 0
+	releaseDevice.InUseBy = ""
+	releaseDevice.InUseByTenant = ""
 
 	api.OKMessage(c, "Message to release device was successfully sent")
 }
@@ -1068,27 +1067,29 @@ func ProviderUpdate(c *gin.Context) {
 		// handle error if needed
 	}
 
-	for _, providerDevice := range providerDeviceData.DeviceData {
-		devices.HubDevicesData.Mu.Lock()
-		hubDevice, ok := devices.HubDevicesData.Devices[providerDevice.UDID]
-		if ok {
-			// If device is not connected reset all fields that might allow it to get stuck in Running automation state
-			// If its not connected, then its not running automation or is available for automation
-			if !providerDevice.Connected {
-				hubDevice.IsAvailableForAutomation = false
-				hubDevice.IsRunningAutomation = false
-				hubDevice.InUseBy = ""
-				hubDevice.SessionID = ""
-				devices.HubDevicesData.Mu.Unlock()
-				continue
-			}
-			// Set a timestamp to indicate last time info about the device was updated from the provider
-			providerDevice.LastUpdatedTimestamp = time.Now().UnixMilli()
-
-			// Update only operational fields from provider
-			syncDeviceFields(&hubDevice.Device, &providerDevice)
+	for i := range providerDeviceData.DeviceData {
+		providerDevice := &providerDeviceData.DeviceData[i]
+		hubDevice, ok := devices.HubDeviceStore.Get(providerDevice.UDID)
+		if !ok {
+			continue
 		}
-		devices.HubDevicesData.Mu.Unlock()
+		hubDevice.Mu.Lock()
+		// If device is not connected reset all fields that might allow it to get stuck in Running automation state
+		// If its not connected, then its not running automation or is available for automation
+		if !providerDevice.Connected {
+			hubDevice.IsAvailableForAutomation = false
+			hubDevice.IsRunningAutomation = false
+			hubDevice.InUseBy = ""
+			hubDevice.SessionID = ""
+			hubDevice.Mu.Unlock()
+			continue
+		}
+		// Set a timestamp to indicate last time info about the device was updated from the provider
+		providerDevice.LastUpdatedTimestamp = time.Now().UnixMilli()
+
+		// Update only operational fields from provider
+		syncDeviceFields(&hubDevice.Device, providerDevice)
+		hubDevice.Mu.Unlock()
 	}
 
 	api.OKMessage(c, "Provider data updated in hub")

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -470,23 +470,14 @@ func DeviceInUseWS(c *gin.Context) {
 	var username string
 	var userTenant string
 
-	// Extract token from Bearer format
-	tokenString, err := auth.ExtractTokenFromBearer(tokenParam)
-	if err == nil {
-		// Get origin from request
-		origin := auth.GetOriginFromRequest(c)
-
-		// Get claims from token with origin
-		claims, err := auth.GetClaimsFromToken(tokenString, origin)
-		if err != nil || claims.Username == "" {
-			// Return 401 for any token validation error
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-
-		username = claims.Username
-		userTenant = claims.Tenant
+	// Extract token from the request
+	claims := getClaimsFromRequest(c)
+	if claims == nil || claims.Username == "" {
+		c.Status(http.StatusUnauthorized)
+		return
 	}
+	username = claims.Username
+	userTenant = claims.Tenant
 
 	// Verify if the device is already in use by another user
 	device, exists := devices.HubDeviceStore.Get(udid)

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -911,6 +911,154 @@ func ReleaseUsedDevice(c *gin.Context) {
 	api.OKMessage(c, "Device was successfully released")
 }
 
+type lockDeviceResponse struct {
+	UDID        string `json:"udid"`
+	LockedBy    string `json:"locked_by"`
+	Tenant      string `json:"tenant"`
+	ExpiresAtMS int64  `json:"expires_at_ms"`
+}
+
+// getClaimsFromRequest extracts JWT claims from the Authorization header (Bearer token)
+// or the raw ?token= query param (no "Bearer " prefix needed for the query param).
+// Returns nil if no token is present or the token is invalid.
+func getClaimsFromRequest(c *gin.Context) *auth.JWTClaims {
+	var tokenString string
+
+	if authHeader := c.GetHeader("Authorization"); authHeader != "" {
+		t, err := auth.ExtractTokenFromBearer(authHeader)
+		if err != nil {
+			return nil
+		}
+		tokenString = t
+	} else if raw := c.Query("token"); raw != "" {
+		tokenString = raw
+	} else {
+		return nil
+	}
+
+	origin := auth.GetOriginFromRequest(c)
+	claims, err := auth.GetClaimsFromToken(tokenString, origin)
+	if err != nil {
+		return nil
+	}
+	return claims
+}
+
+// LockDevice godoc
+// @Summary      Lock a device via REST API
+// @Description  Acquire an exclusive lock on a device. Authenticate via Authorization header (Bearer token) or ?token= query param (raw token, no Bearer prefix). Optional ?ttl_minutes= (default 10, max 60). If locked by another user returns 409. Admins can take over any lock.
+// @Tags         Hub - Devices
+// @Produce      json
+// @Param        udid         path   string  true   "Device UDID"
+// @Param        token        query  string  false  "Raw JWT token (alternative to Authorization header)"
+// @Param        ttl_minutes  query  int     false  "Lock TTL in minutes (default 10, max 60)"
+// @Success      200   {object}  lockDeviceResponse
+// @Failure      401   {object}  models.ErrorResponse
+// @Failure      404   {object}  models.ErrorResponse
+// @Failure      409   {object}  models.ErrorResponse
+// @Security     BearerAuth
+// @Router       /devices/control/{udid}/lock [post]
+func LockDevice(c *gin.Context) {
+	udid := c.Param("udid")
+
+	claims := getClaimsFromRequest(c)
+	if claims == nil || claims.Username == "" {
+		c.Status(http.StatusUnauthorized)
+		return
+	}
+
+	ttl, _ := strconv.Atoi(c.DefaultQuery("ttl_minutes", "10"))
+	if ttl <= 0 {
+		ttl = 10
+	}
+	if ttl > 60 {
+		ttl = 60
+	}
+
+	device, ok := devices.HubDeviceStore.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))
+		return
+	}
+
+	device.Mu.Lock()
+	defer device.Mu.Unlock()
+
+	if device.IsLockedByOther(claims.Username, claims.Tenant) {
+		if claims.Role != "admin" {
+			api.Conflict(c, fmt.Sprintf("Device `%s` is already locked by another user", udid))
+			return
+		}
+		// Admin takeover: kick the current holder out via close frame if UI session
+		if device.InUseWSConnection != nil {
+			ws.WriteFrame(device.InUseWSConnection, ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusCode(4000), "released by admin"))) //nolint:errcheck
+		}
+		device.ReleaseLock()
+	}
+
+	device.AcquireLock(claims.Username, claims.Tenant, devices.LockSourceAPI) //nolint:errcheck — IsLockedByOther already checked above
+	expiresAt := time.Now().Add(time.Duration(ttl) * time.Minute).UnixMilli()
+	device.LeaseExpiresAt = expiresAt
+
+	c.JSON(http.StatusOK, lockDeviceResponse{
+		UDID:        udid,
+		LockedBy:    claims.Username,
+		Tenant:      claims.Tenant,
+		ExpiresAtMS: expiresAt,
+	})
+}
+
+// UnlockDevice godoc
+// @Summary      Unlock a device via REST API
+// @Description  Release a lock on a device. No-op if device is already free. Returns 409 if locked by another user (admins can always unlock). Authenticate via Authorization header or ?token= query param.
+// @Tags         Hub - Devices
+// @Produce      json
+// @Param        udid   path   string  true   "Device UDID"
+// @Param        token  query  string  false  "Raw JWT token (alternative to Authorization header)"
+// @Success      200   {object}  models.SuccessResponse
+// @Failure      401   {object}  models.ErrorResponse
+// @Failure      404   {object}  models.ErrorResponse
+// @Failure      409   {object}  models.ErrorResponse
+// @Security     BearerAuth
+// @Router       /devices/control/{udid}/unlock [post]
+func UnlockDevice(c *gin.Context) {
+	udid := c.Param("udid")
+
+	claims := getClaimsFromRequest(c)
+	if claims == nil || claims.Username == "" {
+		c.Status(http.StatusUnauthorized)
+		return
+	}
+
+	device, ok := devices.HubDeviceStore.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))
+		return
+	}
+
+	device.Mu.Lock()
+	defer device.Mu.Unlock()
+
+	if !device.IsLocked() {
+		api.OKMessage(c, "Device is not locked")
+		return
+	}
+
+	if device.IsLockedByOther(claims.Username, claims.Tenant) {
+		if claims.Role != "admin" {
+			api.Conflict(c, fmt.Sprintf("Device `%s` is locked by another user", udid))
+			return
+		}
+		// Admin kick-out via close frame if UI session
+		if device.InUseWSConnection != nil {
+			ws.WriteFrame(device.InUseWSConnection, ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusCode(4000), "released by admin"))) //nolint:errcheck
+		}
+	}
+
+	device.ReleaseLock()
+	api.OKMessage(c, "Device successfully unlocked")
+}
+
 // syncDeviceFields synchronizes operational fields from provider to hub device
 // Only updates fields that are different between the two devices
 func syncDeviceFields(target *models.Device, source *models.Device) {


### PR DESCRIPTION
* Move LocalHubDevice model to the hub package
* Implement better device store with improved mutex mechanisms instead of the original devices map
* Add receiver methods for the LocalHubDevice with proper mutex handling for the device updates
* Reorganize the device handling code to use the new methods - cleaner and more readable
* Add /lock and /unlock endpoints for reserving and releasing device from CI or other external sources