### PR TITLE
feat(android): add multi-screen display support for screenshots

### DIFF
--- a/common/models/models.go
+++ b/common/models/models.go
@@ -50,7 +50,13 @@ type DBDevice struct {
 	// This field will be removed in next major version release. Only kept for backward compatibility during migration.
 	UseWebRTCVideo bool          `json:"use_webrtc_video" bson:"use_webrtc_video"` // Should the device use WebRTC video instead of MJPEG
 	WorkspaceID    string        `json:"workspace_id" bson:"workspace_id"`         // ID of the associated workspace
-	StreamType StreamingType `json:"stream_type" bson:"stream_type"` // The type of video streaming for the device
+	StreamType     StreamingType `json:"stream_type" bson:"stream_type"`           // The type of video streaming for the device
+}
+
+// AndroidDisplay represents a physical display on an Android device (e.g. foldable inner/outer screen).
+type AndroidDisplay struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // Device stream type - mjpeg, webrtc, etc

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -42,10 +42,12 @@ import (
 // AndroidDevice holds Android-specific runtime state alongside the shared RuntimeState.
 type AndroidDevice struct {
 	RuntimeState
-	StreamPort              string // host port forwarded to device port 1991 (video stream)
-	AndroidIMEPort          string // host port forwarded to device port 1993 (IME keyboard)
-	AndroidRemoteServerPort string // host port forwarded to device port 1994 (remote control server)
-	ADBPort                 string // host port forwarded to device adbd port 5555 (ADB tunnel)
+	StreamPort              string                  // host port forwarded to device port 1991 (video stream)
+	AndroidIMEPort          string                  // host port forwarded to device port 1993 (IME keyboard)
+	AndroidRemoteServerPort string                  // host port forwarded to device port 1994 (remote control server)
+	ADBPort                 string                  // host port forwarded to device adbd port 5555 (ADB tunnel)
+	ActiveDisplayID         string                  // display ID used for screencap; empty = device default
+	AvailableDisplays       []models.AndroidDisplay // all physical displays detected on the device
 }
 
 const adbTCPPort = "5555"
@@ -741,6 +743,103 @@ func (d *AndroidDevice) getHardwareModel() {
 	}
 	model := outBuffer.String()
 	d.HardwareModel = fmt.Sprintf("%s %s", strings.TrimSpace(brand), strings.TrimSpace(model))
+}
+
+// fetchAndSetDisplays queries the device for available physical displays via
+// `dumpsys SurfaceFlinger --display-id` and stores them in AvailableDisplays.
+// ActiveDisplayID is set to the first display if it has not been set yet.
+// A failure is non-fatal — the device falls back to screencap without -d.
+func (d *AndroidDevice) fetchAndSetDisplays() {
+	displays, err := getAndroidDisplayIDs(d.GetUDID())
+	if err != nil {
+		logger.ProviderLogger.LogWarn("android_device_setup",
+			fmt.Sprintf("Could not detect displays for device `%s`: %s", d.GetUDID(), err))
+		return
+	}
+	d.AvailableDisplays = displays
+	ids := make([]string, len(displays))
+	for i, disp := range displays {
+		ids[i] = fmt.Sprintf("%s (%s)", disp.ID, disp.Name)
+	}
+	logger.ProviderLogger.LogInfo("android_device_setup",
+		fmt.Sprintf("Detected %d display(s) for device `%s`: %s", len(displays), d.GetUDID(), strings.Join(ids, ", ")))
+
+	if len(displays) > 0 && d.ActiveDisplayID == "" {
+		d.ActiveDisplayID = displays[0].ID
+		logger.ProviderLogger.LogInfo("android_device_setup",
+			fmt.Sprintf("Active display set to %s (%s) for device `%s`", displays[0].ID, displays[0].Name, d.GetUDID()))
+	}
+}
+
+// GetActiveDisplayID returns the currently selected display ID for screencap.
+func (d *AndroidDevice) GetActiveDisplayID() string { return d.ActiveDisplayID }
+
+// SetActiveDisplayID sets the display ID used for subsequent screenshots.
+func (d *AndroidDevice) SetActiveDisplayID(id string) {
+	prev := d.ActiveDisplayID
+	d.ActiveDisplayID = id
+	d.GetLogger().LogInfo("display",
+		fmt.Sprintf("Active display changed: %s -> %s", prev, id))
+}
+
+// GetAvailableDisplays returns all physical displays detected on the device.
+// Always returns a non-nil slice so callers receive "[]" rather than "null" in JSON.
+func (d *AndroidDevice) GetAvailableDisplays() []models.AndroidDisplay {
+	if d.AvailableDisplays == nil {
+		return []models.AndroidDisplay{}
+	}
+	return d.AvailableDisplays
+}
+
+// getAndroidDisplayIDs runs dumpsys SurfaceFlinger --display-id and returns parsed displays.
+func getAndroidDisplayIDs(udid string) ([]models.AndroidDisplay, error) {
+	var out bytes.Buffer
+	cmd := exec.Command("adb", "-s", udid, "shell", "dumpsys", "SurfaceFlinger", "--display-id")
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("dumpsys SurfaceFlinger --display-id: %w", err)
+	}
+	displays := parseAndroidDisplayIDs(out.String())
+	if len(displays) == 0 {
+		return nil, fmt.Errorf("no display IDs found in SurfaceFlinger output")
+	}
+	return displays, nil
+}
+
+// displayLineRe matches a physical display line from `dumpsys SurfaceFlinger --display-id`:
+//
+//	Display 4630947175568309891 (HWC display 0): port=131 ...
+//	Display 4630946481096930692 (HWC display 3): port=132 ...
+//
+// Group 1 = 64-bit display ID (passed to screencap -d).
+// Group 2 = display type string (e.g. "HWC display 0", "Virtual display").
+var displayLineRe = regexp.MustCompile(`(?m)^Display\s+(\d+)\s+\(([^)]+)\)`)
+
+// hwcNumberRe extracts the HWC index from "HWC display 3".
+var hwcNumberRe = regexp.MustCompile(`HWC display\s+(\d+)`)
+
+// parseAndroidDisplayIDs extracts physical display IDs from `dumpsys SurfaceFlinger --display-id`.
+// Virtual displays (e.g. screen capture sinks) are excluded.
+// Displays are named using their HWC index when available.
+func parseAndroidDisplayIDs(output string) []models.AndroidDisplay {
+	var displays []models.AndroidDisplay
+	for _, m := range displayLineRe.FindAllStringSubmatch(output, -1) {
+		id := m[1]
+		typeStr := m[2]
+
+		// Skip virtual displays — they are not physical screens.
+		if strings.Contains(strings.ToLower(typeStr), "virtual") {
+			continue
+		}
+
+		name := typeStr // fallback: use raw type string as name
+		if hwc := hwcNumberRe.FindStringSubmatch(typeStr); len(hwc) == 2 {
+			name = fmt.Sprintf("HWC display %s", hwc[1])
+		}
+
+		displays = append(displays, models.AndroidDisplay{ID: id, Name: name})
+	}
+	return displays
 }
 
 // LaunchApp is not supported for Android via this interface (use Appium).

--- a/provider/router/control.go
+++ b/provider/router/control.go
@@ -138,21 +138,35 @@ func deviceTouchAndHold(dev devices.PlatformDevice, x float64, y float64, durati
 	}
 }
 
+// androidScreenshot captures a screenshot from the given Android device.
+// displayID is the physical display ID to pass via `screencap -d`; pass empty string
+// to let screencap choose the default display (single-display devices).
+func androidScreenshot(udid, displayID string) ([]byte, error) {
+	args := []string{"-s", udid, "exec-out", "screencap", "-p"}
+	if displayID != "" {
+		args = append(args, "-d", displayID)
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command("adb", args...)
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
 func deviceScreenshot(dev devices.PlatformDevice) (string, error) {
 	if dev.GetOS() == "android" {
-		cmd := exec.Command("adb", "-s", dev.GetUDID(), "exec-out", "screencap", "-p")
-		var out bytes.Buffer
-		cmd.Stdout = &out
-
-		err := cmd.Run()
+		andDev, ok := dev.(*devices.AndroidDevice)
+		if !ok {
+			return "", fmt.Errorf("device %s is not an Android device", dev.GetUDID())
+		}
+		imageBytes, err := androidScreenshot(andDev.GetUDID(), andDev.GetActiveDisplayID())
 		if err != nil {
 			return "", err
 		}
-
-		// Encode PNG bytes to Base64
-		base64Screenshot := base64.StdEncoding.EncodeToString(out.Bytes())
-
-		return base64Screenshot, nil
+		return base64.StdEncoding.EncodeToString(imageBytes), nil
 	} else {
 		iosDev, ok := dev.(*devices.IOSDevice)
 		if !ok {

--- a/provider/router/device_routes.go
+++ b/provider/router/device_routes.go
@@ -232,6 +232,63 @@ func DeviceScreenshot(c *gin.Context) {
 	api.OKMessage(c, screenshotResp)
 }
 
+// DeviceGetDisplays returns the list of physical displays available on an Android device.
+// Returns 400 for non-Android devices.
+func DeviceGetDisplays(c *gin.Context) {
+	udid := c.Param("udid")
+	platDev, ok := devices.DevManager.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with UDID %s not found", udid))
+		return
+	}
+	andDev, ok := platDev.(*devices.AndroidDevice)
+	if !ok {
+		api.BadRequest(c, "Multi-display support is only available for Android devices")
+		return
+	}
+	api.OK(c, "Displays retrieved successfully", andDev.GetAvailableDisplays())
+}
+
+// DeviceSetActiveDisplay sets the active display used for subsequent screenshots on an Android device.
+// Request body: {"display_id": "<id>"}
+func DeviceSetActiveDisplay(c *gin.Context) {
+	udid := c.Param("udid")
+	platDev, ok := devices.DevManager.Get(udid)
+	if !ok {
+		api.NotFound(c, fmt.Sprintf("Device with UDID %s not found", udid))
+		return
+	}
+	andDev, ok := platDev.(*devices.AndroidDevice)
+	if !ok {
+		api.BadRequest(c, "Multi-display support is only available for Android devices")
+		return
+	}
+
+	var body struct {
+		DisplayID string `json:"display_id"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.DisplayID == "" {
+		api.BadRequest(c, "Missing or invalid display_id in request body")
+		return
+	}
+
+	// Validate that the requested display is actually available on this device.
+	found := false
+	for _, d := range andDev.GetAvailableDisplays() {
+		if d.ID == body.DisplayID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		api.BadRequest(c, fmt.Sprintf("Display ID %q is not available on this device", body.DisplayID))
+		return
+	}
+
+	andDev.SetActiveDisplayID(body.DisplayID)
+	api.OKMessage(c, fmt.Sprintf("Active display set to %s", body.DisplayID))
+}
+
 //======================================
 // Appium source
 

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -61,6 +61,8 @@ func HandleRequests() *gin.Engine {
 	deviceGroup.POST("/lock", DeviceLock)
 	deviceGroup.POST("/unlock", DeviceUnlock)
 	deviceGroup.POST("/screenshot", DeviceScreenshot)
+	deviceGroup.GET("/displays", DeviceGetDisplays)
+	deviceGroup.POST("/display", DeviceSetActiveDisplay)
 	deviceGroup.POST("/swipe", DeviceSwipe)
 	deviceGroup.POST("/custom-action", DeviceExecuteCustomAction)
 	deviceGroup.GET("/appiumSource", DeviceAppiumSource)


### PR DESCRIPTION
- Add AndroidDisplay model with ID and Name fields
- Detect physical displays via `dumpsys SurfaceFlinger --display-id`
- Store ActiveDisplayID/AvailableDisplays on AndroidDevice
- Extract androidScreenshot() helper supporting screencap -d flag
- Add GET /devices/:udid/displays  – list available physical displays
- Add POST /devices/:udid/display  – set active display for screenshots

This PR improves screenshot support on Android devices with multiple screens, e.g. foldable devices.
Right now GADS captures screenshots only from the "main" screen even when the "secondary" screen is active.
As far as I can tell, there is no universal way to automatically detect the active screen across different devices.