### PR TITLE
Fix(webrtc): Fix iOS WebRTC stream freeze on WDA MJPEG stall and pipeline death

### DIFF
--- a/provider/router/ios_stream_webrtc.go
+++ b/provider/router/ios_stream_webrtc.go
@@ -647,15 +647,41 @@ func (s *WebRTCSession) writeH264ToTrack() {
 	}
 	frameDuration := time.Second / time.Duration(fps)
 
+	// Watchdog: if no H.264 frames arrive for 10s the WDA MJPEG stream has stalled
+	// without crashing. Cancel the context so the WebSocket handler closes the
+	// connection and the browser reconnects. 10s is safe — normal WDA hiccups are
+	// under 3s; anything longer is a real stall.
+	stallTimer := time.NewTimer(10 * time.Second)
+	defer stallTimer.Stop()
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
+		case <-stallTimer.C:
+			logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("No H.264 frames for 10s for device %s, closing stalled pipeline", s.device.UDID))
+			if s.ctx.Err() == nil {
+				s.cancel()
+			}
+			return
 		case h264Data, ok := <-h264Channel:
 			if !ok {
 				logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("H.264 channel closed for device %s", s.device.UDID))
+				// Cancel context to signal WebSocket handler to close the connection
+				if s.ctx.Err() == nil {
+					s.cancel()
+				}
 				return
 			}
+
+			// Reset stall watchdog on each successful frame
+			if !stallTimer.Stop() {
+				select {
+				case <-stallTimer.C:
+				default:
+				}
+			}
+			stallTimer.Reset(10 * time.Second)
 
 			// Write complete NAL unit to track
 			if err := s.videoTrack.WriteSample(media.Sample{
@@ -765,7 +791,13 @@ func (s *WebRTCSession) Close() {
 	}
 
 	if s.peerConnection != nil {
-		s.peerConnection.Close()
+		// Delay PeerConnection close so the WebSocket TCP close reaches the browser
+		// before DTLS teardown triggers ICE failure via UDP. Without this delay,
+		// the browser sees ICE fail before WebSocket onclose and doesn't reconnect.
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			s.peerConnection.Close()
+		}()
 	}
 
 	logger.ProviderLogger.LogInfo("stream_webrtc", fmt.Sprintf("Closed WebRTC session for device %s", s.device.UDID))
@@ -819,6 +851,12 @@ func IOSWebRTCSocket(c *gin.Context) {
 		wsutil.WriteServerText(conn, []byte(`{"type":"error","message":"Failed to start streaming"}`))
 		return
 	}
+
+	// Close WebSocket when pipeline dies to unblock ReadClientData and trigger session cleanup
+	go func() {
+		<-session.ctx.Done()
+		conn.Close()
+	}()
 
 	// Handle ICE candidates
 	session.OnICECandidate(func(candidate *webrtc.ICECandidate) {


### PR DESCRIPTION
## Summary

Two silent failure modes caused the iOS WebRTC stream to hang with a frozen video frame and no disconnect signal reaching the browser:

- **Pipeline death** (FFmpeg or WDA crash): streaming goroutines exit, but the WebSocket handler stays blocked on `ReadMessage` indefinitely — the browser never receives a close event and shows a frozen frame.
- **WDA MJPEG stall** (WDA alive, no frames): `NextPart()` blocks forever since the MJPEG multipart boundary never arrives — no H.264 output, but no error either, so the session appears connected while video is frozen.

## Changes

**`provider/router/ios_stream_webrtc.go`**

- Add a watcher goroutine in `IOSWebRTCSocket` that closes the WebSocket `conn` as soon as `session.ctx` is cancelled. This unblocks `ReadMessage` on pipeline death and causes the browser to receive a proper WebSocket close event.
- Add a 10-second stall watchdog (`stallTimer`) in `writeH264ToTrack()`. The timer resets on each successful H.264 frame; if it fires, `cancel()` is called to tear down the session via the same path as pipeline death.
- Delay `peerConnection.Close()` by 50ms inside `session.Close()`. The WebSocket close travels provider→hub→browser over TCP (two hops), while the DTLS `close_notify` goes direct provider→browser over UDP. Without the delay, the browser sees ICE failure before `WebSocket.onclose`, which confuses frontend disconnect handling.

## Test plan

- [x] `go build` succeeds on linux/amd64 and darwin/arm64
- [x] Normal session close (user navigates away): WebSocket closes cleanly, `connection state: closed` logged
- [x] WDA MJPEG stall: stallTimer fires after 10s, session tears down, browser receives WebSocket close before ICE failure
- [x] Pipeline death (FFmpeg killed): watcher goroutine closes WebSocket immediately, browser receives close event

## Note on UI auto-reconnect

Currently when the WebSocket closes (due to stall or pipeline death) the browser shows a frozen/black frame and the user has to manually refresh. It would be a nice improvement in `hub-ui` to detect WebSocket close + ICE failure and automatically attempt to reconnect once the device becomes available again (polling device status before re-initiating the WebRTC offer). This backend PR ensures the disconnect signals reach the browser correctly, which is a prerequisite for any future auto-reconnect logic on the frontend.