### PR TITLE
fix(provider): Add per-device exponential backoff for iOS setup retries

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"GADS/common"
@@ -41,6 +42,67 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	iosSetupBackoffBase = 10 * time.Second
+	iosSetupBackoffMax  = 60 * time.Second
+)
+
+type iosSetupBackoffState struct {
+	lastFailedAt        time.Time
+	consecutiveFailures int
+}
+
+var (
+	iosSetupBackoffMu sync.Mutex
+	iosSetupBackoffs  = map[string]*iosSetupBackoffState{}
+)
+
+// shouldAttemptIOSSetup returns false if the device is in cooldown after a recent
+// rapid setup failure, preventing a tight retry loop from overwhelming system resources.
+func shouldAttemptIOSSetup(udid string) bool {
+	iosSetupBackoffMu.Lock()
+	defer iosSetupBackoffMu.Unlock()
+	state, ok := iosSetupBackoffs[udid]
+	if !ok || state.consecutiveFailures == 0 {
+		return true
+	}
+	shifts := state.consecutiveFailures - 1
+	if shifts > 3 {
+		shifts = 3
+	}
+	delay := iosSetupBackoffBase << shifts
+	if delay > iosSetupBackoffMax {
+		delay = iosSetupBackoffMax
+	}
+	return time.Since(state.lastFailedAt) >= delay
+}
+
+// recordIOSSetupFailure increments the per-device backoff counter.
+// Errors from context cancellation or process kill are not counted — those are
+// external resets, not device faults.
+func recordIOSSetupFailure(udid string, err error) {
+	msg := err.Error()
+	if strings.Contains(msg, "context canceled") || strings.Contains(msg, "signal: killed") {
+		return
+	}
+	iosSetupBackoffMu.Lock()
+	defer iosSetupBackoffMu.Unlock()
+	state := iosSetupBackoffs[udid]
+	if state == nil {
+		state = &iosSetupBackoffState{}
+		iosSetupBackoffs[udid] = state
+	}
+	state.consecutiveFailures++
+	state.lastFailedAt = time.Now()
+}
+
+// resetIOSSetupBackoff clears backoff state after a successful setup.
+func resetIOSSetupBackoff(udid string) {
+	iosSetupBackoffMu.Lock()
+	defer iosSetupBackoffMu.Unlock()
+	delete(iosSetupBackoffs, udid)
+}
+
 // IOSDevice holds iOS-specific runtime state alongside the shared RuntimeState.
 type IOSDevice struct {
 	RuntimeState
@@ -60,9 +122,21 @@ func (d *IOSDevice) GetWDAStreamPort() string { return d.WDAStreamPort }
 func (d *IOSDevice) GetWDASessionID() string  { return d.WDASessionID }
 
 // Setup runs the full iOS device provisioning sequence.
-func (d *IOSDevice) Setup() error {
+func (d *IOSDevice) Setup() (retErr error) {
+	if !shouldAttemptIOSSetup(d.GetUDID()) {
+		return nil
+	}
+
 	d.SetupMutex.Lock()
 	defer d.SetupMutex.Unlock()
+
+	defer func() {
+		if retErr != nil {
+			recordIOSSetupFailure(d.GetUDID(), retErr)
+		} else {
+			resetIOSSetupBackoff(d.GetUDID())
+		}
+	}()
 
 	d.SetProviderState("preparing")
 	logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Running setup for device `%v`", d.GetUDID()))


### PR DESCRIPTION
## Problem

When WebDriverAgent (WDA) repeatedly fails to launch on an iOS device, the provider enters a tight retry loop with zero delay — `updateDevices()` calls `Setup()` every second, which resets WDA, which fails again, creating hundreds of goroutines per second per affected device.

Observed in production logs:
- iPhone SE 2020: **9627 resets** in a single session
  - Primary: `Could not launch WebDriverAgent - failed to initiate process communication`
  - Secondary: `Failed to allocate free tunnel port` — resource exhaustion from rapid retries
- iPhone 8: 328 resets — `Did not successfully start WebDriverAgent`
- iPhone 6s: 323 resets — `Failed to run WebDriverAgent via testmanagerd`

This mirrors the same problem that was fixed for Android in PR #296.

## Solution

Applies the same per-device exponential backoff pattern from PR #296 to the iOS provider:

- `shouldAttemptIOSSetup(udid)` — gate at the top of `Setup()`; skips the call if the device is in cooldown
- `recordIOSSetupFailure(udid, err)` — increments the per-device failure counter on error
- `resetIOSSetupBackoff(udid)` — clears the counter on successful setup

**Backoff schedule:** 10s → 20s → 40s → 60s (cap), per device UDID, in-memory only.

Errors from `context canceled` and `signal: killed` are not counted — those are external resets, not device faults. Healthy devices see zero added latency.

## Changes

- `provider/devices/ios.go` — backoff state, three helper functions, gate + deferred record/reset in `Setup()`