### PR TITLE
Prevent provider crash by skipping re-pairing of already paired iOS devices

### DIFF
--- a/provider/devices/ios.go
+++ b/provider/devices/ios.go
@@ -599,6 +599,13 @@ func (d *IOSDevice) pair() (pairErr error) {
 		}
 	}
 
+	// Skip when a pairing record already exists - re-pairing is unnecessary and
+	// go-ios Pair() can panic mid-flow depending on the device lockdown state.
+	if _, err := ios.ReadPairRecord(d.GetUDID()); err == nil {
+		logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Device `%s` already paired, skipping pair flow", d.GetUDID()))
+		return nil
+	}
+
 	logger.ProviderLogger.LogInfo("ios_device_setup", fmt.Sprintf("Pairing device `%s`", d.GetUDID()))
 
 	defer func() {


### PR DESCRIPTION
Restores the guard that skips the pairing flow when a valid pair record already exists for an iOS device. Without it, every device setup attempted a full re-pair, and a panic inside the go-ios pairing routine (nil DevicePublicKey type assertion) would crash the entire provider process. Re-provisioning already paired devices is now faster and no longer exposed to that crash.