### PR TITLE
hub/router: raise LockDevice TTL cap to 6h and refactor UI timeout logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The platform architecture consists of two main components:
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
 - 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
-- 🎮 **Local debugging - Android only**: [Connect](./docs/adb-client.md) remotely controlled Android device to your local `adb` instance for development and debugging
+- 🎮 **Local debugging - Android only**: [Connect](./docs/adb-tunnel.md) remotely controlled Android device to your local `adb` instance for development and debugging
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
 - 🔑 **Flexible Authentication**: Support for multiple JWT issuers with origin-based keys
 - 🛠 **Easy Setup**: Simple installation and configuration process
@@ -61,7 +61,7 @@ The platform architecture consists of two main components:
   - App installation/uninstallation
   - High-quality screenshots
   - Device reservation system
-  - Android devices remote debugging over `adb` [adb-client](./docs/adb-client.md)
+  - Android devices remote debugging over `adb` [adb-tunnel](./docs/adb-tunnel.md)
 - 🔄 **Backend Capabilities**
   - Web interface serving
   - Provider communication proxy

--- a/docs/adb-tunnel.md
+++ b/docs/adb-tunnel.md
@@ -1,4 +1,4 @@
-# Android adb-client
+# Android adb-tunnel
 
 ## Overview
 
@@ -15,4 +15,4 @@ GADS allows you to connect Android devices to your local `adb` instance for debu
 
 - You can only create tunnel to devices that are currently being remotely controlled by you.
 - Stopping the remote control of the device through the hub interface will also drop the tunnel connection.
-- Stopping the adb client will not drop your remote control session.
+- Stopping the adb tunnel will not drop your remote control session.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -62,4 +62,4 @@ The experimental grid was tested only using latest Appium and Selenium Java clie
 
 ### Android devices remote control debugging
 
-GADS allows you to create an adb tunnel to a remotely controlled Android device for local development and debugging - find more information on usage [here](./adb-client.md)
+GADS allows you to create an adb tunnel to a remotely controlled Android device for local development and debugging - find more information on usage [here](./adb-tunnel.md)

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -35,6 +35,27 @@ var netClient = &http.Client{
 	Timeout: time.Second * 120,
 }
 
+const (
+	defaultLockTTLMinutes        = 10
+	maxLockTTLMinutes            = 360
+	deviceInUsePingInterval      = 5 * time.Second
+	deviceInUseInactivityTimeout = 30 * time.Minute
+)
+
+func normalizeLockTTLMinutes(ttl int) int {
+	if ttl <= 0 {
+		return defaultLockTTLMinutes
+	}
+	if ttl > maxLockTTLMinutes {
+		return maxLockTTLMinutes
+	}
+	return ttl
+}
+
+func isDeviceInUseSessionExpired(lastActionTS int64, now time.Time) bool {
+	return (now.UnixMilli() - lastActionTS) > deviceInUseInactivityTimeout.Milliseconds()
+}
+
 // HealthCheck godoc
 // @Summary      Health check endpoint
 // @Description  Check if the GADS hub is running and healthy
@@ -539,7 +560,7 @@ func DeviceInUseWS(c *gin.Context) {
 
 	// Goroutine: send pings every 5s and check for 30-min inactivity
 	go func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(deviceInUsePingInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -550,7 +571,7 @@ func DeviceInUseWS(c *gin.Context) {
 				lastActionTS := device.LastActionTS
 				device.Mu.RUnlock()
 
-				if (time.Now().UnixMilli() - lastActionTS) > (1800 * 1000) {
+				if isDeviceInUseSessionExpired(lastActionTS, time.Now()) {
 					ws.WriteFrame(conn, ws.NewCloseFrame(ws.NewCloseFrameBody(ws.StatusCode(4001), "session expired"))) //nolint:errcheck
 					cancel()
 					return
@@ -912,12 +933,12 @@ type lockDeviceResponse struct {
 
 // LockDevice godoc
 // @Summary      Lock a device via REST API
-// @Description  Acquire an exclusive lock on a device. Authenticate via Authorization header (Bearer token) or ?token= query param (raw token, no Bearer prefix). Optional ?ttl_minutes= (default 10, max 60). If locked by another user returns 409. Admins can take over any lock.
+// @Description  Acquire an exclusive lock on a device. Authenticate via Authorization header (Bearer token) or ?token= query param (raw token, no Bearer prefix). Optional ?ttl_minutes= (default 10, max 360). If locked by another user returns 409. Admins can take over any lock.
 // @Tags         Hub - Devices
 // @Produce      json
 // @Param        udid         path   string  true   "Device UDID"
 // @Param        token        query  string  false  "Raw JWT token (alternative to Authorization header)"
-// @Param        ttl_minutes  query  int     false  "Lock TTL in minutes (default 10, max 60)"
+// @Param        ttl_minutes  query  int     false  "Lock TTL in minutes (default 10, max 360)"
 // @Success      200   {object}  lockDeviceResponse
 // @Failure      401   {object}  models.ErrorResponse
 // @Failure      404   {object}  models.ErrorResponse
@@ -933,13 +954,8 @@ func LockDevice(c *gin.Context) {
 		return
 	}
 
-	ttl, _ := strconv.Atoi(c.DefaultQuery("ttl_minutes", "10"))
-	if ttl <= 0 {
-		ttl = 10
-	}
-	if ttl > 60 {
-		ttl = 60
-	}
+	ttl, _ := strconv.Atoi(c.DefaultQuery("ttl_minutes", strconv.Itoa(defaultLockTTLMinutes)))
+	ttl = normalizeLockTTLMinutes(ttl)
 
 	device, ok := devices.HubDeviceStore.Get(udid)
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -62,24 +62,24 @@ func main() {
 	providerCmd.Flags().Bool("use-ios-pair-cache", false, "Cache iOS pair records on disk to skip Trust dialog on reconnect (for unsupervised devices)")
 	rootCmd.AddCommand(providerCmd)
 
-	// ADB Client Command
-	var adbClientCmd = &cobra.Command{
-		Use:   "adb-client",
+	// ADB Tunnel Command
+	var adbTunnelCmd = &cobra.Command{
+		Use:   "adb-tunnel",
 		Short: "Connect to a remote Android device via ADB tunnel through the hub",
 		Run: func(cmd *cobra.Command, args []string) {
 			adb.Start(cmd.Flags())
 		},
 	}
-	adbClientCmd.Flags().String("hub", "", "Hub URL (e.g. http://localhost:10000)")
-	adbClientCmd.Flags().String("udid", "", "Device UDID to tunnel")
-	adbClientCmd.Flags().String("username", "", "GADS username")
-	adbClientCmd.Flags().String("password", "", "GADS password")
-	adbClientCmd.Flags().Int("port", 0, "Local port to listen on (0 = auto)")
-	adbClientCmd.MarkFlagRequired("hub")
-	adbClientCmd.MarkFlagRequired("udid")
-	adbClientCmd.MarkFlagRequired("username")
-	adbClientCmd.MarkFlagRequired("password")
-	rootCmd.AddCommand(adbClientCmd)
+	adbTunnelCmd.Flags().String("hub", "", "Hub URL (e.g. http://localhost:10000)")
+	adbTunnelCmd.Flags().String("udid", "", "Device UDID to tunnel")
+	adbTunnelCmd.Flags().String("username", "", "GADS username")
+	adbTunnelCmd.Flags().String("password", "", "GADS password")
+	adbTunnelCmd.Flags().Int("port", 0, "Local port to listen on (0 = auto)")
+	adbTunnelCmd.MarkFlagRequired("hub")
+	adbTunnelCmd.MarkFlagRequired("udid")
+	adbTunnelCmd.MarkFlagRequired("username")
+	adbTunnelCmd.MarkFlagRequired("password")
+	rootCmd.AddCommand(adbTunnelCmd)
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
Since the LockDevice endpoint may be used by CI pipelines, it seems appropriate to increase the maximum lock timeout.