### PR TITLE
fix(ios): tolerate HangUp failure on iOS 27+ DDI mount

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -409,8 +409,37 @@ func (d *IOSDevice) mountDeveloperImage() error {
 		if strings.Contains(err.Error(), "already mounted") || strings.Contains(err.Error(), "AlreadyMounted") {
 			return nil
 		}
+		if strings.Contains(err.Error(), "HangUp command failed") {
+			logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("DDI mount succeeded but HangUp rejected by device `%s` (likely iOS 27+), verifying mount via ListImages", d.GetUDID()))
+			for attempt := 0; attempt < 3; attempt++ {
+				time.Sleep(time.Duration(2+attempt*2) * time.Second)
+				if verifyErr := d.verifyDDIMounted(); verifyErr != nil {
+					logger.ProviderLogger.LogWarn("ios_device_setup", fmt.Sprintf("DDI verification attempt %d failed for device `%s`: %s", attempt+1, d.GetUDID(), verifyErr))
+					continue
+				}
+				return nil
+			}
+			return fmt.Errorf("failed to mount DDI: %w", err)
+		}
 		return fmt.Errorf("failed to mount DDI: %w", err)
 	}
+	return nil
+}
+
+func (d *IOSDevice) verifyDDIMounted() error {
+	mounter, err := imagemounter.NewImageMounter(d.GoIOSDeviceEntry)
+	if err != nil {
+		return fmt.Errorf("verifyDDIMounted: failed to create image mounter: %w", err)
+	}
+	defer mounter.Close()
+	signatures, err := mounter.ListImages()
+	if err != nil {
+		return fmt.Errorf("verifyDDIMounted: ListImages failed: %w", err)
+	}
+	if len(signatures) == 0 {
+		return fmt.Errorf("verifyDDIMounted: no developer images found on device")
+	}
+	logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("DDI verified mounted on device `%s` (%d image(s) found)", d.GetUDID(), len(signatures)))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

On iOS 27, the device closes the `mobile_image_mounter` lockdown connection immediately after the personalized DDI mount succeeds. The trailing `HangUp` command gets 0 bytes instead of the expected 229-byte response, causing `mountDeveloperImage()` to treat a successful mount as a fatal error and enter an infinite retry loop.

## Fix

When `MountImage` fails with `"HangUp command failed"`, log a warning and verify the DDI is actually mounted by opening a fresh connection and calling `ListImages`. Retry up to 3 times with increasing delay (2s, 4s, 6s) to account for the device needing time to register the mount.

## Root Cause

go-ios's `PersonalizedDeveloperDiskImageMounter.MountImage()` flow:
1. Query identifiers → get nonce → get Apple TSS signature
2. sendUploadRequest → stream DMG bytes → waitForUploadComplete  
3. mountPersonalizedImage ← the actual mount; **returns nil (succeeds)**
4. hangUp ← sends `{"Command":"Hangup"}` over the same lockdown connection

On iOS 27, the device closes the connection after step 3. Step 4's write gets 0 bytes → `MountImage: HangUp command failed`.

## Device

| Field | Value |
|-------|-------|
| Device | iPhone 14 (iPhone14,7) |
| iOS | 27.0 (27A5209h) |
| GADS | v5.7.0 |

## Testing

- `go build ./provider/devices/` ✅
- `go vet ./provider/devices/` ✅  
- Live verified: setup now proceeds past DDI mount to WDA installation on iOS 27

Fixes #315