### PR TITLE
Add Android local debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ jsconfig.json
 Provider1/
 go-ios*
 memory/*
+GADS-Remote/*
+GADS-Remote

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@
 
   <h1>GADS - Device Farm for Mobile & Smart TV Testing</h1>
 
-  [![GitHub Stars](https://img.shields.io/github/stars/shamanec/GADS?style=social)](https://github.com/shamanec/GADS/stargazers)
-  [![GitHub Release](https://img.shields.io/github/v/release/shamanec/GADS)](https://github.com/shamanec/GADS/releases)
-  [![GitHub Downloads](https://img.shields.io/github/downloads/shamanec/GADS/total)](https://github.com/shamanec/GADS/releases)
-  [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-  [![Discord](https://dcbadge.limes.pink/api/server/5amWvknKQd?style=flat&theme=clean&compact=true)](https://discord.gg/5amWvknKQd)
+[![GitHub Stars](https://img.shields.io/github/stars/shamanec/GADS?style=social)](https://github.com/shamanec/GADS/stargazers)
+[![GitHub Release](https://img.shields.io/github/v/release/shamanec/GADS)](https://github.com/shamanec/GADS/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/shamanec/GADS/total)](https://github.com/shamanec/GADS/releases)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Discord](https://dcbadge.limes.pink/api/server/5amWvknKQd?style=flat&theme=clean&compact=true)](https://discord.gg/5amWvknKQd)
 
-  🚀 **Self-Hosted Device Farm & Test Automation Platform** - Alternative to AWS Device Farm and Firebase Test Lab for Mobile & Smart TV Testing
+🚀 **Self-Hosted Device Farm & Test Automation Platform** - Alternative to AWS Device Farm and Firebase Test Lab for Mobile & Smart TV Testing
+
 </div>
 
 ## 🎯 What is GADS?
@@ -27,13 +28,16 @@
 **GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS and LG WebOS). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
 
 The platform architecture consists of two main components:
+
 - **Hub**: A web interface for remote device control and provider management.
 - **Provider**: Handles device setup and makes them available for remote access.
 
 ### Why Choose GADS?
+
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
 - 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
+- 🎮 **Local debugging - Android only**: [Connect](./docs/adb-client.md) remotely controlled Android device to your local `adb` instance for development and debugging
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
 - 🔑 **Flexible Authentication**: Support for multiple JWT issuers with origin-based keys
 - 🛠 **Easy Setup**: Simple installation and configuration process
@@ -41,6 +45,7 @@ The platform architecture consists of two main components:
 ## ✨ Key Features
 
 ### Hub Features 🎯
+
 - 🔐 **Authentication System**
   - User login with session management
   - Admin user management
@@ -56,6 +61,7 @@ The platform architecture consists of two main components:
   - App installation/uninstallation
   - High-quality screenshots
   - Device reservation system
+  - Android devices remote debugging over `adb` [adb-client](./docs/adb-client.md)
 - 🔄 **Backend Capabilities**
   - Web interface serving
   - Provider communication proxy
@@ -66,6 +72,7 @@ The platform architecture consists of two main components:
   - [Detailed Workspace Documentation](./docs/workspaces.md)
 
 ### Provider Features 🔌
+
 - 🛠️ **Easy Setup**
   - UI-based device management
 - 🤖 **Automated Device Provisioning**
@@ -85,11 +92,11 @@ The platform architecture consists of two main components:
 
 ## 💻 Platform Support
 
-| OS         | Android Support | iOS Support | Smart TV Support    | Notes                                                                          |
-|------------|----------------|-------------|---------------------|--------------------------------------------------------------------------------|
-| **macOS**  | ✅             | ✅           | ✅ (automation only) | Full support for mobile, Smart TVs support only automated testing             |
-| **Linux**  | ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
-| **Windows**| ✅             | ⚠️           | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
+| OS          | Android Support | iOS Support | Smart TV Support     | Notes                                                                         |
+| ----------- | --------------- | ----------- | -------------------- | ----------------------------------------------------------------------------- |
+| **macOS**   | ✅              | ✅          | ✅ (automation only) | Full support for mobile, Smart TVs support only automated testing             |
+| **Linux**   | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
+| **Windows** | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
 
 **Important**: Smart TV support (Tizen OS and WebOS) is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
 
@@ -123,9 +130,12 @@ GADS, including both open source and obfuscated proprietary components, is freel
 ## 🚀 Getting Started
 
 > ### **Prerequisites**
+>
 > Before getting started, make sure you have the following:
+>
 > - A **MongoDB** instance (v6.0 recommended)
 > - Network connectivity between Hub, Providers, MongoDB, and Selenium Grid
+>
 > ---
 
 ### ⚡ Quick Start
@@ -135,7 +145,8 @@ GADS, including both open source and obfuscated proprietary components, is freel
 1. Go to the [releases page](https://github.com/shamanec/GADS/releases) and download the latest binary for your platform.
 
 #### Option 2: Build from source for non-UI related development
-**IMPORTANT** You can freely use the Go code to your ends or provide new features/bug fixes on mainstream project but any changes to the UI should be requested from the core team.  
+
+**IMPORTANT** You can freely use the Go code to your ends or provide new features/bug fixes on mainstream project but any changes to the UI should be requested from the core team.
 
 ```bash
 # Clone the repository
@@ -147,48 +158,63 @@ go build .
 ```
 
 #### Option 3: Build from source for UI related development
-**IMPORTANT** You can freely use the Go code to your ends or provide new features/bug fixes on mainstream project but any changes to the UI should be requested from the core team.  
+
+**IMPORTANT** You can freely use the Go code to your ends or provide new features/bug fixes on mainstream project but any changes to the UI should be requested from the core team.
 
 1. Clone the repository
+
 ```bash
 git clone https://github.com/shamanec/GADS
 ```
+
 2. Download the prebuilt UI files zip from the latest [release](https://github.com/shamanec/GADS/releases)
 3. Unzip the file from step into your GADS folder in a new folder named `hub-ui`, your folder structure should look like `../GADS/hub-ui/build/*`
 4. Build the application
+
 ```bash
 cd ../..
 go build -tags ui .
 ```
+
 > **Note**: Optionally before building you can update the docs.go (OpenAPI spec) by running `swag init -g hub/hub.go -o docs`
 
 ### 🛠️ Common setup
+
 #### 🌱 MongoDB
+
 The project uses MongoDB for storing logs and for synchronization of some data between hub and providers.
-You can either run MongoDB in a docker container:  
+You can either run MongoDB in a docker container:
+
 - You need to have Docker(Docker Desktop on macOS, Windows) installed.
 - Execute `docker run -d --restart=always --name mongodb -p 27017:27017 mongo:6.0`. This will pull the official MongoDB 6.0 image from Docker Hub and start a container binding ports `27017` for the MongoDB instance.
 - You can use MongoDB Compass or another tool to access the db if needed.
 
-or  
+or
+
 - Start MongoDB instance in the way you prefer
 
 #### ⚙️ Hub setup
-For detailed instructions on setting up the Hub, refer to the [Hub Setup Docs](./docs/hub.md)  
+
+For detailed instructions on setting up the Hub, refer to the [Hub Setup Docs](./docs/hub.md)
 
 #### 📱 Provider setup
+
 For detailed instructions on setting up the Provider, refer to the [Provider Setup Docs.](./docs/provider.md)
 
 ## Running GADS as a System Service
+
 To ensure that GADS runs continuously and can be managed easily, it is recommended to execute it as a service on your operating system. Running GADS as a service allows it to start automatically on boot, restart on failure, and be managed through standard service commands.
 
 ### 🐧 Linux
+
 For detailed instructions on how to create a service for Linux using systemd, please refer to the [Linux Service Documentation](./docs/linux-service.md).
 
 ### 🖥️ Windows
+
 For detailed instructions on how to create a service for Windows using WinSW, please refer to the [Windows Service Documentation](./docs/windows-service.md).
 
 ### 🍏 macOS
+
 For detailed instructions on how to create a service for macOS using launchd, please refer to the [macOS Service Documentation](./docs/macos-service.md).
 
 ## ❓ FAQ
@@ -199,36 +225,44 @@ For more details, refer to the [full FAQ](./docs/faq.md).
 
 ## 🙏 Thanks
 
-| | About                                                                                                                                                              |
-|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
-|[go-ios](https://github.com/danielpaulus/go-ios)| Many thanks for creating this CLI tool to communicate with iOS devices, perfect for installing/reinstalling and running WebDriverAgentRunner without Xcode |
-|[Appium](https://github.com/appium)| It would be impossible to control the devices remotely without Appium for the control and WebDriverAgent for the iOS screen stream, kudos!                         |  
+|                                                  | About                                                                                                                                                      |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [go-ios](https://github.com/danielpaulus/go-ios) | Many thanks for creating this CLI tool to communicate with iOS devices, perfect for installing/reinstalling and running WebDriverAgentRunner without Xcode |
+| [Appium](https://github.com/appium)              | It would be impossible to control the devices remotely without Appium for the control and WebDriverAgent for the iOS screen stream, kudos!                 |
 
 ## 🎥 Videos
+
 #### Start hub
+
 https://github.com/user-attachments/assets/7a6dab5a-52d1-4c48-882d-48b67e180c89
 
 #### Add provider configuration
+
 https://github.com/user-attachments/assets/07c94ecf-217e-4185-9465-8b8054ddef7e
 
 #### Add devices and start provider
+
 https://github.com/user-attachments/assets/a1b323da-0169-463e-9a37-b0364fc52480
 
 #### Run Appium tests in parallel with TestNG
+
 https://github.com/user-attachments/assets/cb2da413-6a72-4ead-9433-c4d2b41d5f4b
 
 #### Remote control
+
 https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 
 ## 💡 Use Cases
 
 ### Mobile Testing 📱
+
 - **Mobile App Testing**: Automate testing across multiple real iOS and Android devices
 - **Manual QA**: Remote access to physical devices for manual testing and debugging
 - **Cross-Browser Testing**: Test web applications across multiple mobile browsers
 - **Device Lab Management**: Centralized management of your organization's mobile devices
 
 ### Smart TV Testing 📺
+
 - **Smart TV App Testing**: Automated testing for TV applications
 - **Currently Supported**: Samsung Tizen OS and LG WebOS
 - **TV-Specific Testing**: Validate TV app functionality, performance, and compatibility

--- a/client/adb/adb.go
+++ b/client/adb/adb.go
@@ -10,6 +10,7 @@
 package adb
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
@@ -35,6 +37,12 @@ func Start(flags *pflag.FlagSet) {
 	udid, _ := flags.GetString("udid")
 	username, _ := flags.GetString("username")
 	password, _ := flags.GetString("password")
+	if password == "" {
+		password = os.Getenv("GADS_PASSWORD")
+	}
+	if password == "" {
+		log.Fatal("password is required: use --password flag or GADS_PASSWORD env var")
+	}
 	localPort, _ := flags.GetInt("port")
 
 	hub = strings.TrimRight(hub, "/")
@@ -197,10 +205,13 @@ func wsErrorToMessage(err error) error {
 }
 
 func authenticate(hub, username, password string) (string, error) {
-	body := fmt.Sprintf(`{"username":"%s","password":"%s"}`, username, password)
-	resp, err := http.Post(hub+"/authenticate", "application/json", strings.NewReader(body))
+	payload, err := json.Marshal(map[string]string{"username": username, "password": password})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to encode credentials: %w", err)
+	}
+	resp, err := http.Post(hub+"/authenticate", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("Failed to post to authenticate endpoint - %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/client/adb/adb.go
+++ b/client/adb/adb.go
@@ -1,0 +1,225 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package adb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/spf13/pflag"
+)
+
+func Start(flags *pflag.FlagSet) {
+	log.SetFlags(log.Ldate | log.Ltime)
+
+	hub, _ := flags.GetString("hub")
+	udid, _ := flags.GetString("udid")
+	username, _ := flags.GetString("username")
+	password, _ := flags.GetString("password")
+	localPort, _ := flags.GetInt("port")
+
+	hub = strings.TrimRight(hub, "/")
+
+	// Authenticate
+	token, err := authenticate(hub, username, password)
+	if err != nil {
+		log.Fatalf("Authentication failed: %v", err)
+	}
+	log.Println("Authenticated successfully")
+
+	// Open local TCP listener
+	listenAddr := fmt.Sprintf("localhost:%d", localPort)
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		log.Fatalf("Failed to listen on %s: %v", listenAddr, err)
+	}
+
+	actualPort := ln.Addr().(*net.TCPAddr).Port
+	adbAddr := fmt.Sprintf("localhost:%d", actualPort)
+
+	// Handle shutdown via signal or tunnel loss
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Build WebSocket URL
+	wsScheme := "ws"
+	if strings.HasPrefix(hub, "https") {
+		wsScheme = "wss"
+	}
+	parsedHub, err := url.Parse(hub)
+	if err != nil {
+		log.Fatalf("Invalid hub URL: %v", err)
+	}
+
+	wsURL := url.URL{
+		Scheme: wsScheme,
+		Host:   parsedHub.Host,
+		Path:   fmt.Sprintf("/devices/control/%s/adb-tunnel", udid),
+	}
+
+	log.Printf("ADB tunnel listening on %s", adbAddr)
+
+	// Verify the tunnel works before connecting ADB
+	log.Println("Verifying ADB tunnel connectivity...")
+	if err := verifyTunnel(ctx, wsURL.String(), token); err != nil {
+		log.Fatalf("ADB tunnel not available: %v", err)
+	}
+	log.Println("ADB tunnel verified, connecting adb...")
+
+	// Connect ADB after a short delay to let the accept loop start
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		out, err := exec.Command("adb", "connect", adbAddr).CombinedOutput()
+		result := strings.TrimSpace(string(out))
+		if err != nil || !strings.Contains(result, "connected") {
+			log.Printf("Warning: adb connect failed: %s", result)
+			return
+		}
+		log.Printf("adb connect: %s", result)
+	}()
+
+	// Cleanup on context cancellation
+	go func() {
+		<-ctx.Done()
+		log.Println("Shutting down...")
+		ln.Close()
+
+		if err := exec.Command("adb", "disconnect", adbAddr).Run(); err != nil {
+			log.Printf("Warning: failed to adb disconnect %s: %v", adbAddr, err)
+		} else {
+			log.Printf("Disconnected adb from %s", adbAddr)
+		}
+	}()
+
+	// Accept connections
+	for {
+		tcpConn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				log.Printf("Accept error: %v", err)
+				continue
+			}
+		}
+		go handleConnection(ctx, cancel, tcpConn, wsURL.String(), token)
+	}
+}
+
+func verifyTunnel(ctx context.Context, wsURL string, token string) error {
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + token},
+		}),
+	}
+
+	conn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err != nil {
+		return wsErrorToMessage(err)
+	}
+	conn.Close()
+	return nil
+}
+
+func handleConnection(ctx context.Context, shutdown context.CancelFunc, tcpConn net.Conn, wsURL string, token string) {
+	defer tcpConn.Close()
+
+	dialer := ws.Dialer{
+		Header: ws.HandshakeHeaderHTTP(http.Header{
+			"Authorization": []string{"Bearer " + token},
+		}),
+	}
+
+	wsConn, _, _, err := dialer.Dial(ctx, wsURL)
+	if err != nil {
+		// If the tunnel is rejected (session ended, auth failed, etc.), shut down the client
+		friendlyErr := wsErrorToMessage(err)
+		log.Printf("Remote control session lost: %v", friendlyErr)
+		shutdown()
+		return
+	}
+	defer wsConn.Close()
+
+	log.Println("ADB connection established")
+
+	done := make(chan struct{})
+
+	go func() {
+		io.Copy(wsConn, tcpConn)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		io.Copy(tcpConn, wsConn)
+		done <- struct{}{}
+	}()
+
+	<-done
+	log.Println("ADB connection closed")
+}
+
+func wsErrorToMessage(err error) error {
+	errMsg := err.Error()
+	switch {
+	case strings.Contains(errMsg, "409"):
+		return fmt.Errorf("device requires an active remote control session - open the device in the web UI first")
+	case strings.Contains(errMsg, "401"):
+		return fmt.Errorf("authentication failed - check your credentials")
+	case strings.Contains(errMsg, "400"):
+		return fmt.Errorf("bad request - device not found or not an Android device")
+	case strings.Contains(errMsg, "422"):
+		return fmt.Errorf("device is not available")
+	case strings.Contains(errMsg, "502"):
+		return fmt.Errorf("hub could not connect to provider - check if the provider is running")
+	default:
+		return err
+	}
+}
+
+func authenticate(hub, username, password string) (string, error) {
+	body := fmt.Sprintf(`{"username":"%s","password":"%s"}`, username, password)
+	resp, err := http.Post(hub+"/authenticate", "application/json", strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("auth returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Success bool `json:"success"`
+		Result  struct {
+			AccessToken string `json:"access_token"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode auth response: %v", err)
+	}
+	if result.Result.AccessToken == "" {
+		return "", fmt.Errorf("no access_token in auth response")
+	}
+	return result.Result.AccessToken, nil
+}

--- a/common/db/generic.go
+++ b/common/db/generic.go
@@ -28,7 +28,7 @@ func GetDocuments[T any](ctx context.Context, coll *mongo.Collection, filter int
 	}
 	defer cursor.Close(ctx)
 
-	var results []T
+	var results = make([]T, 0)
 	if err := cursor.All(ctx, &results); err != nil {
 		return nil, err
 	}

--- a/common/models/responses.go
+++ b/common/models/responses.go
@@ -13,8 +13,8 @@ package models
 // Use the concrete type aliases below for Swagger annotations.
 type APIResponse[T any] struct {
 	Success bool   `json:"success" example:"true"`
-	Message string `json:"message,omitempty" example:"Operation completed successfully"`
-	Result  T      `json:"result,omitempty"`
+	Message string `json:"message" example:"Operation completed successfully"`
+	Result  T      `json:"result"`
 }
 
 // Page is a generic paginated result wrapper.

--- a/docs/adb-client.md
+++ b/docs/adb-client.md
@@ -1,0 +1,18 @@
+# Android adb-client
+
+## Overview
+
+GADS allows you to connect Android devices to your local `adb` instance for debugging and development. Communication is authenticated and goes through the hub.
+
+## Usage
+
+1. Log in to the hub web interface and start remotely controlling an available Android device.
+2. Start the Android client adb tunnel with `./GADS adb-tunnel --hub={GADS hub address} --username={GADS username} --password={GADS password} --udid={device-udid}`, e.g. `./GADS adb-tunnel --hub=http://192.168.1.24:10000 --username=admin --password=password --udid=ABC123`.
+3. Wait for the tunnel connection to be established.
+4. Run `adb devices` - you should see the device connected - you can now use the device through Android Studio for example for live development and debugging of applications.
+
+## Notes
+
+- You can only create tunnel to devices that are currently being remotely controlled by you.
+- Stopping the remote control of the device through the hub interface will also drop the tunnel connection.
+- Stopping the adb client will not drop your remote control session.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -1,61 +1,65 @@
 # Hub Setup
+
 Unless you are building from source, running the hub does not require any additional dependencies except a running MongoDB instance.
 
 ## IMPORTANT
-This is only hub/UI, to actually have devices available you need to have at least one [**provider**](./provider.md) instance running on the same host (or another host on the same network) that will actually set up and provision devices.   
+
+This is only hub/UI, to actually have devices available you need to have at least one [**provider**](./provider.md) instance running on the same host (or another host on the same network) that will actually set up and provision devices.  
 Follow the setup steps to create and run a provider instance.  
-You can have multiple provider instances on different hosts providing devices.  
+You can have multiple provider instances on different hosts providing devices.
 
 ## Starting hub instance
+
 Run `./GADS hub` with the following flags:
-- `--host-address=` - local IP address of the host machine, e.g. `192.168.1.6` (default is `localhost`, I would advise against using the default value)  
-- `--port=` - port on which the UI and backend service will be served  
-- `--auth=` - enable/disable authentication. When disabled you can access any UI page/hub endpoint without login token validation, note that this is **highly insecure** and should be used only for development - `true/false` 
+
+- `--host-address=` - local IP address of the host machine, e.g. `192.168.1.6` (default is `localhost`, I would advise against using the default value)
+- `--port=` - port on which the UI and backend service will be served
+- `--auth=` - enable/disable authentication. When disabled you can access any UI page/hub endpoint without login token validation, note that this is **highly insecure** and should be used only for development - `true/false`
 - `--mongo-db=` - IP address and port of the MongoDB instance, e.g `192.168.1.6:27017` (default is `localhost:27017`) - tested only on local network
 - `--files-dir=` - directory where the UI static files will be unpacked and served from. By default the app tries to use a temporary folder available on the host automatically. **NB** Use this flag only if you have issues with the default behaviour.
 
 Then access the hub UI and API on `http://{host-address}:{port}`
 
 ## UI development
+
 If you want to work on the React UI with hot reload you need to add a proxy in `package.json` to point to the Go backend
+
 1. Open the `hub/gads-ui` folder.
 2. Open the `package-json` file.
 3. Add a new field `"proxy": "http://192.168.1.28:10000/"` providing the host and port of the Go backend service.
 4. Run `npm start`
 
 ## Additional notes
+
 ### Users administration
+
 You can add/delete users and change their roles/passwords via the `Admin` panel.  
 There are no limitations on usernames and passwords - only the default `admin` user cannot be deleted and its role changed(you can change its password though)
 
 ### Providers administration
+
 For each provider instance you need to create a provider configuration via the `Admin` panel.  
 All fields have tooltips to help you with the required information.
 
 ### Devices administration
+
 Device configurations are added via the `Admin` panel.  
 You have to provide all the required information and assign each device to a provider.  
 Changes to the device configuration require the respective provider instance restarted.  
 All fields have tooltips to help you with the required information.
 
 ### Experimental Appium grid
+
 Using Selenium Grid 4 is a bit of a hassle and some versions do not work properly with Appium relay nodes.  
 For this reason I created an experimental grid implementation into the hub itself.  
 I haven't even read the Selenium Grid implementation and made up something myself - it might not work properly but could be the better alternative if it does work properly.  
-The experimental grid was tested only using latest Appium and Selenium Java client versions and with TestNG. Tests can be executed sequentially or in parallel using TestNG with `methods` or `classes` with multiple threads. I assume it should support any type of session creation with any Appium language client  
+The experimental grid was tested only using latest Appium and Selenium Java client versions and with TestNG. Tests can be executed sequentially or in parallel using TestNG with `methods` or `classes` with multiple threads. I assume it should support any type of session creation with any Appium language client
 
-* The grid is accessible on your hub instance e.g. `http://192.168.1.6:10000/grid` and should be used as Appium/Selenium driver URL target. You just try to start a session as you usually do with Selenium Grid
-* The grid allows targeting devices by UDID
-* The grid allows targeting devices by `platformName`(iOS or Android) or `appium:automationName`(XCUITest or UiAutomator2) capabilities during session creation
-  * Additionally the grid allows filtering by `appium:platformVersion` capability which supports exact version e.g. `17.5.1` or a major version e.g. `17`, `11` etc
+- The grid is accessible on your hub instance e.g. `http://192.168.1.6:10000/grid` and should be used as Appium/Selenium driver URL target. You just try to start a session as you usually do with Selenium Grid
+- The grid allows targeting devices by UDID
+- The grid allows targeting devices by `platformName`(iOS or Android) or `appium:automationName`(XCUITest or UiAutomator2) capabilities during session creation
+  - Additionally the grid allows filtering by `appium:platformVersion` capability which supports exact version e.g. `17.5.1` or a major version e.g. `17`, `11` etc
 
-### Selenium Grid
-Devices can be automatically connected to Selenium Grid 4 instance.  
-You need to create the Selenium Grid hub instance yourself and then set it up in the provider configuration to connect to it.  
-* Start your Selenium hub instance, e.g. `java -jar selenium.jar --host 192.168.1.6 --port 4444`
-* When adding/updating provider configuration from `Admin > Provider` you need to supply the Selenium hub address, e.g. `http://192.168.1.6:4444`
-* You also need to upload the respective Selenium jar file so the provider instances have access to it
-  * Log in to the hub with admin user, go to `Admin > Files` and upload the Selenium jar file - v4.13 is recommended.  
-  * The file will be stored in Mongo and providers will download it on start automatically.
+### Android devices remote control debugging
 
-**NB** At the time support for Selenium Grid was implemented latest Selenium version was 4.15. The latest version that actually worked with Appium relay nodes was 4.13. I haven't tested with lower versions. Use lower versions at your own risk. Versions > 4.15 might also work but it wasn't tested as well.
+GADS allows you to create an adb tunnel to a remotely controlled Android device for local development and debugging - find more information on usage [here](./adb-client.md)

--- a/hub/router/adb_tunnel.go
+++ b/hub/router/adb_tunnel.go
@@ -1,0 +1,124 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/hub/auth"
+	"GADS/hub/devices"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gobwas/ws"
+)
+
+func ADBTunnelHandler(c *gin.Context) {
+	udid := c.Param("udid")
+
+	var username string
+	if claims, err := auth.GetClaimsFromRequest(c); err == nil {
+		username = claims.Username
+	}
+
+	device, ok := devices.HubDeviceStore.Get(udid)
+	if !ok || device == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Device with UDID `%s` not found", udid)})
+		return
+	}
+
+	device.Mu.RLock()
+
+	if device.Device.OS != "android" {
+		device.Mu.RUnlock()
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ADB tunnel is only available for Android devices"})
+		return
+	}
+
+	// ADB tunnel is only allowed when the device is actively used from remote control by this user
+	if !device.HasUISession() || device.InUseBy != username {
+		device.Mu.RUnlock()
+		c.JSON(http.StatusConflict, gin.H{"error": "ADB tunnel requires an active remote control session on this device"})
+		return
+	}
+	host := device.Host
+	device.Mu.RUnlock()
+
+	// Connect to provider's ADB tunnel WebSocket
+	providerURL := url.URL{
+		Scheme: "ws",
+		Host:   host,
+		Path:   fmt.Sprintf("/device/%s/adb-tunnel", udid),
+	}
+
+	providerConn, _, _, err := ws.DefaultDialer.Dial(context.Background(), providerURL.String())
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Failed to connect to provider ADB tunnel - %s", err)})
+		return
+	}
+
+	// Upgrade client connection to WebSocket
+	clientConn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
+	if err != nil {
+		providerConn.Close()
+		return
+	}
+
+	defer func() {
+		clientConn.Close()
+		providerConn.Close()
+	}()
+
+	// Monitor: close the tunnel if the remote control session ends
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				device.Mu.RLock()
+				active := device.HasUISession() && device.InUseBy == username
+				device.Mu.RUnlock()
+				if !active {
+					// Remote control session ended, close the tunnel
+					clientConn.Close()
+					providerConn.Close()
+					return
+				}
+			}
+		}
+	}()
+
+	// Bidirectional relay: client WebSocket <-> provider WebSocket
+	done := make(chan struct{})
+
+	go func() {
+		io.Copy(providerConn, clientConn)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		io.Copy(clientConn, providerConn)
+		done <- struct{}{}
+	}()
+
+	<-done
+	clientConn.Close()
+	providerConn.Close()
+	<-done
+}

--- a/hub/router/adb_tunnel.go
+++ b/hub/router/adb_tunnel.go
@@ -26,10 +26,12 @@ import (
 func ADBTunnelHandler(c *gin.Context) {
 	udid := c.Param("udid")
 
-	var username string
-	if claims, err := auth.GetClaimsFromRequest(c); err == nil {
-		username = claims.Username
+	claims, err := auth.GetClaimsFromRequest(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return
 	}
+	username := claims.Username
 
 	device, ok := devices.HubDeviceStore.Get(udid)
 	if !ok || device == nil {

--- a/hub/router/adb_tunnel.go
+++ b/hub/router/adb_tunnel.go
@@ -105,7 +105,7 @@ func ADBTunnelHandler(c *gin.Context) {
 	}()
 
 	// Bidirectional relay: client WebSocket <-> provider WebSocket
-	done := make(chan struct{})
+	done := make(chan struct{}, 2)
 
 	go func() {
 		io.Copy(providerConn, clientConn)

--- a/hub/router/handler.go
+++ b/hub/router/handler.go
@@ -101,6 +101,7 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	authGroup.GET("/appium-logs", GetAppiumLogs)
 	authGroup.GET("/health", HealthCheck)
 	authGroup.POST("/logout", auth.LogoutHandler)
+	authGroup.GET("/devices/control/:udid/adb-tunnel", ADBTunnelHandler)
 	authGroup.Any("/device/:udid/*path", DeviceProxyHandler)
 	authGroup.Any("/provider/:name/*path", ProviderProxyHandler)
 	authGroup.GET("/admin/providers", GetProviders)

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -260,10 +260,7 @@ func DeleteUser(c *gin.Context) {
 // @Router       /admin/providers [get]
 func GetProviders(c *gin.Context) {
 	providers, _ := db.GlobalMongoStore.GetAllProviders()
-	if len(providers) == 0 {
-		api.OK(c, "", []models.Provider{})
-		return
-	}
+
 	api.OK(c, "", providers)
 }
 
@@ -599,7 +596,7 @@ func AvailableDevicesSSE(c *gin.Context) {
 	}
 
 	c.Stream(func(w io.Writer) bool {
-		var deviceList []*devices.LocalHubDevice
+		var deviceList = make([]*devices.LocalHubDevice, 0)
 
 		for _, d := range devices.HubDeviceStore.AllSorted() {
 			d.Mu.Lock()
@@ -830,7 +827,7 @@ func DeleteDevice(c *gin.Context) {
 }
 
 type AdminDeviceData struct {
-	Devices           []models.DBDevice     `json:"devices"`
+	Devices           []models.DBDevice   `json:"devices"`
 	Providers         []string            `json:"providers"`
 	DeviceStreamTypes []models.StreamType `json:"device_stream_types"`
 }
@@ -912,7 +909,6 @@ type lockDeviceResponse struct {
 	Tenant      string `json:"tenant"`
 	ExpiresAtMS int64  `json:"expires_at_ms"`
 }
-
 
 // LockDevice godoc
 // @Summary      Lock a device via REST API

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"GADS/client/adb"
 	"GADS/hub"
 	"GADS/provider"
 	"embed"
@@ -60,6 +61,25 @@ func main() {
 	providerCmd.Flags().String("turn-username-suffix", "gads", "Suffix to append to TURN usernames (format: timestamp:suffix)")
 	providerCmd.Flags().Bool("use-ios-pair-cache", false, "Cache iOS pair records on disk to skip Trust dialog on reconnect (for unsupervised devices)")
 	rootCmd.AddCommand(providerCmd)
+
+	// ADB Client Command
+	var adbClientCmd = &cobra.Command{
+		Use:   "adb-client",
+		Short: "Connect to a remote Android device via ADB tunnel through the hub",
+		Run: func(cmd *cobra.Command, args []string) {
+			adb.Start(cmd.Flags())
+		},
+	}
+	adbClientCmd.Flags().String("hub", "", "Hub URL (e.g. http://localhost:10000)")
+	adbClientCmd.Flags().String("udid", "", "Device UDID to tunnel")
+	adbClientCmd.Flags().String("username", "", "GADS username")
+	adbClientCmd.Flags().String("password", "", "GADS password")
+	adbClientCmd.Flags().Int("port", 0, "Local port to listen on (0 = auto)")
+	adbClientCmd.MarkFlagRequired("hub")
+	adbClientCmd.MarkFlagRequired("udid")
+	adbClientCmd.MarkFlagRequired("username")
+	adbClientCmd.MarkFlagRequired("password")
+	rootCmd.AddCommand(adbClientCmd)
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -43,6 +43,7 @@ type AndroidDevice struct {
 	StreamPort              string // host port forwarded to device port 1991 (video stream)
 	AndroidIMEPort          string // host port forwarded to device port 1993 (IME keyboard)
 	AndroidRemoteServerPort string // host port forwarded to device port 1994 (remote control server)
+	ADBPort                 string // host port forwarded to device adbd port 5555 (ADB tunnel)
 }
 
 var remoteServerNetClient = &http.Client{
@@ -53,6 +54,7 @@ var remoteServerNetClient = &http.Client{
 func (d *AndroidDevice) GetStreamPort() string              { return d.StreamPort }
 func (d *AndroidDevice) GetAndroidIMEPort() string          { return d.AndroidIMEPort }
 func (d *AndroidDevice) GetAndroidRemoteServerPort() string { return d.AndroidRemoteServerPort }
+func (d *AndroidDevice) GetADBPort() string                 { return d.ADBPort }
 
 // Setup runs the full Android device provisioning sequence.
 func (d *AndroidDevice) Setup() error {
@@ -72,6 +74,9 @@ func (d *AndroidDevice) Setup() error {
 	}
 	if err := d.allocatePorts(); err != nil {
 		return d.resetWithError("allocate free host ports", err)
+	}
+	if err := d.enableADBTCPMode(); err != nil {
+		return d.resetWithError("enable ADB TCP mode", err)
 	}
 	if err := d.cleanupOldApps(); err != nil {
 		return err // already reset inside cleanupOldApps
@@ -131,6 +136,12 @@ func (d *AndroidDevice) allocatePorts() error {
 		return fmt.Errorf("could not allocate free host port for GADS Android remote control server - %w", err)
 	}
 	d.AndroidRemoteServerPort = remoteServerPort
+
+	adbPort, err := providerutil.GetFreePort()
+	if err != nil {
+		return fmt.Errorf("could not allocate free host port for ADB tunnel - %w", err)
+	}
+	d.ADBPort = adbPort
 	return nil
 }
 
@@ -220,6 +231,13 @@ func (d *AndroidDevice) forwardAndSetupPorts() error {
 		d.Reset("Failed to forward GADS Android Settings port to host port.")
 		return err
 	}
+
+	// Forward ADB port for remote ADB tunnel
+	if err := d.forwardADB(); err != nil {
+		logger.ProviderLogger.LogError("android_device_setup", fmt.Sprintf("Could not forward ADB port for Android device `%v` - %v", d.GetUDID(), err))
+		d.Reset("Failed to forward ADB port to host port.")
+		return err
+	}
 	return nil
 }
 
@@ -265,6 +283,7 @@ func (d *AndroidDevice) Reset(reason string) {
 		delete(providerutil.UsedPorts, d.StreamPort)
 		delete(providerutil.UsedPorts, d.AndroidIMEPort)
 		delete(providerutil.UsedPorts, d.AndroidRemoteServerPort)
+		delete(providerutil.UsedPorts, d.ADBPort)
 		common.MutexManager.LocalDevicePorts.Unlock()
 	}
 }
@@ -422,6 +441,32 @@ func (d *AndroidDevice) forwardIME() error {
 
 func (d *AndroidDevice) forwardRemoteServer() error {
 	return d.forwardPort("1994", d.AndroidRemoteServerPort)
+}
+
+func (d *AndroidDevice) enableADBTCPMode() error {
+	// Check if tcpip mode is already enabled to avoid restarting adbd unnecessarily
+	checkCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "getprop", "service.adb.tcp.port")
+	var outBuffer bytes.Buffer
+	checkCmd.Stdout = &outBuffer
+	if err := checkCmd.Run(); err == nil {
+		if strings.TrimSpace(outBuffer.String()) == "5555" {
+			logger.ProviderLogger.LogInfo("android_device_setup", fmt.Sprintf("ADB TCP mode already enabled on device `%v`, skipping", d.GetUDID()))
+			return nil
+		}
+	}
+
+	logger.ProviderLogger.LogInfo("android_device_setup", fmt.Sprintf("Enabling ADB TCP mode on device `%v`", d.GetUDID()))
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "tcpip", "5555")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("enableADBTCPMode: Error executing `%s` - %s", cmd.Args, err)
+	}
+	// Wait for adbd to restart and USB to reconnect
+	time.Sleep(2 * time.Second)
+	return nil
+}
+
+func (d *AndroidDevice) forwardADB() error {
+	return d.forwardPort("5555", d.ADBPort)
 }
 
 func (d *AndroidDevice) updateScreenSizeADB() error {

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -46,6 +46,8 @@ type AndroidDevice struct {
 	ADBPort                 string // host port forwarded to device adbd port 5555 (ADB tunnel)
 }
 
+const adbTCPPort = "5555"
+
 var remoteServerNetClient = &http.Client{
 	Timeout: time.Second * 120,
 }
@@ -449,14 +451,14 @@ func (d *AndroidDevice) enableADBTCPMode() error {
 	var outBuffer bytes.Buffer
 	checkCmd.Stdout = &outBuffer
 	if err := checkCmd.Run(); err == nil {
-		if strings.TrimSpace(outBuffer.String()) == "5555" {
+		if strings.TrimSpace(outBuffer.String()) == adbTCPPort {
 			logger.ProviderLogger.LogInfo("android_device_setup", fmt.Sprintf("ADB TCP mode already enabled on device `%v`, skipping", d.GetUDID()))
 			return nil
 		}
 	}
 
 	logger.ProviderLogger.LogInfo("android_device_setup", fmt.Sprintf("Enabling ADB TCP mode on device `%v`", d.GetUDID()))
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "tcpip", "5555")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "tcpip", adbTCPPort)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("enableADBTCPMode: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -466,7 +468,7 @@ func (d *AndroidDevice) enableADBTCPMode() error {
 }
 
 func (d *AndroidDevice) forwardADB() error {
-	return d.forwardPort("5555", d.ADBPort)
+	return d.forwardPort(adbTCPPort, d.ADBPort)
 }
 
 func (d *AndroidDevice) updateScreenSizeADB() error {

--- a/provider/router/adb_tunnel.go
+++ b/provider/router/adb_tunnel.go
@@ -1,0 +1,86 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/provider/devices"
+	"GADS/provider/logger"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gobwas/ws"
+)
+
+func ADBTunnelProxy(c *gin.Context) {
+	udid := c.Param("udid")
+	platDev, ok := devices.DevManager.Get(udid)
+	if !ok {
+		logger.ProviderLogger.LogError("ADBTunnelProxy", fmt.Sprintf("Device with UDID `%s` not found", udid))
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	androidDev, ok := platDev.(*devices.AndroidDevice)
+	if !ok {
+		logger.ProviderLogger.LogError("ADBTunnelProxy", fmt.Sprintf("Device `%s` is not an Android device", udid))
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	adbPort := androidDev.GetADBPort()
+	if adbPort == "" {
+		logger.ProviderLogger.LogError("ADBTunnelProxy", fmt.Sprintf("ADB port not allocated for device `%s`", udid))
+		c.AbortWithStatus(http.StatusServiceUnavailable)
+		return
+	}
+
+	// Connect to the local ADB forwarded port
+	adbConn, err := net.Dial("tcp", "localhost:"+adbPort)
+	if err != nil {
+		logger.ProviderLogger.LogError("ADBTunnelProxy", fmt.Sprintf("Failed to connect to ADB port for device `%s` - %s", udid, err))
+		c.AbortWithStatus(http.StatusServiceUnavailable)
+		return
+	}
+
+	// Upgrade the HTTP connection to WebSocket
+	wsConn, _, _, err := ws.UpgradeHTTP(c.Request, c.Writer)
+	if err != nil {
+		logger.ProviderLogger.LogError("ADBTunnelProxy", fmt.Sprintf("Failed to upgrade to WebSocket for device `%s` - %s", udid, err))
+		adbConn.Close()
+		return
+	}
+
+	logger.ProviderLogger.LogInfo("ADBTunnelProxy", fmt.Sprintf("ADB tunnel established for device `%s`", udid))
+
+	// Bidirectional relay: WebSocket <-> ADB TCP
+	done := make(chan struct{})
+
+	go func() {
+		io.Copy(adbConn, wsConn)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		io.Copy(wsConn, adbConn)
+		done <- struct{}{}
+	}()
+
+	// Wait for either direction to finish
+	<-done
+	wsConn.Close()
+	adbConn.Close()
+	// Wait for the other goroutine to finish
+	<-done
+
+	logger.ProviderLogger.LogInfo("ADBTunnelProxy", fmt.Sprintf("ADB tunnel closed for device `%s`", udid))
+}

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -66,6 +66,7 @@ func HandleRequests() *gin.Engine {
 	deviceGroup.POST("/typeText", DeviceTypeText)
 	deviceGroup.GET("/getClipboard", DeviceGetClipboard)
 	deviceGroup.Any("/appium/*proxyPath", AppiumReverseProxy)
+	deviceGroup.GET("/adb-tunnel", ADBTunnelProxy)
 	deviceGroup.GET("/android-stream", AndroidStreamProxy)
 	deviceGroup.GET("/android-stream-mjpeg", AndroidStreamMJPEG)
 	deviceGroup.POST("/update-stream-settings", UpdateDeviceStreamSettings)


### PR DESCRIPTION
Add a new CLI option `adb-client` that allows you to connect a remotely controlled Android device over adb tunnel to your local PC for development and debugging. Readme has been updated with relevant information on usage

**Note:**
You can use the `adb-client` like this - `./GADS adb-client --hub={hub url} --username={GADS username} --password={GADS password} --udid={device udid}`, e.g. `./GADS adb-client --hub=http://192.168.1.24:10000 --username=admin --password=password --udid=123ABC`. You can only connect devices that are currently being remotely controlled by you.