### PR TITLE
docs: fix macOS WDA IPA packaging and add Auto-Lock requirement

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,6 +10,9 @@
 - *When I start my provider WDA is in a install loop and I get the error: `Error accepting new connection accept tcp [::]:56505: use of closed network connection`*
     -   Make sure you've properly signed and created the uploaded [WebDriverAgent](./provider.md#prepare-webdriveragent-file---linux-windows) ipa
     -   In your provider config in GADS UI make sure you've provided proper bundle identifier for WebDriverAgent, e.g. `com.shamanec.WebDriverAgentRunner`
+- *[macOS] WebDriverAgent starts (I see "Automation Running" on the device) but immediately stops and the provider enters a loop, why?*
+    - The most common cause is the device **Auto-Lock** setting. When the screen locks, iOS drops the tunnel connection, which kills the WebDriverAgent process. Set `Settings > Display & Brightness > Auto-Lock` to **Never** on the test device.
+    - If Auto-Lock is already disabled, the IPA may have been packaged incorrectly. On macOS, the IPA **must** be created using `ditto` — using `cp`/`zip` breaks the code signature silently. See the [Build WebDriverAgent IPA](./provider.md#build-webdriveragent-ipa-file-manually-using-xcode) section.
 - *[macOS/Linux/Windows] I have a connected iOS device where WebDriverAgent installation/start up consistently fails, why?*
     - Make sure you've properly signed and created the uploaded [WebDriverAgent](./provider.md#prepare-webdriveragent-file---linux-windows) ipa
     - Observe the provider logs - if installation is failing, you will see the full `go-ios` command used by GADS to install the prepared WebDriverAgent ipa. Copy the command and try to run it from terminal without the provider. Observe and debug the output.

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -203,17 +203,28 @@ Fork is kept up to date with latest mainstream.
 #### Build WebDriverAgent IPA file manually using Xcode
 
 - Download the code from the `main` branch of my fork of [WebDriverAgent](https://github.com/shamanec/WebDriverAgent).
+- **macOS only**: ensure `xcode-select` points at the full Xcode app, not just Command Line Tools:
+  ```bash
+  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+  ```
 - Open `WebDriverAgent.xcodeproj` in Xcode.
-- Select signing profile for WebDriverAgentRunner. To do this go to: _Targets_, select WebDriverAgentRunner. There should be a field for assigning teams certificates to the target.
+- Select the `WebDriverAgentRunner` target → `Signing & Capabilities` tab.
+  - Enable **Automatically manage signing** and set your Team.
+  - Set the Bundle Identifier to something unique, e.g. `com.yourname.WebDriverAgentRunner`. Note this value — you will need to enter it as the **WDA bundle ID** in the provider configuration.
+- Plug in your iOS device and select it as the build destination in the Xcode toolbar (required for free Apple Developer accounts so the device UDID is included in the provisioning profile).
 - Select `Build > Clean build folder` (just in case)
-- Next build the application by selecting the `WebDriverAgentRunner` target and build for `Generic iOS Device`. Select `Product => Build for testing`. This will create a `Products/Debug-iphoneos` folder in the specified project directory.  
-   `Example`: **/Users/<username>/Library/Developer/Xcode/DerivedData/WebDriverAgent-dzxbpamuepiwamhdbyvyfkbecyer/Build/Products/Debug-iphoneos**
-- Navigate to the folder above and create an empty directory with the name `Payload`.
-- Copy the `.app` bundle inside the `Payload` folder
-- Compress the `Payload` directory into an archive (.zip file) and give it a new name with `.ipa` appended to the end of the file name.
+- Select `Product > Build For Testing`. This will create a `Products/Debug-iphoneos` folder under the DerivedData directory.  
+   `Example`: **/Users/<username>/Library/Developer/Xcode/DerivedData/WebDriverAgent-<hash>/Build/Products/Debug-iphoneos**
+- Navigate to that folder and package the IPA using `ditto` (macOS only). Using `cp`/`zip` will break the code signature:
+  ```bash
+  cd /Users/<username>/Library/Developer/Xcode/DerivedData/WebDriverAgent-<hash>/Build/Products/Debug-iphoneos
+  mkdir Payload
+  ditto WebDriverAgentRunner-Runner.app Payload/WebDriverAgentRunner-Runner.app
+  ditto -c -k --sequesterRsrc --keepParent Payload ~/Downloads/WebDriverAgent-signed.ipa
+  ```
 - **NB** iOS 17-17.3 Windows/Linux WebDriverAgent additional step
   - Open the `.app` bundle, navigate to `Frameworks` and delete the `XC*.framework` folders before moving it to `Payload`
-  - IPA has to be re-signed after that once again uzing any applicable tool
+  - IPA has to be re-signed after that once again using any applicable tool
 
 ## Device Notes
 
@@ -225,6 +236,13 @@ Developer mode needs to be enabled on iOS 16+ devices to allow `go-ios` usage ag
 
 - Open `Settings > Privacy & Security > Developer Mode`
 - Enable the toggle
+
+#### Disable Auto-Lock
+
+> **Required.** When the device screen locks, iOS drops the tunnel connection used by GADS, causing WebDriverAgent to crash and the provider to enter a setup loop.
+
+- Open `Settings > Display & Brightness > Auto-Lock`
+- Set to **Never**
 
 #### Supervise devices
 


### PR DESCRIPTION
- Replace cp/zip with ditto for IPA packaging on macOS — zip breaks code signing silently, causing installation to fail with signature errors
- Add xcode-select step to ensure xcodebuild uses full Xcode, not CLT
- Clarify that device must be connected during build for free Apple Developer accounts (device UDID must be in provisioning profile)
- Add Auto-Lock disable requirement under iOS device notes — screen lock drops the iOS tunnel connection and causes WDA to crash in a loop
- Add FAQ entry for the WDA Automation Running crash loop pattern