### PR TITLE
fix(provider): Support iPhone 16 Pro/Max (A18 Pro) by downloading PDI from doronz88/DeveloperDiskImage

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -380,7 +381,13 @@ func (d *IOSDevice) mountDeveloperImage() error {
 			return nil
 		}
 		if strings.Contains(err.Error(), "findIdentity") && d.SemVer.Major() >= 17 {
-			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Skipping DDI mount for device `%s` (iOS %s): chip not in go-ios identities, DDI not required on iOS 17+", d.GetUDID(), d.SemVer.Original()))
+			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Chip not in go-ios DDI identities for device `%s` (iOS %s), attempting PDI mount via CoreDevice", d.GetUDID(), d.SemVer.Original()))
+			out, xcrunErr := exec.Command("xcrun", "devicectl", "device", "info", "details", "--device", d.GetUDID()).CombinedOutput()
+			if xcrunErr != nil {
+				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("xcrun devicectl failed for device `%s` - %s: %s", d.GetUDID(), xcrunErr, strings.TrimSpace(string(out))))
+			} else {
+				logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("PDI mounted via CoreDevice for device `%s`", d.GetUDID()))
+			}
 			return nil
 		}
 		return fmt.Errorf("failed to mount DDI: %w", err)

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"strings"
@@ -446,7 +447,7 @@ func downloadDoronz88PDI(basedir string) (string, error) {
 		}
 	}
 
-	// Parse manifest to get actual file names.
+	// Parse manifest to get the paths go-ios will look for.
 	f, err := os.Open(manifestDest)
 	if err != nil {
 		return "", fmt.Errorf("failed to open BuildManifest.plist: %w", err)
@@ -456,27 +457,35 @@ func downloadDoronz88PDI(basedir string) (string, error) {
 	if err := plist.NewDecoder(f).Decode(&m); err != nil {
 		return "", fmt.Errorf("failed to parse BuildManifest.plist: %w", err)
 	}
-
-	// Collect unique file names referenced in the manifest.
-	seen := map[string]bool{}
-	for _, identity := range m.BuildIdentities {
-		seen[identity.Manifest.PersonalizedDMG.Info.Path] = true
-		seen[identity.Manifest.LoadableTrustCache.Info.Path] = true
+	if len(m.BuildIdentities) == 0 {
+		return "", fmt.Errorf("BuildManifest.plist contains no BuildIdentities")
 	}
 
-	for filename := range seen {
-		if filename == "" {
+	// The repo ships Image.dmg / Image.dmg.trustcache but BuildManifest.plist
+	// references versioned names (e.g. 022-21627-023.dmg). Download the generic
+	// files and save them under the paths the manifest specifies so go-ios finds them.
+	dmgRelPath := m.BuildIdentities[0].Manifest.PersonalizedDMG.Info.Path
+	tcRelPath := m.BuildIdentities[0].Manifest.LoadableTrustCache.Info.Path
+
+	for _, entry := range []struct{ relPath, remoteFile string }{
+		{dmgRelPath, "Image.dmg"},
+		{tcRelPath, "Image.dmg.trustcache"},
+	} {
+		if entry.relPath == "" {
 			continue
 		}
-		dest := fmt.Sprintf("%s/%s", dir, filename)
+		dest := filepath.Join(dir, entry.relPath)
 		fi, statErr := os.Stat(dest)
 		if statErr == nil && fi.Size() > 0 {
 			continue
 		}
-		logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Downloading PDI file %s from doronz88/DeveloperDiskImage", filename))
-		if err := downloadFileToPath(doronz88PDIBaseURL+filename, dest); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return "", fmt.Errorf("could not create directory for %s: %w", entry.relPath, err)
+		}
+		logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Downloading %s as %s from doronz88/DeveloperDiskImage", entry.remoteFile, entry.relPath))
+		if err := downloadFileToPath(doronz88PDIBaseURL+entry.remoteFile, dest); err != nil {
 			os.Remove(dest)
-			return "", fmt.Errorf("failed to download PDI file %s: %w", filename, err)
+			return "", fmt.Errorf("failed to download %s: %w", entry.remoteFile, err)
 		}
 	}
 	return dir, nil

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -18,8 +18,8 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
+	"sync"
 	"strings"
 	"time"
 
@@ -366,33 +366,96 @@ func (d *IOSDevice) UpdateStreamSettingsOnDevice() error {
 	return nil
 }
 
+const (
+	doronz88PDIBaseURL  = "https://raw.githubusercontent.com/doronz88/DeveloperDiskImage/main/PersonalizedImages/Xcode_iOS_DDI_Personalized/"
+	doronz88PDICacheTTL = 24 * time.Hour
+)
+
+var doronz88PDIMu sync.Mutex
+
 func (d *IOSDevice) mountDeveloperImage() error {
 	basedir := fmt.Sprintf("%s/devimages", config.ProviderConfig.ProviderFolder)
 
-	path, err := imagemounter.DownloadImageFor(d.GoIOSDeviceEntry, basedir)
+	var imagePath string
+	var err error
+
+	if d.SemVer.Major() >= 17 {
+		imagePath, err = downloadDoronz88PDI(basedir)
+	} else {
+		imagePath, err = imagemounter.DownloadImageFor(d.GoIOSDeviceEntry, basedir)
+	}
 	if err != nil {
-		logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Failed to download DDI for device `%s` to path `%s` - %s", d.GetUDID(), basedir, err))
+		logger.ProviderLogger.LogError("ios_device_setup", fmt.Sprintf("Failed to download DDI for device `%s` - %s", d.GetUDID(), err))
 		return fmt.Errorf("failed to download DDI: %w", err)
 	}
 
-	err = imagemounter.MountImage(d.GoIOSDeviceEntry, path)
+	err = imagemounter.MountImage(d.GoIOSDeviceEntry, imagePath)
 	if err != nil {
 		if strings.Contains(err.Error(), "already mounted") || strings.Contains(err.Error(), "AlreadyMounted") {
-			return nil
-		}
-		if strings.Contains(err.Error(), "findIdentity") && d.SemVer.Major() >= 17 {
-			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Chip not in go-ios DDI identities for device `%s` (iOS %s), attempting PDI mount via CoreDevice", d.GetUDID(), d.SemVer.Original()))
-			out, xcrunErr := exec.Command("xcrun", "devicectl", "device", "info", "details", "--device", d.GetUDID()).CombinedOutput()
-			if xcrunErr != nil {
-				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("xcrun devicectl failed for device `%s` - %s: %s", d.GetUDID(), xcrunErr, strings.TrimSpace(string(out))))
-			} else {
-				logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("PDI mounted via CoreDevice for device `%s`", d.GetUDID()))
-			}
 			return nil
 		}
 		return fmt.Errorf("failed to mount DDI: %w", err)
 	}
 	return nil
+}
+
+func downloadDoronz88PDI(basedir string) (string, error) {
+	doronz88PDIMu.Lock()
+	defer doronz88PDIMu.Unlock()
+
+	dir := fmt.Sprintf("%s/doronz88-pdi", basedir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("could not create PDI directory: %w", err)
+	}
+	for _, filename := range []string{"BuildManifest.plist", "Image.dmg", "Image.dmg.trustcache"} {
+		dest := fmt.Sprintf("%s/%s", dir, filename)
+		fi, statErr := os.Stat(dest)
+		fileExists := statErr == nil && fi.Size() > 0
+		isStale := fileExists && filename == "BuildManifest.plist" && time.Since(fi.ModTime()) > doronz88PDICacheTTL
+
+		if fileExists && !isStale {
+			continue
+		}
+
+		logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Downloading PDI file %s from doronz88/DeveloperDiskImage", filename))
+
+		if isStale {
+			tmp := dest + ".tmp"
+			if err := downloadFileToPath(doronz88PDIBaseURL+filename, tmp); err != nil {
+				os.Remove(tmp)
+				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to refresh %s, using cached version: %s", filename, err))
+				continue
+			}
+			if err := os.Rename(tmp, dest); err != nil {
+				os.Remove(tmp)
+				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to replace %s, using cached version: %s", filename, err))
+			}
+		} else {
+			if err := downloadFileToPath(doronz88PDIBaseURL+filename, dest); err != nil {
+				os.Remove(dest)
+				return "", fmt.Errorf("failed to download PDI file %s: %w", filename, err)
+			}
+		}
+	}
+	return dir, nil
+}
+
+func downloadFileToPath(url, dest string) error {
+	resp, err := netClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status %d for %s", resp.StatusCode, url)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
 }
 
 func (d *IOSDevice) pair() (pairErr error) {

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -41,6 +41,7 @@ import (
 	"github.com/danielpaulus/go-ios/ios/tunnel"
 	"github.com/danielpaulus/go-ios/ios/zipconduit"
 	"golang.org/x/sync/errgroup"
+	"howett.net/plist"
 )
 
 // IOSDevice holds iOS-specific runtime state alongside the shared RuntimeState.
@@ -373,6 +374,19 @@ const (
 
 var doronz88PDIMu sync.Mutex
 
+type pdiManifest struct {
+	BuildIdentities []struct {
+		Manifest struct {
+			PersonalizedDMG struct {
+				Info struct{ Path string }
+			} `plist:"PersonalizedDMG"`
+			LoadableTrustCache struct {
+				Info struct{ Path string }
+			}
+		}
+	}
+}
+
 func (d *IOSDevice) mountDeveloperImage() error {
 	basedir := fmt.Sprintf("%s/devimages", config.ProviderConfig.ProviderFolder)
 
@@ -407,34 +421,62 @@ func downloadDoronz88PDI(basedir string) (string, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("could not create PDI directory: %w", err)
 	}
-	for _, filename := range []string{"BuildManifest.plist", "Image.dmg", "Image.dmg.trustcache"} {
-		dest := fmt.Sprintf("%s/%s", dir, filename)
-		fi, statErr := os.Stat(dest)
-		fileExists := statErr == nil && fi.Size() > 0
-		isStale := fileExists && filename == "BuildManifest.plist" && time.Since(fi.ModTime()) > doronz88PDICacheTTL
 
-		if fileExists && !isStale {
+	// Download/refresh BuildManifest.plist with TTL-based staleness.
+	manifestDest := fmt.Sprintf("%s/BuildManifest.plist", dir)
+	fi, statErr := os.Stat(manifestDest)
+	manifestExists := statErr == nil && fi.Size() > 0
+	manifestStale := manifestExists && time.Since(fi.ModTime()) > doronz88PDICacheTTL
+
+	if !manifestExists || manifestStale {
+		logger.ProviderLogger.LogInfo("ios_device_setup", "Downloading BuildManifest.plist from doronz88/DeveloperDiskImage")
+		tmp := manifestDest + ".tmp"
+		if err := downloadFileToPath(doronz88PDIBaseURL+"BuildManifest.plist", tmp); err != nil {
+			os.Remove(tmp)
+			if !manifestExists {
+				return "", fmt.Errorf("failed to download BuildManifest.plist: %w", err)
+			}
+			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to refresh BuildManifest.plist, using cached version: %s", err))
+		} else if err := os.Rename(tmp, manifestDest); err != nil {
+			os.Remove(tmp)
+			if !manifestExists {
+				return "", fmt.Errorf("failed to save BuildManifest.plist: %w", err)
+			}
+			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to replace BuildManifest.plist, using cached version: %s", err))
+		}
+	}
+
+	// Parse manifest to get actual file names.
+	f, err := os.Open(manifestDest)
+	if err != nil {
+		return "", fmt.Errorf("failed to open BuildManifest.plist: %w", err)
+	}
+	defer f.Close()
+	var m pdiManifest
+	if err := plist.NewDecoder(f).Decode(&m); err != nil {
+		return "", fmt.Errorf("failed to parse BuildManifest.plist: %w", err)
+	}
+
+	// Collect unique file names referenced in the manifest.
+	seen := map[string]bool{}
+	for _, identity := range m.BuildIdentities {
+		seen[identity.Manifest.PersonalizedDMG.Info.Path] = true
+		seen[identity.Manifest.LoadableTrustCache.Info.Path] = true
+	}
+
+	for filename := range seen {
+		if filename == "" {
 			continue
 		}
-
+		dest := fmt.Sprintf("%s/%s", dir, filename)
+		fi, statErr := os.Stat(dest)
+		if statErr == nil && fi.Size() > 0 {
+			continue
+		}
 		logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Downloading PDI file %s from doronz88/DeveloperDiskImage", filename))
-
-		if isStale {
-			tmp := dest + ".tmp"
-			if err := downloadFileToPath(doronz88PDIBaseURL+filename, tmp); err != nil {
-				os.Remove(tmp)
-				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to refresh %s, using cached version: %s", filename, err))
-				continue
-			}
-			if err := os.Rename(tmp, dest); err != nil {
-				os.Remove(tmp)
-				logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Failed to replace %s, using cached version: %s", filename, err))
-			}
-		} else {
-			if err := downloadFileToPath(doronz88PDIBaseURL+filename, dest); err != nil {
-				os.Remove(dest)
-				return "", fmt.Errorf("failed to download PDI file %s: %w", filename, err)
-			}
+		if err := downloadFileToPath(doronz88PDIBaseURL+filename, dest); err != nil {
+			os.Remove(dest)
+			return "", fmt.Errorf("failed to download PDI file %s: %w", filename, err)
 		}
 	}
 	return dir, nil

--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -379,6 +379,10 @@ func (d *IOSDevice) mountDeveloperImage() error {
 		if strings.Contains(err.Error(), "already mounted") || strings.Contains(err.Error(), "AlreadyMounted") {
 			return nil
 		}
+		if strings.Contains(err.Error(), "findIdentity") && d.SemVer.Major() >= 17 {
+			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("Skipping DDI mount for device `%s` (iOS %s): chip not in go-ios identities, DDI not required on iOS 17+", d.GetUDID(), d.SemVer.Original()))
+			return nil
+		}
 		return fmt.Errorf("failed to mount DDI: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Problem

iPhone 16 Pro and 16 Pro Max (chip A18 Pro, \`ApChipID=0x8140\`, \`ApBoardID=0xe\`) fail to start WDA on the iOS provider with:

\`\`\`
Failed to mount Developer Disk Image (DDI) for device \`00008140-...\` -
failed to mount DDI: MountImage: could not find identity for identifiers
{BoardId:14 ChipID:33088 ...}: findIdentity: failed to find identity for
ApBoardId 0xe and ApChipId 0x8140
\`\`\`

**Root cause:** go-ios v1.0.202 hardcodes \`ddi-15F31d\` for all iOS 17+ devices. Its \`BuildManifest.plist\` only contains identities up to A16 Bionic (chip \`0x8132\`). The A18 Pro (\`0x8140\`) is absent, so \`MountImage\` fails with a \`findIdentity\` error and GADS resets the device.

## Solution

For iOS 17+, bypass go-ios's hardcoded DDI download and use [doronz88/DeveloperDiskImage](https://github.com/doronz88/DeveloperDiskImage/tree/main/PersonalizedImages/Xcode_iOS_DDI_Personalized), which maintains up-to-date chip identities including A18 Pro.

**Key insight:** The repo ships two generic files (\`Image.dmg\`, \`Image.dmg.trustcache\`), but \`BuildManifest.plist\` references them by versioned names (e.g. \`022-21627-023.dmg\`, \`Firmware/022-21627-023.dmg.trustcache\`). go-ios reads the manifest and looks for files by those exact paths — so the files must be saved under the manifest-specified names.

**Algorithm:**
1. Download \`BuildManifest.plist\` (refreshed every 24h via TTL, atomic replace via \`.tmp\` → rename)
2. Parse it with \`howett.net/plist\` (already an indirect dependency) to extract \`dmgRelPath\` and \`tcRelPath\` from the first \`BuildIdentity\`
3. Download \`Image.dmg\` → save as \`dir/dmgRelPath\`, download \`Image.dmg.trustcache\` → save as \`dir/tcRelPath\` (creating subdirectories as needed)
4. Return \`dir\` — \`imagemounter.MountImage\` finds the files, contacts Apple TSS for a personalized signature, and mounts the PDI

**Other details:**
- Files cached in \`<providerFolder>/devimages/doronz88-pdi/\`
- Package-level mutex prevents concurrent downloads on first provider startup
- For iOS < 17, existing \`imagemounter.DownloadImageFor()\` behaviour is unchanged
- Works cross-platform (macOS, Linux, Windows) — pure HTTP download, no system tools required

## Testing

Verified on a real device fleet:
- ✅ iPhone 16 Pro Max (A18 Pro, \`0x8140\`, UDID \`00008140-0018794802E8401C\`) — DDI mounted, WDA started
- ✅ 24 other devices across iOS versions — no regressions

Log output on success:
\`\`\`
Downloading Image.dmg as 022-21627-023.dmg from doronz88/DeveloperDiskImage
Downloading Image.dmg.trustcache as Firmware/022-21627-023.dmg.trustcache from doronz88/DeveloperDiskImage
Successfully started WebDriverAgent for device 00008140-0018794802E8401C
\`\`\`