### PR TITLE
Add provider log file rotation

### DIFF
--- a/.codex/agent_learnings/entries/20260628-provider-log-retention.json
+++ b/.codex/agent_learnings/entries/20260628-provider-log-retention.json
@@ -1,0 +1,11 @@
+{
+  "ts_utc": "2026-06-28T23:36:17Z",
+  "category": "architecture",
+  "text": "GADS no longer uses container logs for provider runtime diagnostics.\nCurrent local log files are owned by the Provider under the provider folder: provider.log plus per-device device_*/device.log.\nProvider-side log retention is the repo-aligned place to implement automatic log file cleanup.",
+  "issue": "https://github.com/shamanec/GADS/issues/2",
+  "pointers": [
+    "provider/logger/logger.go",
+    "provider/devices/common.go",
+    "docs/provider.md"
+  ]
+}

--- a/.codex/agent_learnings/entries/20260629-gads-mongo-test-timeouts.json
+++ b/.codex/agent_learnings/entries/20260629-gads-mongo-test-timeouts.json
@@ -1,0 +1,11 @@
+{
+  "ts_utc": "2026-06-29T00:50:06Z",
+  "category": "technical-gotcha",
+  "text": "GADS has Mongo-backed auth tests that may run in developer or CI environments without MongoDB.\nUse bounded MongoDB reachability checks and explicit skips for integration-style tests so missing services do not consume the full Go test timeout.",
+  "issue": "#2",
+  "pointers": [
+    "hub/auth/secretaudit_http_test.go",
+    "hub/auth/secretaudit_test.go",
+    "go test -timeout=2m ./hub/auth"
+  ]
+}

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -307,6 +307,8 @@ Note that it is possible that on some devices it might not work at all, in this 
   - `--mongo-db=` - optional, IP address and port of the MongoDB instance (default is `localhost:27017`)
   - `--provider-folder=` - optional, folder where provider should store logs and apps and other needed files. Can be relative path to the folder where provider binary is located or full path on the host - `./test`, `.`, `./test/test1`, `/Users/shamanec/Desktop/test` are all valid. Default is the folder where the binary is currently located - `.`
   - `--log-level=` - optional, how verbose should the provider logs be (default is `info`, use `debug` for more log output)
+  - `--log-max-size-mb=` - optional, maximum size in MB for each local provider/device log file before it is rotated (default is `10`, set `0` to disable cleanup)
+  - `--log-max-backups=` - optional, number of rotated local log file backups to keep for each provider/device log (default is `3`)
   - `--hub=` - mandatory, the address of the hub instance so the provider can push data to it automatically, e.g `http://192.168.68.109:10000`
   - `--use-ios-pair-cache` - optional, cache iOS pair records on disk to skip the Trust dialog on reconnect for unsupervised devices (default is `false`)
 
@@ -315,6 +317,7 @@ Note that it is possible that on some devices it might not work at all, in this 
 Provider logs both to local files and to MongoDB.
 Provider logs can be found in the `provider.log` file in the used provider folder - default or provided by the `--provider-folder` flag.  
 They will also be stored in MongoDB in DB `logs` and collection corresponding to the provider nickname.
+Local provider and device log files are automatically rotated when they reach `--log-max-size-mb`, keeping up to `--log-max-backups` older files next to the active log.
 
 ## Device logs
 

--- a/hub/auth/secretaudit_http_test.go
+++ b/hub/auth/secretaudit_http_test.go
@@ -24,6 +24,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const mongoTestTimeout = 2 * time.Second
+
 func setupTestRouter(secretStore *SecretStore) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -46,10 +48,25 @@ func setupTestRouter(secretStore *SecretStore) *gin.Engine {
 	return router
 }
 
-func setupTestDatabase() (*mongo.Database, *SecretStore, func()) {
+func setupTestDatabase(t *testing.T) (*mongo.Database, *SecretStore, func()) {
+	t.Helper()
+
 	// Setup test database
-	ctx := context.Background()
-	client, _ := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
+	ctx, cancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().
+		ApplyURI("mongodb://localhost:27017").
+		SetServerSelectionTimeout(mongoTestTimeout).
+		SetConnectTimeout(mongoTestTimeout))
+	if err != nil {
+		t.Skipf("MongoDB is not available for integration test setup: %v", err)
+	}
+
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(context.Background())
+		t.Skipf("MongoDB is not available for integration test setup: %v", err)
+	}
 
 	// Use a separate test database
 	dbName := "gads_test_" + primitive.NewObjectID().Hex()
@@ -60,12 +77,17 @@ func setupTestDatabase() (*mongo.Database, *SecretStore, func()) {
 
 	// Create indexes for the audit collection
 	auditStore := secretStore.GetSecretKeyAuditStore()
-	auditStore.CreateMongoIndexes()
+	if err := auditStore.CreateMongoIndexes(); err != nil {
+		_ = client.Disconnect(context.Background())
+		t.Fatalf("Failed to create audit log indexes: %v", err)
+	}
 
 	// Cleanup function to be called at the end of the test
 	cleanup := func() {
-		db.Drop(ctx)
-		client.Disconnect(ctx)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), mongoTestTimeout)
+		defer cleanupCancel()
+		_ = db.Drop(cleanupCtx)
+		_ = client.Disconnect(cleanupCtx)
 	}
 
 	return db, secretStore, cleanup
@@ -73,7 +95,7 @@ func setupTestDatabase() (*mongo.Database, *SecretStore, func()) {
 
 func TestAdminSecretKeyHistoryHandler(t *testing.T) {
 	// Setup test
-	db, secretStore, cleanup := setupTestDatabase()
+	db, secretStore, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
 	// Add some test records to the audit collection
@@ -164,7 +186,7 @@ func TestAdminSecretKeyHistoryHandler(t *testing.T) {
 
 func TestAdminSecretKeyHistoryByIDHandler(t *testing.T) {
 	// Setup test
-	db, secretStore, cleanup := setupTestDatabase()
+	db, secretStore, cleanup := setupTestDatabase(t)
 	defer cleanup()
 
 	// Create a known ID for testing

--- a/hub/auth/secretaudit_test.go
+++ b/hub/auth/secretaudit_test.go
@@ -17,31 +17,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // TestSecretKeyAudit tests the secret key audit functionality
 func TestSecretKeyAudit(t *testing.T) {
-	// Setup test database
 	ctx := context.Background()
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
-	if err != nil {
-		t.Fatalf("Failed to connect to MongoDB: %v", err)
-	}
-	defer client.Disconnect(ctx)
+	db, secretStore, cleanup := setupTestDatabase(t)
+	defer cleanup()
 
-	// Use a separate test database
-	dbName := "gads_test_" + primitive.NewObjectID().Hex()
-	db := client.Database(dbName)
-	defer db.Drop(ctx)
-
-	// Create stores
-	secretStore := NewSecretStore(db)
 	auditStore := secretStore.GetSecretKeyAuditStore()
 
 	// Create indexes for the audit collection
-	err = auditStore.CreateMongoIndexes()
+	err := auditStore.CreateMongoIndexes()
 	assert.NoError(t, err, "Failed to create audit log indexes")
 
 	// Test 1: Adding a Secret Key should create an audit log

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -94,7 +94,9 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 			if appiumSessionBody.DesiredCapabilities.PlatformName != "" && appiumSessionBody.DesiredCapabilities.AutomationName != "" {
 				capsToUse = appiumSessionBody.DesiredCapabilities
-			} else if appiumSessionBody.Capabilities.FirstMatch[0].PlatformName != "" && appiumSessionBody.Capabilities.FirstMatch[0].AutomationName != "" {
+			} else if len(appiumSessionBody.Capabilities.FirstMatch) > 0 &&
+				appiumSessionBody.Capabilities.FirstMatch[0].PlatformName != "" &&
+				appiumSessionBody.Capabilities.FirstMatch[0].AutomationName != "" {
 				capsToUse = appiumSessionBody.Capabilities.FirstMatch[0]
 			} else if appiumSessionBody.Capabilities.AlwaysMatch.PlatformName != "" && appiumSessionBody.Capabilities.AlwaysMatch.AutomationName != "" {
 				capsToUse = appiumSessionBody.Capabilities.AlwaysMatch

--- a/hub/router/client_credentials_test.go
+++ b/hub/router/client_credentials_test.go
@@ -40,10 +40,11 @@ func TestCreateClientCredential_Unauthorized(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	var response models.OAuthErrorResponse
+	var response models.ErrorResponse
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "unauthorized", response.Error)
+	assert.False(t, response.Success)
+	assert.Equal(t, "unauthorized", response.Message)
 }
 
 func TestListClientCredentials_Unauthorized(t *testing.T) {
@@ -58,10 +59,11 @@ func TestListClientCredentials_Unauthorized(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	var response models.OAuthErrorResponse
+	var response models.ErrorResponse
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "unauthorized", response.Error)
+	assert.False(t, response.Success)
+	assert.Equal(t, "unauthorized", response.Message)
 }
 
 func TestOAuth2TokenEndpoint_InvalidJSON(t *testing.T) {

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -143,60 +143,66 @@ func TestDeviceProxyHandler(t *testing.T) {
 		devices.HubDeviceStore.Delete(udid)
 	})
 
-	t.Run("Missing Client Credentials - Should Return W3C Error Format", func(t *testing.T) {
-		// Setup a device
-		udid := "test-device-no-credentials"
-		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
-			Device: models.DBDevice{
-				UDID: udid,
-			},
-			Host:      "localhost:8080",
-			Available: true,
-		})
-
-		// Create request WITHOUT credentials
+	t.Run("Legacy Appium Endpoint - Should Return 410", func(t *testing.T) {
 		router := gin.New()
 		router.POST("/device/:udid/*path", DeviceProxyHandler)
 
-		sessionReq := map[string]interface{}{
-			"capabilities": map[string]interface{}{
-				"alwaysMatch": map[string]interface{}{
-					"platformName": "iOS",
-					// Note: NO client credentials provided
-				},
-			},
-		}
-		jsonData, _ := json.Marshal(sessionReq)
-
-		req, _ := http.NewRequest("POST", "/device/"+udid+"/session", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
+		req, _ := http.NewRequest("POST", "/device/test-device/appium/session", nil)
 		w := httptest.NewRecorder()
 
-		// Execute request
 		router.ServeHTTP(w, req)
 
-		// Verify status code
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t, http.StatusGone, w.Code)
 
-		// Verify W3C error format
 		var response map[string]interface{}
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		assert.NoError(t, err)
 
-		// Check W3C structure
 		assert.Contains(t, response, "value")
 		value, ok := response["value"].(map[string]interface{})
 		assert.True(t, ok, "value should be a map")
 
-		assert.Equal(t, "invalid argument", value["error"])
-		expectedMsg := fmt.Sprintf("Client credentials are required. Provide %[1]s:clientSecret in the capabilities.", capabilityPrefix)
-		assert.Equal(t, expectedMsg, value["message"])
+		assert.Equal(t, "unknown method", value["error"])
+		assert.Equal(t, "The legacy endpoint /device/{udid}/appium is deprecated. Please use /grid endpoint instead.", value["message"])
 		assert.Equal(t, "", value["stacktrace"])
-
-		// Cleanup
-		devices.HubDeviceStore.Delete(udid)
 	})
 
+}
+
+func TestAppiumGridMiddleware_MissingClientCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/grid/session", AppiumGridMiddleware())
+
+	sessionReq := map[string]interface{}{
+		"capabilities": map[string]interface{}{
+			"alwaysMatch": map[string]interface{}{
+				"platformName":          "iOS",
+				"appium:automationName": "XCUITest",
+			},
+		},
+	}
+	jsonData, _ := json.Marshal(sessionReq)
+
+	req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	value, ok := response["value"].(map[string]interface{})
+	assert.True(t, ok, "value should be a map")
+
+	assert.Equal(t, "session not created", value["error"])
+	expectedMsg := fmt.Sprintf("Client credentials are required. Provide %[1]s:clientSecret in the capabilities.", capabilityPrefix)
+	assert.Equal(t, expectedMsg, value["message"])
+	assert.Equal(t, "", value["stacktrace"])
 }
 
 func TestExtractClientSecretFromSession(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"GADS/client/adb"
 	"GADS/hub"
 	"GADS/provider"
+	"GADS/provider/logger"
 	"embed"
 	"fmt"
 	"os"
@@ -57,6 +58,8 @@ func main() {
 	providerCmd.Flags().String("nickname", "", "Nickname of the provider")
 	providerCmd.Flags().String("provider-folder", ".", "The folder where logs and other data will be stored")
 	providerCmd.Flags().String("log-level", "info", "The verbosity of the logs of the provider instance")
+	providerCmd.Flags().Int("log-max-size-mb", logger.DefaultLogMaxSizeMB, "Maximum size in MB for each local provider/device log file before rotation; 0 disables cleanup")
+	providerCmd.Flags().Int("log-max-backups", logger.DefaultLogMaxBackups, "Number of rotated local log file backups to keep for each provider/device log")
 	providerCmd.Flags().String("hub", "", "The address of the GADS hub instance")
 	providerCmd.Flags().String("turn-username-suffix", "gads", "Suffix to append to TURN usernames (format: timestamp:suffix)")
 	providerCmd.Flags().Bool("use-ios-pair-cache", false, "Cache iOS pair records on disk to skip Trust dialog on reconnect (for unsupervised devices)")

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -111,7 +111,7 @@ func (d *AndroidDevice) Setup() (retErr error) {
 	}
 	time.Sleep(1 * time.Second)
 	if err := d.pushGadsSettingsInTmpLocal(); err != nil {
-		return fmt.Errorf("push GADS Settings to /tmp/local", err)
+		return fmt.Errorf("push GADS Settings to /tmp/local: %w", err)
 	}
 	time.Sleep(2 * time.Second)
 	if err := d.startServicesAndStreaming(); err != nil {

--- a/provider/logger/logger.go
+++ b/provider/logger/logger.go
@@ -37,11 +37,19 @@ var logLevelMapping = map[string]logrus.Level{
 
 var ProviderLogger *CustomLogger
 var logLevel string
+var logRetention = LogFileRetention{
+	MaxSizeBytes: int64(DefaultLogMaxSizeMB) * bytesPerMegabyte,
+	MaxBackups:   DefaultLogMaxBackups,
+}
 
-func SetupLogging(level string) {
+func SetupLogging(level string, maxSizeMB, maxBackups int) {
 	logLevel = level
+	retention, err := NewLogFileRetention(maxSizeMB, maxBackups)
+	if err != nil {
+		log.Fatalf("Failed to configure provider log cleanup - %s", err)
+	}
+	logRetention = retention
 
-	var err error
 	fmt.Println(fmt.Sprintf("Provider will be logging to `%s/provider.log`", config.ProviderConfig.ProviderFolder))
 	ProviderLogger, err = CreateCustomLogger(fmt.Sprintf("%s/provider.log", config.ProviderConfig.ProviderFolder), config.ProviderConfig.Nickname)
 	if err != nil {
@@ -94,8 +102,8 @@ func CreateCustomLogger(logFilePath, collection string) (*CustomLogger, error) {
 	logger.SetFormatter(&log.JSONFormatter{})
 	logger.SetLevel(logLevelMapping[logLevel])
 
-	// Open the log file
-	logFile, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	// Open the local log file with automatic size-based cleanup.
+	logFile, err := newRotatingFileWriter(logFilePath, logRetention)
 	if err != nil {
 		return &CustomLogger{}, fmt.Errorf("Could not set log output - %v", err)
 	}

--- a/provider/logger/logger.go
+++ b/provider/logger/logger.go
@@ -96,7 +96,7 @@ func (l CustomLogger) LogPanic(eventName string, message string) {
 func CreateCustomLogger(logFilePath, collection string) (*CustomLogger, error) {
 	// Create a new logger instance
 	logger := log.New()
-	ctx, _ := context.WithCancel(db.GlobalMongoStore.Ctx)
+	ctx := db.GlobalMongoStore.Ctx
 
 	// Configure the logger
 	logger.SetFormatter(&log.JSONFormatter{})

--- a/provider/logger/rotating_writer.go
+++ b/provider/logger/rotating_writer.go
@@ -1,0 +1,164 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package logger
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+const (
+	bytesPerMegabyte     = 1024 * 1024
+	DefaultLogMaxSizeMB  = 10
+	DefaultLogMaxBackups = 3
+)
+
+type LogFileRetention struct {
+	MaxSizeBytes int64
+	MaxBackups   int
+}
+
+func NewLogFileRetention(maxSizeMB, maxBackups int) (LogFileRetention, error) {
+	if maxSizeMB < 0 {
+		return LogFileRetention{}, fmt.Errorf("log max size must be greater than or equal to 0")
+	}
+	if maxBackups < 0 {
+		return LogFileRetention{}, fmt.Errorf("log max backups must be greater than or equal to 0")
+	}
+
+	return LogFileRetention{
+		MaxSizeBytes: int64(maxSizeMB) * bytesPerMegabyte,
+		MaxBackups:   maxBackups,
+	}, nil
+}
+
+type rotatingFileWriter struct {
+	mu        sync.Mutex
+	path      string
+	retention LogFileRetention
+	file      *os.File
+	size      int64
+}
+
+func newRotatingFileWriter(path string, retention LogFileRetention) (*rotatingFileWriter, error) {
+	writer := &rotatingFileWriter{
+		path:      path,
+		retention: retention,
+	}
+	if err := writer.open(); err != nil {
+		return nil, err
+	}
+	return writer, nil
+}
+
+func (w *rotatingFileWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.shouldRotate(len(p)) {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+
+	n, err := w.file.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+func (w *rotatingFileWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}
+
+func (w *rotatingFileWriter) open() error {
+	file, err := os.OpenFile(w.path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+
+	w.file = file
+	w.size = info.Size()
+	return nil
+}
+
+func (w *rotatingFileWriter) shouldRotate(nextWriteBytes int) bool {
+	return w.retention.MaxSizeBytes > 0 &&
+		w.size > 0 &&
+		w.size+int64(nextWriteBytes) > w.retention.MaxSizeBytes
+}
+
+func (w *rotatingFileWriter) rotate() error {
+	if w.file != nil {
+		if err := w.file.Close(); err != nil {
+			return err
+		}
+		w.file = nil
+	}
+
+	if w.retention.MaxBackups == 0 {
+		if err := removeIfExists(w.path); err != nil {
+			return err
+		}
+		return w.open()
+	}
+
+	if err := removeIfExists(w.backupPath(w.retention.MaxBackups)); err != nil {
+		return err
+	}
+
+	for index := w.retention.MaxBackups - 1; index >= 1; index-- {
+		source := w.backupPath(index)
+		destination := w.backupPath(index + 1)
+		if err := renameIfExists(source, destination); err != nil {
+			return err
+		}
+	}
+
+	if err := renameIfExists(w.path, w.backupPath(1)); err != nil {
+		return err
+	}
+
+	return w.open()
+}
+
+func (w *rotatingFileWriter) backupPath(index int) string {
+	return fmt.Sprintf("%s.%d", w.path, index)
+}
+
+func removeIfExists(path string) error {
+	err := os.Remove(path)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func renameIfExists(source, destination string) error {
+	err := os.Rename(source, destination)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/provider/logger/rotating_writer_test.go
+++ b/provider/logger/rotating_writer_test.go
@@ -1,0 +1,117 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRotatingFileWriterRotatesAndCleansOldBackups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "provider.log")
+	writer, err := newRotatingFileWriter(path, LogFileRetention{
+		MaxSizeBytes: 20,
+		MaxBackups:   2,
+	})
+	require.NoError(t, err)
+	defer writer.Close()
+
+	lines := []string{
+		"first log line\n",
+		"second log line\n",
+		"third log line\n",
+		"fourth log line\n",
+	}
+
+	for _, line := range lines {
+		_, err := writer.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	assertFileContains(t, path, "fourth log line")
+	assertFileContains(t, path+".1", "third log line")
+	assertFileContains(t, path+".2", "second log line")
+	assert.NoFileExists(t, path+".3")
+	assertFileNotContains(t, path+".2", "first log line")
+}
+
+func TestRotatingFileWriterCanDisableCleanup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "provider.log")
+	writer, err := newRotatingFileWriter(path, LogFileRetention{
+		MaxSizeBytes: 0,
+		MaxBackups:   0,
+	})
+	require.NoError(t, err)
+	defer writer.Close()
+
+	_, err = writer.Write([]byte(strings.Repeat("a", 128)))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(strings.Repeat("b", 128)))
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, path+".1")
+	assertFileContains(t, path, strings.Repeat("a", 128))
+	assertFileContains(t, path, strings.Repeat("b", 128))
+}
+
+func TestNewLogFileRetentionRejectsInvalidValues(t *testing.T) {
+	_, err := NewLogFileRetention(-1, 1)
+	assert.ErrorContains(t, err, "log max size")
+
+	_, err = NewLogFileRetention(1, -1)
+	assert.ErrorContains(t, err, "log max backups")
+}
+
+func TestRotatingFileWriterReturnsOpenError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "provider.log")
+	_, err := newRotatingFileWriter(path, LogFileRetention{
+		MaxSizeBytes: 20,
+		MaxBackups:   1,
+	})
+	assert.Error(t, err)
+}
+
+func TestRotatingFileWriterReturnsRotationCleanupError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "provider.log")
+	writer, err := newRotatingFileWriter(path, LogFileRetention{
+		MaxSizeBytes: 10,
+		MaxBackups:   1,
+	})
+	require.NoError(t, err)
+	defer writer.Close()
+
+	require.NoError(t, os.Mkdir(path+".1", 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(path+".1", "blocked"), []byte("backup"), 0644))
+
+	_, err = writer.Write([]byte("first line\n"))
+	require.NoError(t, err)
+
+	_, err = writer.Write([]byte("second line\n"))
+	assert.Error(t, err)
+}
+
+func assertFileContains(t *testing.T, path, expected string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), expected)
+}
+
+func assertFileNotContains(t *testing.T, path, unexpected string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), unexpected)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -32,6 +32,8 @@ var targetAppiumPluginVersion = "0.0.11"
 
 func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 	logLevel, _ := flags.GetString("log-level")
+	logMaxSizeMB, _ := flags.GetInt("log-max-size-mb")
+	logMaxBackups, _ := flags.GetInt("log-max-backups")
 	nickname, _ := flags.GetString("nickname")
 	mongoDb, _ := flags.GetString("mongo-db")
 	providerFolder, _ := flags.GetString("provider-folder")
@@ -69,7 +71,7 @@ func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 	config.ProviderConfig.UseIOSPairCache = useIOSPairCache
 
 	// Setup logging for the provider itself
-	logger.SetupLogging(logLevel)
+	logger.SetupLogging(logLevel, logMaxSizeMB, logMaxBackups)
 	logger.ProviderLogger.LogInfo("provider_setup", fmt.Sprintf("Starting provider on port `%v`", config.ProviderConfig.Port))
 
 	// Check if the default workspace exists


### PR DESCRIPTION
Summary:
- Add size-based rotation for provider and per-device local log files, defaulting to 10 MB with 3 backups.
- Add provider CLI flags to tune or disable local log cleanup and document them.
- Preserve Android setup error wrapping and fix the provider logger vet warning caught during validation.
- Make Mongo-backed secret-key audit tests skip quickly when MongoDB is unavailable instead of hanging in server selection.
- Align hub router tests with current API envelopes and legacy Appium proxy behavior, and guard `/grid/session` capability selection for always-match-only requests.

Validation:
- go test ./provider/logger
- go test -count=1 ./provider/logger -run TestRotatingFileWriterRotatesAndCleansOldBackups
- go test -count=1 ./provider/logger -run TestNewLogFileRetentionRejectsInvalidValues
- go test -count=1 ./provider/logger -run TestRotatingFileWriterReturnsOpenError
- go test -count=1 ./provider/logger -run TestRotatingFileWriterReturnsRotationCleanupError
- go build -o .codex/tmp/GADS .
- .codex/tmp/GADS provider --help | rg -- '--log-max-size-mb|--log-max-backups|--log-level'
- go vet ./provider/...
- go test ./provider/...
- go test -count=1 -timeout=2m ./hub/auth
- go test -count=1 -timeout=2m ./hub/router
- go test -count=1 -timeout=2m ./provider/...
- go test -timeout=2m ./...
- go build .
- go run . --help

Local environment note:
- `go test -count=1 -v -timeout=2m ./hub/auth -run 'TestSecretKeyAudit|TestAdminSecretKeyHistory'` skips the Mongo-backed integration tests when `localhost:27017` is unavailable, with a bounded 2s server-selection timeout.

Fixes #2
