### PR TITLE
Unify device rotation handling via RemoteControllable

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -1028,14 +1028,58 @@ func (d *IOSDevice) GetHardwareModel() (string, error) {
 	return d.HardwareModel, nil
 }
 
-// GetCurrentRotation returns the current device rotation (iOS uses WDA for this, handled by router).
+// GetCurrentRotation returns "portrait" or "landscape" based on the interface
+// orientation of the foreground application reported by WebDriverAgent.
 func (d *IOSDevice) GetCurrentRotation() (string, error) {
-	return d.CurrentRotation, nil
+	url := fmt.Sprintf("http://localhost:%v/orientation", d.GetWDAPort())
+	client := &http.Client{Timeout: 20 * time.Second}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return "portrait", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "portrait", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "portrait", fmt.Errorf("WebDriverAgent returned status %d - %s", resp.StatusCode, string(body))
+	}
+
+	var orientationResp struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &orientationResp); err != nil {
+		return "portrait", err
+	}
+	if strings.EqualFold(orientationResp.Value, "landscape") {
+		return "landscape", nil
+	}
+	return "portrait", nil
 }
 
-// ChangeRotation is handled via WDA in the router for iOS.
+// ChangeRotation changes the device rotation to "portrait" or "landscape" via
+// WebDriverAgent, which waits for the interface to reach the requested
+// orientation and reverts the pending device orientation when the foreground
+// app does not support it. A non-OK status only means the rotation was not
+// applied - the caller reads the rotation back to report the effective one.
 func (d *IOSDevice) ChangeRotation(rotation string) error {
-	return fmt.Errorf("iOS rotation is handled via WebDriverAgent")
+	url := fmt.Sprintf("http://localhost:%v/orientation", d.GetWDAPort())
+	body := strings.NewReader(fmt.Sprintf(`{"orientation":%q}`, strings.ToUpper(rotation)))
+	client := &http.Client{Timeout: 20 * time.Second}
+
+	resp, err := client.Post(url, "application/json", body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		d.Logger.LogDebug("ios_rotation", fmt.Sprintf("WebDriverAgent did not rotate device `%s` to `%s` - the foreground app may not support this orientation", d.GetUDID(), rotation))
+	}
+	return nil
 }
 
 // ApplyStreamSettings applies stream settings from DB to the device runtime state.

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -402,32 +402,14 @@ func DeviceChangeRotation(c *gin.Context) {
 		return
 	}
 
-	dev := platDev.GetDBDevice()
+	if err := rc.ChangeRotation(requestBody.Rotation); err != nil {
+		api.InternalError(c, err.Error())
+		return
+	}
+
 	currentRotation := requestBody.Rotation
-	if dev.OS == "android" {
-		if err := rc.ChangeRotation(requestBody.Rotation); err != nil {
-			api.InternalError(c, err.Error())
-			return
-		}
-		if rotation, err := rc.GetCurrentRotation(); err == nil {
-			currentRotation = rotation
-		}
-	} else {
-		reqBody := struct {
-			Orientation string `json:"orientation"`
-		}{
-			Orientation: strings.ToUpper(requestBody.Rotation),
-		}
-		orientationJson, err := json.MarshalIndent(reqBody, "", "  ")
-		if err != nil {
-			api.InternalError(c, err.Error())
-			return
-		}
-		_, err = wdaRequest(platDev, http.MethodPost, "orientation", bytes.NewReader(orientationJson))
-		if err != nil {
-			api.InternalError(c, err.Error())
-			return
-		}
+	if rotation, err := rc.GetCurrentRotation(); err == nil {
+		currentRotation = rotation
 	}
 
 	api.OK(c, "Device rotation request processed", gin.H{


### PR DESCRIPTION
Move the iOS-specific WebDriverAgent orientation calls out of the router and into `IOSDevice.GetCurrentRotation/ChangeRotation`, so the `DeviceChangeRotation` handler uses the same `RemoteControllable` code path for every platform. The handler now also reads the rotation back after applying it, reporting the effective orientation even when the foreground app rejects the requested one.