### PR TITLE
fix(provider): Fix WDA launch on iOS 17.0-17.3 — unsupported range with clear error

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -247,20 +247,12 @@ func (d *IOSDevice) allocateAndForwardPorts() error {
 }
 
 func (d *IOSDevice) startWebDriverAgent() error {
-	if d.SemVer.Major() < 17 || d.SemVer.Compare(semver.MustParse("17.4.0")) >= 0 {
-		if err := d.installApp(fmt.Sprintf("%s/WebDriverAgent.ipa", config.ProviderConfig.ProviderFolder)); err != nil {
-			logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Could not install WebDriverAgent on device `%s` - %s", d.GetUDID(), err))
-			d.Reset("Failed to install WebDriverAgent on device.")
-			return err
-		}
-		go d.runWDA()
-	} else {
-		if err := d.launchApp(config.ProviderConfig.WdaBundleID, true); err != nil {
-			logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Could not launch WebDriverAgent on device `%s` - %s", d.GetUDID(), err))
-			d.Reset("Failed to launch WebDriverAgent on device.")
-			return err
-		}
+	if err := d.installApp(fmt.Sprintf("%s/WebDriverAgent.ipa", config.ProviderConfig.ProviderFolder)); err != nil {
+		logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Could not install WebDriverAgent on device `%s` - %s", d.GetUDID(), err))
+		d.Reset("Failed to install WebDriverAgent on device.")
+		return err
 	}
+	go d.runWDA()
 	return nil
 }
 

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -247,6 +247,14 @@ func (d *IOSDevice) allocateAndForwardPorts() error {
 }
 
 func (d *IOSDevice) startWebDriverAgent() error {
+	// iOS 17.0–17.3 cannot run WDA: DVTSecureSocketProxy was removed in the DDI shipped
+	// with Xcode 15.4+, and testmanagerd (Xcode 15 path) requires an RSD tunnel that is
+	// only available from iOS 17.4. Upgrading the device to iOS 17.4+ resolves this.
+	if d.SemVer.Major() == 17 && d.SemVer.Compare(semver.MustParse("17.4.0")) < 0 {
+		d.Reset("iOS 17.0–17.3 is not supported. Please upgrade the device to iOS 17.4 or newer.")
+		return fmt.Errorf("iOS 17.0–17.3 is not supported on this provider version - upgrade the device to iOS 17.4+")
+	}
+
 	if err := d.installApp(fmt.Sprintf("%s/WebDriverAgent.ipa", config.ProviderConfig.ProviderFolder)); err != nil {
 		logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Could not install WebDriverAgent on device `%s` - %s", d.GetUDID(), err))
 		d.Reset("Failed to install WebDriverAgent on device.")

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -247,12 +247,13 @@ func (d *IOSDevice) allocateAndForwardPorts() error {
 }
 
 func (d *IOSDevice) startWebDriverAgent() error {
-	// iOS 17.0–17.3 cannot run WDA: DVTSecureSocketProxy was removed in the DDI shipped
+	// iOS 17.0-17.3 cannot run WDA: DVTSecureSocketProxy was removed in the DDI shipped
 	// with Xcode 15.4+, and testmanagerd (Xcode 15 path) requires an RSD tunnel that is
 	// only available from iOS 17.4. Upgrading the device to iOS 17.4+ resolves this.
 	if d.SemVer.Major() == 17 && d.SemVer.Compare(semver.MustParse("17.4.0")) < 0 {
-		d.Reset("iOS 17.0–17.3 is not supported. Please upgrade the device to iOS 17.4 or newer.")
-		return fmt.Errorf("iOS 17.0–17.3 is not supported on this provider version - upgrade the device to iOS 17.4+")
+		logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Device `%s` runs iOS 17.0-17.3 which is not supported - upgrade to iOS 17.4+", d.GetUDID()))
+		d.Reset("iOS 17.0-17.3 is not supported. Please upgrade the device to iOS 17.4 or newer.")
+		return fmt.Errorf("iOS 17.0-17.3 is not supported - upgrade the device to iOS 17.4+")
 	}
 
 	if err := d.installApp(fmt.Sprintf("%s/WebDriverAgent.ipa", config.ProviderConfig.ProviderFolder)); err != nil {

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -521,7 +521,11 @@ func (d *IOSDevice) installApp(appPath string) error {
 		d.Reset("Failed to create zipconduit connection for app installation.")
 		return err
 	}
-	conn.SendFile(appPath)
+	if err := conn.SendFile(appPath); err != nil {
+		logger.ProviderLogger.LogInfo("install_app_ios", fmt.Sprintf("Failed to send app file when installing app `%s` on device `%s`", appPath, d.GetUDID()))
+		d.Reset("Failed to send app file for installation.")
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

iOS 17.0–17.3 devices fail to start with a cryptic error from go-ios internals. Two separate issues were discovered while investigating:

**Original symptom (`launchApp` path):**
```
Could not launch WebDriverAgent on device `...` -
failed to initiate process control - Could not start service:
com.apple.instruments.remoteserver.DVTSecureSocketProxy with reason:'InvalidService'
```
`DVTSecureSocketProxy` was removed from the DDI shipped with Xcode 15.4+, so `launchApp` (instruments path) no longer works on any iOS version.

**After switching to `installApp+runWDA` (testmanagerd path):**
```
runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd:
ConnectToServiceTunnelIface: Cannot connect to com.apple.dt.testmanagerd.remote,
missing tunnel address and RSD port
```
`testmanagerd` (Xcode 15 path) requires an RSD tunnel, which `setupTunnelIfNeeded` only creates for iOS ≥ 17.4. For 17.0–17.3 the RSD tunnel requires root access (`ManualPairAndConnectToTunnel` / stopping `remoted`), which is incompatible with running as a user LaunchAgent.

**Conclusion:** iOS 17.0–17.3 is architecturally unsupported without root access. No WDA launch mechanism works for this range.

## Changes

**1. Unified `installApp+runWDA` for all supported iOS versions**

Removed the special `else` branch in `startWebDriverAgent` that used `launchApp` (DVTSecureSocketProxy) for iOS 17.0–17.3. That path required WDA to be pre-installed and no longer works regardless. For iOS < 17 and iOS ≥ 17.4 the behavior is unchanged.

**2. Explicit fail-fast for iOS 17.0–17.3**

Added a version guard at the top of `startWebDriverAgent` that immediately resets the device and logs an actionable error instead of letting it fall through to cryptic internal errors:
```
Device `<udid>` runs iOS 17.0-17.3 which is not supported - upgrade to iOS 17.4+
```

**3. Handle `SendFile` error in `installApp`**

`zipconduit.SendFile` returns an `error` that was silently discarded — installation failures went undetected and the device would proceed to `runWDA` with no WDA installed.

## Testing

Tested on iPhone 13 Pro, iOS 17.0.3 — device now immediately enters `failed` state with the unsupported-version message instead of hanging or showing internal go-ios errors.

iOS < 17 and iOS ≥ 17.4 paths are unchanged.