### PR TITLE
Android TV Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
   Title: GADS - Open Source Device Farm
-  Description: Self-hosted device farm and test automation platform for iOS, Android, and Smart TVs (Samsung Tizen OS, LG WebOS). Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
+  Description: Self-hosted device farm and test automation platform for iOS, Android, and Smart TVs (Samsung Tizen OS, LG WebOS, Android TV). Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
   Author: shamanec
   Tags: device-farm, mobile-testing, ios-testing, android-testing, appium, test-automation, qa-tools, continuous-testing, mobile-device-management, selenium-grid
   -->
@@ -25,7 +25,7 @@
 
 ## 🎯 What is GADS?
 
-**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS and LG WebOS). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
+**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS, LG WebOS and Android TV). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
 
 The platform architecture consists of two main components:
 
@@ -35,7 +35,7 @@ The platform architecture consists of two main components:
 ### Why Choose GADS?
 
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
-- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS)
+- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS, Android TV)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
 - 🎮 **Local debugging - Android only**: [Connect](./docs/adb-tunnel.md) remotely controlled Android device to your local `adb` instance for development and debugging
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
@@ -88,15 +88,15 @@ The platform architecture consists of two main components:
 - 🧪 **Testing Integration**
   - Individual Appium server endpoints (optional)
   - Optional Selenium Grid 4 node registration
-  - Automated testing for Smart TVs - currently supports Samsung Tizen OS and LG WebOS (no remote control, testing only)
+  - Automated testing for Smart TVs - currently supports Samsung Tizen OS, LG WebOS and Android TV (no remote control, testing only)
 
 ## 💻 Platform Support
 
 | OS          | Android Support | iOS Support | Smart TV Support     | Notes                                                                         |
 | ----------- | --------------- | ----------- | -------------------- | ----------------------------------------------------------------------------- |
 | **macOS**   | ✅              | ✅          | ✅ (automation only) | Full support for mobile, Smart TVs support only automated testing             |
-| **Linux**   | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
-| **Windows** | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen & WebOS |
+| **Linux**   | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS & Android TV |
+| **Windows** | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS & Android TV |
 
 **Important**: Smart TV support (Tizen OS and WebOS) is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
 
@@ -264,7 +264,7 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 ### Smart TV Testing 📺
 
 - **Smart TV App Testing**: Automated testing for TV applications
-- **Currently Supported**: Samsung Tizen OS and LG WebOS
+- **Currently Supported**: Samsung Tizen OS, LG WebOS and Android TV
 - **TV-Specific Testing**: Validate TV app functionality, performance, and compatibility
 - **Remote-First Testing**: Test TV apps without physical access to devices
 
@@ -275,4 +275,4 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 
 ## 🔍 Keywords
 
-`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`, `webos-testing`, `lg-tv-testing`
+`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`, `webos-testing`, `lg-tv-testing`, `android-tv-testing`

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -15,6 +15,7 @@ type Provider struct {
 	HostAddress          string `json:"host_address" bson:"host_address"`
 	Port                 int    `json:"port" bson:"port"`
 	ProvideAndroid       bool   `json:"provide_android" bson:"provide_android"`
+	ProvideAndroidTv     bool   `json:"provide_androidtv" bson:"provide_androidtv"`
 	ProvideIOS           bool   `json:"provide_ios" bson:"provide_ios"`
 	ProvideTizen         bool   `json:"provide_tizen" bson:"provide_tizen"`
 	ProvideWebOS         bool   `json:"provide_webos" bson:"provide_webos"`
@@ -73,10 +74,11 @@ type TURNConfig struct {
 }
 
 // RegularizeProviderState applies business rules to ensure provider configuration is consistent
-// If SetupAppiumServers is false, ProvideTizen and ProvideWebOS must also be false since they require Appium servers
+// If SetupAppiumServers is false, ProvideTizen, ProvideWebOS and ProvideAndroidTv must also be false since they require Appium servers
 func (p *Provider) RegularizeProviderState() {
 	if !p.SetupAppiumServers {
 		p.ProvideTizen = false
 		p.ProvideWebOS = false
+		p.ProvideAndroidTv = false
 	}
 }

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -308,6 +308,13 @@ func ValidateDeviceUsageForOS(os, usage string) error {
 		}
 	}
 
+	// Validate Android TV devices can only be used for automation
+	if normalizedOS == "androidtv" {
+		if normalizedUsage != "automation" {
+			return fmt.Errorf("androidtv devices only support 'automation' usage. Current usage '%s' is not supported. Android TV devices can only be used for Appium testing and automation", usage)
+		}
+	}
+
 	return nil
 }
 

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -12,6 +12,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -318,6 +319,9 @@ func ValidateDeviceUsageForOS(os, usage string) error {
 	return nil
 }
 
+// androidTvUDIDPattern matches an explicit IP:PORT address (e.g. 10.30.50.107:5555).
+var androidTvUDIDPattern = regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}:\d+$`)
+
 // ValidateDevice performs comprehensive validation on a device struct
 func ValidateDevice(device *DBDevice) error {
 	if device == nil {
@@ -327,6 +331,14 @@ func ValidateDevice(device *DBDevice) error {
 	// Validate OS and Usage combination
 	if err := ValidateDeviceUsageForOS(device.OS, device.Usage); err != nil {
 		return err
+	}
+
+	// Android TV connects over ADB TCP/IP, so the UDID must be an explicit IP:PORT.
+	// The port is required (not assumed) since it must match what the TV exposes.
+	if strings.ToLower(strings.TrimSpace(device.OS)) == "androidtv" {
+		if !androidTvUDIDPattern.MatchString(device.UDID) {
+			return fmt.Errorf("androidtv devices require the UDID in IP:PORT format (e.g. 10.30.50.107:5555)")
+		}
 	}
 
 	return nil

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -14,6 +14,7 @@ The provider component is responsible for setting up the Appium servers and mana
 - [Device Notes](#device-notes)
   - [iOS Phones](#ios-phones)
   - [Android](#android-phone)
+  - [Android TV](#android-tv)
   - [Tizen TV](#tizen-tv)
   - [WebOS TV](#webos-tv)
 - [Starting Provider Instance](#starting-a-provider-instance)
@@ -50,6 +51,11 @@ To specify a folder, create it on your machine and provide it at startup using t
 - **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android devices.
 - **Enable** [USB Debugging](#usb-debugging) on each Android device.
 
+#### Android TV
+
+- **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android TV devices.
+- **Enable** [Developer Mode and network ADB debugging](#android-tv) on each Android TV.
+
 #### iOS
 
 - **Prepare** [WebDriverAgent](#build-webdriveragent-ipa-file-manually-using-xcode).
@@ -79,6 +85,11 @@ To specify a folder, create it on your machine and provide it at startup using t
 
 - **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android devices.
 - **Enable** [USB Debugging](#usb-debugging) on each Android device.
+
+#### Android TV
+
+- **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android TV devices.
+- **Enable** [Developer Mode and network ADB debugging](#android-tv) on each Android TV.
 
 #### iOS
 
@@ -115,6 +126,11 @@ To specify a folder, create it on your machine and provide it at startup using t
 
 - **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android devices.
 - **Enable** [USB Debugging](#usb-debugging) on each Android device.
+
+#### Android TV
+
+- **Install** [ADB (Android Debug Bridge)](#adb---android-debug-bridge) if providing Android TV devices.
+- **Enable** [Developer Mode and network ADB debugging](#android-tv) on each Android TV.
 
 #### iOS
 
@@ -299,6 +315,42 @@ Note that it is possible that on some devices it might not work at all, in this 
 
 **NB** It is complex to handle both device encoder and browser decoder limitations, I would suggest using Chrome/Safari, but I assume that most of the time also Firefox should manage.  
 **NB** WebRTC video has some initial delay/latency while calculating the bitrate and connection capabilities when you access the device control.
+
+### Android TV
+
+Android TV devices are provided over a network ADB connection and support **automated Appium testing only** - there is no remote control or video streaming, similar to Tizen and WebOS. They reuse the same `adb` dependency as Android phones, so no additional tooling is required.
+
+#### Developer Mode and network ADB debugging
+
+- On the Android TV open `Settings` and navigate to the `About`/`Device` section
+- Select the build/version entry repeatedly until `Developer options` are unlocked
+- Open `Developer options` and enable `USB debugging` and `Network debugging`/`ADB debugging` (the exact naming varies by manufacturer)
+
+#### Device Connection
+
+- Ensure the Android TV and the provider host machine are on the same local network
+- Connect to the TV using ADB over the network:
+  ```bash
+  adb connect <tv-ip-address>:<port>
+  ```
+  - The default ADB port is `5555`
+- The first connection will prompt an authorization dialog on the TV - accept it
+- Verify the connection by running:
+  ```bash
+  adb devices
+  ```
+- The TV should appear in the list with status `device`
+
+#### Device UDID Format
+
+- Android TV devices use the format `IP:PORT` as their UDID (e.g., `192.168.1.100:5555`)
+- This UDID must be registered in the GADS database before the device can be used and must match the address used with `adb connect`
+
+#### Known Limitations
+
+- Video streaming is not available for Android TV devices
+- Remote control is not available - Android TV devices can only be used for automated Appium testing
+- Android TV devices only support the `automation` usage type
 
 ## Starting a provider instance
 

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -113,7 +113,7 @@ func (d *AndroidDevice) Setup() (retErr error) {
 	}
 	time.Sleep(1 * time.Second)
 	if err := d.pushGadsSettingsInTmpLocal(); err != nil {
-		return fmt.Errorf("push GADS Settings to /tmp/local", err)
+		return fmt.Errorf("push GADS Settings to /tmp/local: %w", err)
 	}
 	time.Sleep(2 * time.Second)
 	if err := d.startServicesAndStreaming(); err != nil {

--- a/provider/devices/androidtv.go
+++ b/provider/devices/androidtv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 
 	"GADS/common/models"
@@ -63,6 +64,28 @@ func connectAndroidTvDevice(deviceUDID string) error {
 		return fmt.Errorf("failed to connect to Android TV device %s. Output: %s", deviceUDID, string(output))
 	}
 	return nil
+}
+
+// handleAndroidTvAutoConnection issues `adb connect` for configured Android TV devices
+// that aren't connected yet. TVs connect over the network (IP:PORT) and won't show up in
+// `adb devices` until connected, so without this the device never reaches Setup. The first
+// connect for an unauthorized TV triggers the on-device authorization prompt; the periodic
+// retry picks the device up once it's authorized. `adb connect` is idempotent.
+func handleAndroidTvAutoConnection(connectedDevices []string) {
+	for _, dev := range DevManager.All() {
+		if dev.GetOS() != "androidtv" || dev.GetDBDevice().Usage == "disabled" {
+			continue
+		}
+
+		udid := dev.GetUDID()
+		if slices.Contains(connectedDevices, udid) {
+			continue
+		}
+
+		if err := connectAndroidTvDevice(udid); err != nil {
+			logger.ProviderLogger.LogDebug("androidtv_autoconnect", fmt.Sprintf("Auto-connect attempt for Android TV %s failed: %v", udid, err))
+		}
+	}
 }
 
 func (d *AndroidTvDevice) getTVInfo() {

--- a/provider/devices/androidtv.go
+++ b/provider/devices/androidtv.go
@@ -1,0 +1,164 @@
+package devices
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"GADS/common/models"
+	"GADS/provider/config"
+	"GADS/provider/logger"
+)
+
+// AndroidTvDevice holds Android TV-specific runtime state alongside the shared RuntimeState.
+type AndroidTvDevice struct {
+	RuntimeState
+	DeviceAddress string // HOST_IP:PORT address of the Android TV
+}
+
+// Setup runs the full Android TV device provisioning sequence.
+func (d *AndroidTvDevice) Setup() error {
+	d.SetupMutex.Lock()
+	defer d.SetupMutex.Unlock()
+
+	d.SetProviderState("preparing")
+	logger.ProviderLogger.LogInfo("androidtv_device_setup", fmt.Sprintf("Running setup for Android TV device `%v`", d.GetUDID()))
+
+	if err := connectAndroidTvDevice(d.GetUDID()); err != nil {
+		logger.ProviderLogger.LogError("androidtv_device_setup", fmt.Sprintf("Failed to connect to Android TV device `%v` - %v", d.GetUDID(), err))
+		d.Reset("Failed to connect to Android TV.")
+		return err
+	}
+
+	d.getTVInfo()
+	d.DeviceAddress = d.GetUDID()
+
+	if err := setupAppiumForDevice(d); err != nil {
+		return err
+	}
+
+	d.SetProviderState("live")
+	return nil
+}
+
+// AppiumCapabilities returns the Android TV-specific Appium server capabilities.
+func (d *AndroidTvDevice) AppiumCapabilities() models.AppiumServerCapabilities {
+	return models.AppiumServerCapabilities{
+		AutomationName: "UiAutomator2",
+		PlatformName:   "Android",
+		UDID:           d.GetUDID(),
+		DeviceName:     d.DBDevice.Name,
+	}
+}
+
+func connectAndroidTvDevice(deviceUDID string) error {
+	cmd := exec.Command("adb", "connect", deviceUDID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Android TV device %s: %s. Output: %s", deviceUDID, err, string(output))
+	}
+	if strings.Contains(string(output), "failed") || strings.Contains(string(output), "cannot") {
+		return fmt.Errorf("failed to connect to Android TV device %s. Output: %s", deviceUDID, string(output))
+	}
+	return nil
+}
+
+func (d *AndroidTvDevice) getTVInfo() {
+	brand := d.getProp("ro.product.brand")
+	model := d.getProp("ro.product.model")
+	d.HardwareModel = strings.TrimSpace(fmt.Sprintf("%s %s", brand, model))
+}
+
+func (d *AndroidTvDevice) getProp(prop string) string {
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "getprop", prop)
+	var outBuffer bytes.Buffer
+	cmd.Stdout = &outBuffer
+	if err := cmd.Run(); err != nil {
+		logger.ProviderLogger.LogError("androidtv_device_setup", fmt.Sprintf("Failed to get prop %s for device %s: %v", prop, d.GetUDID(), err))
+		return ""
+	}
+	return strings.TrimSpace(outBuffer.String())
+}
+
+// InstallApp installs an app on the Android TV device.
+func (d *AndroidTvDevice) InstallApp(appName string) error {
+	appPath := fmt.Sprintf("%s/%s", config.ProviderConfig.ProviderFolder, appName)
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "install", "-r", appPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install app %s: %s. Output: %s", appName, err, string(output))
+	}
+	return nil
+}
+
+// UninstallApp uninstalls an app from the Android TV device.
+func (d *AndroidTvDevice) UninstallApp(packageName string) error {
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "uninstall", packageName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to uninstall app %s: %s. Output: %s", packageName, err, string(output))
+	}
+	return nil
+}
+
+// GetInstalledApps returns installed apps info (returns as []models.DeviceApp for the interface).
+func (d *AndroidTvDevice) GetInstalledApps() ([]models.DeviceApp, error) {
+	var result []models.DeviceApp
+	for _, packageName := range d.getInstalledAppsAndroidTv() {
+		result = append(result, models.DeviceApp{
+			AppName:          packageName,
+			BundleIdentifier: packageName,
+			CanUninstall:     true,
+		})
+	}
+	return result, nil
+}
+
+func (d *AndroidTvDevice) getInstalledAppsAndroidTv() []string {
+	installedApps := make([]string, 0)
+
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "cmd", "package", "list", "packages", "-3")
+	var outBuffer bytes.Buffer
+	cmd.Stdout = &outBuffer
+	if err := cmd.Run(); err != nil {
+		logger.ProviderLogger.LogError("androidtv_list_apps", fmt.Sprintf("Failed to list apps for device %s: %v", d.GetUDID(), err))
+		return installedApps
+	}
+
+	result := strings.TrimSpace(outBuffer.String())
+	lines := regexp.MustCompile("\r?\n").Split(result, -1)
+	for _, line := range lines {
+		lineSplit := strings.Split(line, ":")
+		if len(lineSplit) > 1 {
+			installedApps = append(installedApps, lineSplit[1])
+		}
+	}
+	return installedApps
+}
+
+// GetInstalledAppBundleIDs returns bundle identifiers (package names) of installed apps.
+func (d *AndroidTvDevice) GetInstalledAppBundleIDs() []string {
+	return d.getInstalledAppsAndroidTv()
+}
+
+// LaunchApp launches an app on the Android TV device.
+func (d *AndroidTvDevice) LaunchApp(packageName string) error {
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "monkey", "-p", packageName, "-c", "android.intent.category.LAUNCHER", "1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to launch app %s: %s. Output: %s", packageName, err, string(output))
+	}
+	return nil
+}
+
+// KillApp force-stops an app on the Android TV device.
+func (d *AndroidTvDevice) KillApp(packageName string) error {
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "am", "force-stop", packageName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to kill app %s: %s. Output: %s", packageName, err, string(output))
+	}
+	return nil
+}

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -289,6 +289,13 @@ func newPlatformDevice(dbDevice *models.DBDevice, deviceLogger models.CustomLogg
 		d.SemVer = sv
 		d.InitialSetupDone = true
 		return d
+	case "androidtv":
+		d := &AndroidTvDevice{}
+		d.DBDevice = *dbDevice
+		d.Logger = deviceLogger
+		d.SemVer = sv
+		d.InitialSetupDone = true
+		return d
 	default:
 		return nil
 	}
@@ -368,7 +375,9 @@ func GetConnectedDevicesCommon() []string {
 	var tizenDevices []string
 	var webosDevices []string
 
-	if config.ProviderConfig.ProvideAndroid {
+	// Android TV devices connect over ADB just like Android mobile devices, so the same
+	// `adb devices` listing is used; the concrete device type is resolved from the DB OS field.
+	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv {
 		androidDevices = getConnectedDevicesAndroid()
 	}
 

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -314,6 +314,15 @@ func updateDevices() {
 		defer tizenTicker.Stop()
 	}
 
+	var androidTvTicker *time.Ticker
+	var androidTvChan <-chan time.Time
+
+	if config.ProviderConfig.ProvideAndroidTv {
+		androidTvTicker = time.NewTicker(30 * time.Second)
+		androidTvChan = androidTvTicker.C
+		defer androidTvTicker.Stop()
+	}
+
 	for {
 		select {
 		case <-ticker.C:
@@ -352,6 +361,11 @@ func updateDevices() {
 		case <-tizenChan:
 			if tizenChan != nil {
 				handleTizenAutoConnection(GetConnectedDevicesCommon())
+			}
+
+		case <-androidTvChan:
+			if androidTvChan != nil {
+				handleAndroidTvAutoConnection(GetConnectedDevicesCommon())
 			}
 		}
 	}

--- a/provider/logger/logger.go
+++ b/provider/logger/logger.go
@@ -88,7 +88,7 @@ func (l CustomLogger) LogPanic(eventName string, message string) {
 func CreateCustomLogger(logFilePath, collection string) (*CustomLogger, error) {
 	// Create a new logger instance
 	logger := log.New()
-	ctx, _ := context.WithCancel(db.GlobalMongoStore.Ctx)
+	ctx := db.GlobalMongoStore.Ctx
 
 	// Configure the logger
 	logger.SetFormatter(&log.JSONFormatter{})

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -174,8 +174,8 @@ func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 		log.Fatalf("Failed to extract embedded resource files - %s", err)
 	}
 
-	// If we want to provide Android devices check if adb is available on PATH
-	if config.ProviderConfig.ProvideAndroid {
+	// If we want to provide Android or Android TV devices check if adb is available on PATH
+	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv {
 		if !providerutil.AdbAvailable() {
 			logger.ProviderLogger.LogError("provider", "adb is not available, you need to set up the host as explained in the readme")
 			fmt.Println("adb is not available, you need to set up the host as explained in the readme")


### PR DESCRIPTION
Adds **Android TV** as a new supported device platform. Like Tizen and WebOS, Android TVs are **automation-only**. They connect over the network via ADB TCP/IP and reuse the existing `adb` dependency, so no additional tooling is required.