### PR TITLE
Add recent apps endpoint

### DIFF
--- a/provider/router/control.go
+++ b/provider/router/control.go
@@ -289,6 +289,14 @@ func deviceHome(dev devices.PlatformDevice) (*http.Response, error) {
 	}
 }
 
+func deviceRecents(dev devices.PlatformDevice) error {
+	if dev.GetOS() == "ios" {
+		return fmt.Errorf("App switcher not supported on iOS via WDA")
+	}
+	cmd := exec.CommandContext(dev.GetContext(), "adb", "-s", dev.GetUDID(), "shell", "input", "keyevent", "KEYCODE_APP_SWITCH")
+	return cmd.Run()
+}
+
 func activateApp(dev devices.PlatformDevice, appIdentifier string) (*http.Response, error) {
 	if dev.GetOS() == "ios" {
 		requestBody := struct {

--- a/provider/router/device_routes.go
+++ b/provider/router/device_routes.go
@@ -86,6 +86,24 @@ func DeviceHome(c *gin.Context) {
 	c.JSON(homeResponse.StatusCode, models.APIResponse[any]{Success: homeResponse.StatusCode < 400, Message: string(homeResponseBody)})
 }
 
+func DeviceRecents(c *gin.Context) {
+	udid := c.Param("udid")
+	platDev, ok := devices.DevManager.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with UDID %s not found", udid))
+		return
+	}
+	platDev.GetLogger().LogInfo("appium_interact", "Opening Recent Apps")
+
+	if err := deviceRecents(platDev); err != nil {
+		platDev.GetLogger().LogError("appium_interact", fmt.Sprintf("Failed to open Recent Apps - %s", err))
+		api.InternalError(c, err.Error())
+		return
+	}
+
+	api.OKMessage(c, "Recent Apps opened")
+}
+
 func DeviceGetClipboard(c *gin.Context) {
 	udid := c.Param("udid")
 	platDev, ok := devices.DevManager.Get(udid)

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -57,6 +57,7 @@ func HandleRequests() *gin.Engine {
 	deviceGroup.POST("/tap", DeviceTap)
 	deviceGroup.POST("/touchAndHold", DeviceTouchAndHold)
 	deviceGroup.POST("/home", DeviceHome)
+	deviceGroup.POST("/recents", DeviceRecents)
 	deviceGroup.POST("/lock", DeviceLock)
 	deviceGroup.POST("/unlock", DeviceUnlock)
 	deviceGroup.POST("/screenshot", DeviceScreenshot)


### PR DESCRIPTION
## Summary 

- Adds `POST /device/:udid/recents` endpoint to the provider
- On Android: triggers app switcher via `adb shell input keyevent KEYCODE_APP_SWITCH`                                                                                             
- Error message is propagated to the API response body for client consumption

resolve #280