### PR TITLE
Fix(cli): Rename adb-client command to adb-tunnel for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The platform architecture consists of two main components:
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
 - 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
-- 🎮 **Local debugging - Android only**: [Connect](./docs/adb-client.md) remotely controlled Android device to your local `adb` instance for development and debugging
+- 🎮 **Local debugging - Android only**: [Connect](./docs/adb-tunnel.md) remotely controlled Android device to your local `adb` instance for development and debugging
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
 - 🔑 **Flexible Authentication**: Support for multiple JWT issuers with origin-based keys
 - 🛠 **Easy Setup**: Simple installation and configuration process
@@ -61,7 +61,7 @@ The platform architecture consists of two main components:
   - App installation/uninstallation
   - High-quality screenshots
   - Device reservation system
-  - Android devices remote debugging over `adb` [adb-client](./docs/adb-client.md)
+  - Android devices remote debugging over `adb` [adb-tunnel](./docs/adb-tunnel.md)
 - 🔄 **Backend Capabilities**
   - Web interface serving
   - Provider communication proxy

--- a/docs/adb-tunnel.md
+++ b/docs/adb-tunnel.md
@@ -1,4 +1,4 @@
-# Android adb-client
+# Android adb-tunnel
 
 ## Overview
 
@@ -15,4 +15,4 @@ GADS allows you to connect Android devices to your local `adb` instance for debu
 
 - You can only create tunnel to devices that are currently being remotely controlled by you.
 - Stopping the remote control of the device through the hub interface will also drop the tunnel connection.
-- Stopping the adb client will not drop your remote control session.
+- Stopping the adb tunnel will not drop your remote control session.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -62,4 +62,4 @@ The experimental grid was tested only using latest Appium and Selenium Java clie
 
 ### Android devices remote control debugging
 
-GADS allows you to create an adb tunnel to a remotely controlled Android device for local development and debugging - find more information on usage [here](./adb-client.md)
+GADS allows you to create an adb tunnel to a remotely controlled Android device for local development and debugging - find more information on usage [here](./adb-tunnel.md)

--- a/main.go
+++ b/main.go
@@ -62,24 +62,24 @@ func main() {
 	providerCmd.Flags().Bool("use-ios-pair-cache", false, "Cache iOS pair records on disk to skip Trust dialog on reconnect (for unsupervised devices)")
 	rootCmd.AddCommand(providerCmd)
 
-	// ADB Client Command
-	var adbClientCmd = &cobra.Command{
-		Use:   "adb-client",
+	// ADB Tunnel Command
+	var adbTunnelCmd = &cobra.Command{
+		Use:   "adb-tunnel",
 		Short: "Connect to a remote Android device via ADB tunnel through the hub",
 		Run: func(cmd *cobra.Command, args []string) {
 			adb.Start(cmd.Flags())
 		},
 	}
-	adbClientCmd.Flags().String("hub", "", "Hub URL (e.g. http://localhost:10000)")
-	adbClientCmd.Flags().String("udid", "", "Device UDID to tunnel")
-	adbClientCmd.Flags().String("username", "", "GADS username")
-	adbClientCmd.Flags().String("password", "", "GADS password")
-	adbClientCmd.Flags().Int("port", 0, "Local port to listen on (0 = auto)")
-	adbClientCmd.MarkFlagRequired("hub")
-	adbClientCmd.MarkFlagRequired("udid")
-	adbClientCmd.MarkFlagRequired("username")
-	adbClientCmd.MarkFlagRequired("password")
-	rootCmd.AddCommand(adbClientCmd)
+	adbTunnelCmd.Flags().String("hub", "", "Hub URL (e.g. http://localhost:10000)")
+	adbTunnelCmd.Flags().String("udid", "", "Device UDID to tunnel")
+	adbTunnelCmd.Flags().String("username", "", "GADS username")
+	adbTunnelCmd.Flags().String("password", "", "GADS password")
+	adbTunnelCmd.Flags().Int("port", 0, "Local port to listen on (0 = auto)")
+	adbTunnelCmd.MarkFlagRequired("hub")
+	adbTunnelCmd.MarkFlagRequired("udid")
+	adbTunnelCmd.MarkFlagRequired("username")
+	adbTunnelCmd.MarkFlagRequired("password")
+	rootCmd.AddCommand(adbTunnelCmd)
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
## Summary

The Cobra subcommand was registered as `adb-client`, but the rest of the codebase consistently uses `adb-tunnel`:

- HTTP endpoints: `/device/:udid/adb-tunnel`, `/devices/control/:udid/adb-tunnel`
- Router files: `hub/router/adb_tunnel.go`, `provider/router/adb_tunnel.go`
- Handler functions: `ADBTunnelHandler`, `ADBTunnelProxy`
- Usage examples in `docs/adb-client.md` already referenced `./GADS adb-tunnel`

As a result, following the docs literally fails:

```
$ ./GADS adb-tunnel --hub=... --udid=...
Error: unknown command "adb-tunnel" for "GADS"
```

## Changes

- `main.go`: rename Cobra command `adb-client` → `adb-tunnel` and variable `adbClientCmd` → `adbTunnelCmd`
- `docs/adb-client.md` → `docs/adb-tunnel.md` (git rename, history preserved)
- Update heading and closing note inside the doc
- Update links in `README.md` and `docs/hub.md`

No behavior changes — only renames. The documented usage now actually works.

## Test plan

- [x] `go build` succeeds
- [x] `./GADS adb-tunnel --help` shows the command
- [x] `./GADS adb-client` correctly errors with "unknown command"
- [x] All `adb-client` / `adbClient` references removed (verified via grep)