### PR TITLE
Link macOS service configuration docs in the README and make minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ For detailed instructions on how to create a service for Linux using systemd, pl
 For detailed instructions on how to create a service for Windows using WinSW, please refer to the [Windows Service Documentation](./docs/windows-service.md).
 
 ### 🍏 macOS
-*Note: Service implementation for macOS is yet to be documented.*
+For detailed instructions on how to create a service for macOS using launchd, please refer to the [macOS Service Documentation](./docs/macos-service.md).
 
 ## ❓ FAQ
 

--- a/docs/macos-service.md
+++ b/docs/macos-service.md
@@ -25,11 +25,11 @@ Paste the following configuration, adjusting the values for your environment:
         <string>/usr/local/bin/gads</string>
         <string>provider</string>
         <string>--hub</string>
-        <string>[http://192.168.254.___:PORT](http://192.168.254.___:PORT)</string>
+        <string>http://___.___.___.___:PORT</string>
         <string>--mongo-db</string>
-        <string>192.168.254.___:27017</string>
+        <string>___.___.___.___:27017</string>
         <string>--nickname</string>
-        <string>[your-provider-name]</string>
+        <string>YOUR-PROVIDER-NAME</string>
         <string>--log-level</string>
         <string>info</string>
     </array>


### PR DESCRIPTION
Revised the README per request, also changed the placeholder values in case someone is not always using a NAT IP.