### PR TITLE
Add Roku TV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
   Title: GADS - Open Source Device Farm
-  Description: Self-hosted device farm and test automation platform for iOS, Android, and Smart TVs (Samsung Tizen OS, LG WebOS, Android TV). Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
+  Description: Self-hosted device farm and test automation platform for iOS, Android, and Smart TVs (Samsung Tizen OS, LG WebOS, Android TV, Roku). Open source alternative to AWS Device Farm and Firebase Test Lab with Appium integration.
   Author: shamanec
   Tags: device-farm, mobile-testing, ios-testing, android-testing, appium, test-automation, qa-tools, continuous-testing, mobile-device-management, selenium-grid
   -->
@@ -25,7 +25,7 @@
 
 ## 🎯 What is GADS?
 
-**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS, LG WebOS and Android TV). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
+**GADS** is a free, open-source device farm platform that enables **remote device control** and **Appium test execution** on mobile devices (iOS/Android) and smart TVs (currently supporting Samsung Tizen OS, LG WebOS, Android TV and Roku). Perfect for QA teams, mobile developers, and organizations looking for a self-hosted alternative to expensive cloud testing services like AWS Device Farm and Firebase Test Lab.
 
 The platform architecture consists of two main components:
 
@@ -35,7 +35,7 @@ The platform architecture consists of two main components:
 ### Why Choose GADS?
 
 - 💰 **Free**: Self-hosted alternative to AWS Device Farm and Firebase Test Lab
-- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS, Android TV)
+- 📱 **Cross-Platform**: Full support for iOS and Android devices, plus automated testing for Smart TVs (Samsung Tizen OS, LG WebOS, Android TV, Roku)
 - 🎮 **Remote Control**: Real-time device control and testing capabilities
 - 🎮 **Local debugging - Android only**: [Connect](./docs/adb-tunnel.md) remotely controlled Android device to your local `adb` instance for development and debugging
 - 🔌 **Appium Compatible**: Works with industry-standard Appium testing framework
@@ -88,17 +88,17 @@ The platform architecture consists of two main components:
 - 🧪 **Testing Integration**
   - Individual Appium server endpoints (optional)
   - Optional Selenium Grid 4 node registration
-  - Automated testing for Smart TVs - currently supports Samsung Tizen OS, LG WebOS and Android TV (no remote control, testing only)
+  - Automated testing for Smart TVs - currently supports Samsung Tizen OS, LG WebOS, Android TV and Roku (no remote control, testing only)
 
 ## 💻 Platform Support
 
 | OS          | Android Support | iOS Support | Smart TV Support     | Notes                                                                         |
 | ----------- | --------------- | ----------- | -------------------- | ----------------------------------------------------------------------------- |
 | **macOS**   | ✅              | ✅          | ✅ (automation only) | Full support for mobile, Smart TVs support only automated testing             |
-| **Linux**   | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS & Android TV |
-| **Windows** | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS & Android TV |
+| **Linux**   | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS, Android TV & Roku |
+| **Windows** | ✅              | ⚠️          | ✅ (automation only) | Limited iOS support due to Xcode dependency. Currently supports Tizen, WebOS, Android TV & Roku |
 
-**Important**: Smart TV support (Tizen OS and WebOS) is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
+**Important**: Smart TV support (Tizen OS, WebOS, Android TV and Roku) is focused on **automated testing only**. Manual interaction and real-time device control available for mobile devices are not supported for smart TVs.
 
 ## License
 
@@ -264,7 +264,7 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 ### Smart TV Testing 📺
 
 - **Smart TV App Testing**: Automated testing for TV applications
-- **Currently Supported**: Samsung Tizen OS, LG WebOS and Android TV
+- **Currently Supported**: Samsung Tizen OS, LG WebOS, Android TV and Roku
 - **TV-Specific Testing**: Validate TV app functionality, performance, and compatibility
 - **Remote-First Testing**: Test TV apps without physical access to devices
 
@@ -275,4 +275,4 @@ https://github.com/user-attachments/assets/2d6b29fc-3e83-46be-88c4-d7a563205975
 
 ## 🔍 Keywords
 
-`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`, `webos-testing`, `lg-tv-testing`, `android-tv-testing`
+`device-farm`, `mobile-testing`, `ios-testing`, `android-testing`, `appium`, `test-automation`, `qa-tools`, `continuous-testing`, `mobile-device-management`, `selenium-grid`, `remote-device-control`, `mobile-qa`, `tizen-testing`, `smart-tv-testing`, `webos-testing`, `lg-tv-testing`, `android-tv-testing`, `roku-testing`

--- a/common/models/appium.go
+++ b/common/models/appium.go
@@ -77,6 +77,13 @@ type AppiumServerCapabilities struct {
 	DeviceAddress          string `json:"appium:deviceAddress,omitempty"`
 	DeviceHost             string `json:"appium:deviceHost,omitempty"`
 	ChromeDriverExecutable string `json:"appium:chromedriverExecutable,omitempty"`
+	// Roku-specific capabilities consumed
+	RokuHost       string `json:"appium:rokuHost,omitempty"`
+	RokuEcpPort    int    `json:"appium:rokuEcpPort,omitempty"`
+	RokuWebPort    int    `json:"appium:rokuWebPort,omitempty"`
+	RokuUser       string `json:"appium:rokuUser,omitempty"`
+	RokuPass       string `json:"appium:rokuPass,omitempty"`
+	RokuHeaderHost string `json:"appium:rokuHeaderHost,omitempty"`
 }
 
 type AppiumTomlNode struct {

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -19,6 +19,7 @@ type Provider struct {
 	ProvideIOS           bool   `json:"provide_ios" bson:"provide_ios"`
 	ProvideTizen         bool   `json:"provide_tizen" bson:"provide_tizen"`
 	ProvideWebOS         bool   `json:"provide_webos" bson:"provide_webos"`
+	ProvideRoku          bool   `json:"provide_roku" bson:"provide_roku"`
 	WdaBundleID          string `json:"wda_bundle_id" bson:"wda_bundle_id"`
 	WebDriverAgentIPA    string `json:"web_driver_agent_ipa" bson:"web_driver_agent_ipa"`
 	BroadcastIPA         string `json:"broadcast_ipa" bson:"broadcast_ipa"`
@@ -74,11 +75,12 @@ type TURNConfig struct {
 }
 
 // RegularizeProviderState applies business rules to ensure provider configuration is consistent
-// If SetupAppiumServers is false, ProvideTizen, ProvideWebOS and ProvideAndroidTv must also be false since they require Appium servers
+// If SetupAppiumServers is false, ProvideTizen, ProvideWebOS, ProvideAndroidTv and ProvideRoku must also be false since they require Appium servers
 func (p *Provider) RegularizeProviderState() {
 	if !p.SetupAppiumServers {
 		p.ProvideTizen = false
 		p.ProvideWebOS = false
 		p.ProvideAndroidTv = false
+		p.ProvideRoku = false
 	}
 }

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -52,6 +52,8 @@ type DBDevice struct {
 	UseWebRTCVideo bool          `json:"use_webrtc_video" bson:"use_webrtc_video"` // Should the device use WebRTC video instead of MJPEG
 	WorkspaceID    string        `json:"workspace_id" bson:"workspace_id"`         // ID of the associated workspace
 	StreamType     StreamingType `json:"stream_type" bson:"stream_type"`           // The type of video streaming for the device
+	// Roku developer-mode password
+	RokuDevPassword string `json:"roku_dev_password,omitempty" bson:"roku_dev_password,omitempty"`
 }
 
 // AndroidDisplay represents a physical display on an Android device (e.g. foldable inner/outer screen).
@@ -316,11 +318,22 @@ func ValidateDeviceUsageForOS(os, usage string) error {
 		}
 	}
 
+	// Validate Roku devices can only be used for automation
+	if normalizedOS == "roku" {
+		if normalizedUsage != "automation" {
+			return fmt.Errorf("roku devices only support 'automation' usage. Current usage '%s' is not supported. Roku devices can only be used for Appium testing and automation", usage)
+		}
+	}
+
 	return nil
 }
 
 // androidTvUDIDPattern matches an explicit IP:PORT address (e.g. 10.30.50.107:5555).
 var androidTvUDIDPattern = regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}:\d+$`)
+
+// rokuUDIDPattern matches a Roku IP address, optionally with a port (e.g. 10.30.50.112 or 10.30.50.112:8060).
+// Roku is reached over ECP (fixed port 8060), so only the IP is required.
+var rokuUDIDPattern = regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}(:\d+)?$`)
 
 // ValidateDevice performs comprehensive validation on a device struct
 func ValidateDevice(device *DBDevice) error {
@@ -338,6 +351,13 @@ func ValidateDevice(device *DBDevice) error {
 	if strings.ToLower(strings.TrimSpace(device.OS)) == "androidtv" {
 		if !androidTvUDIDPattern.MatchString(device.UDID) {
 			return fmt.Errorf("androidtv devices require the UDID in IP:PORT format (e.g. 10.30.50.107:5555)")
+		}
+	}
+
+	// Roku connects over ECP (fixed port 8060), so the UDID must be the TV IP address.
+	if strings.ToLower(strings.TrimSpace(device.OS)) == "roku" {
+		if !rokuUDIDPattern.MatchString(device.UDID) {
+			return fmt.Errorf("roku devices require the UDID to be the TV IP address (e.g. 10.30.50.112)")
 		}
 	}
 

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -52,8 +52,6 @@ type DBDevice struct {
 	UseWebRTCVideo bool          `json:"use_webrtc_video" bson:"use_webrtc_video"` // Should the device use WebRTC video instead of MJPEG
 	WorkspaceID    string        `json:"workspace_id" bson:"workspace_id"`         // ID of the associated workspace
 	StreamType     StreamingType `json:"stream_type" bson:"stream_type"`           // The type of video streaming for the device
-	// Roku developer-mode password
-	RokuDevPassword string `json:"roku_dev_password,omitempty" bson:"roku_dev_password,omitempty"`
 }
 
 // AndroidDisplay represents a physical display on an Android device (e.g. foldable inner/outer screen).

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -537,11 +537,12 @@ with the Roku driver installed.
 
 ### Developer Credentials
 
-- Sideloading/removing the dev channel (`InstallApp`/`UninstallApp`) uses the developer web installer,
-  which requires HTTP digest authentication.
 - The developer-mode **username is always `rokudev`** (fixed by Roku), so only the **password** is needed.
-- Set the password **per device in the UI**: open the device in `Admin` → `Devices` and fill in the
-  `Roku dev password` field (the password you chose when enabling Developer Mode on that TV).
+- **Automation:** provide the password via the `appium:rokuPass` capability when creating the Appium
+  session (the password you chose when enabling Developer Mode on that TV).
+- **Install/uninstall:** the install and uninstall endpoints accept a `roku_dev_password` field; the
+  provider uses it to sideload/remove the dev channel through the developer web installer (HTTP digest
+  authentication on port `80`).
 - The password is only required to sideload/remove dev channels; launching apps, listing apps and
   automation over ECP do not need it.
 
@@ -549,4 +550,4 @@ with the Roku driver installed.
 
 - Video streaming and remote control are not available for Roku devices (automation only).
 - `KillApp` has no per-app equivalent on Roku; the Home key is sent to exit the active channel.
-- Only the sideloaded dev channel (app id `dev`) can be uninstalled via the web installer.
+- Only the sideloaded dev channel (app id `dev`) can be uninstalled, through the dev web installer.

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -17,6 +17,7 @@ The provider component is responsible for setting up the Appium servers and mana
   - [Android TV](#android-tv)
   - [Tizen TV](#tizen-tv)
   - [WebOS TV](#webos-tv)
+  - [Roku TV](#roku-tv)
 - [Starting Provider Instance](#starting-a-provider-instance)
 - [Logging](#logging)
 
@@ -501,3 +502,51 @@ They will also be stored in MongoDB in DB `logs` and collection corresponding to
 - Remote control features are limited compared to mobile devices
 - Only web-based TV apps can be automated (native apps have limited support)
 - Developer Mode has a 1000-hour time limit and needs periodic renewal
+
+## Roku TV
+
+Roku devices are standalone network devices controlled over the External Control Protocol (ECP)
+and automated through the [`@headspinio/appium-roku-driver`](https://github.com/headspinio/appium-roku-driver).
+Unlike Tizen/WebOS, Roku does not require an SDK CLI on the host — only a working Appium server
+with the Roku driver installed.
+
+### Requirements
+
+- Enable `Setup Appium servers` on the provider (Roku only supports automation via Appium).
+- Install the Roku driver on the Appium server:
+
+  ```bash
+  appium driver install --source=npm @headspinio/appium-roku-driver
+  ```
+
+- The provider host must be able to reach the TV over TCP on ports `8060` (ECP) and `80` (dev web installer).
+
+### Developer Mode - Roku
+
+- On the Roku remote press: **Home** ×3 → **Up** ×2 → **Right** → **Left** → **Right** → **Left** → **Right**
+- Accept the SDK agreement and **set a developer password** (the username is always `rokudev`).
+- The TV reboots and exposes the Development Application Installer at `http://<TV_IP>`.
+
+### Device Connection
+
+- Ensure the TV and the provider host machine are on the same network.
+- Add the device in GADS using the **TV IP address** as the UDID (e.g. `10.30.50.112`). The ECP port
+  (`8060`) is fixed and does not need to be included.
+- A Roku device is considered connected when its ECP endpoint (`http://<TV_IP>:8060/query/device-info`)
+  responds.
+
+### Developer Credentials
+
+- Sideloading/removing the dev channel (`InstallApp`/`UninstallApp`) uses the developer web installer,
+  which requires HTTP digest authentication.
+- The developer-mode **username is always `rokudev`** (fixed by Roku), so only the **password** is needed.
+- Set the password **per device in the UI**: open the device in `Admin` → `Devices` and fill in the
+  `Roku dev password` field (the password you chose when enabling Developer Mode on that TV).
+- The password is only required to sideload/remove dev channels; launching apps, listing apps and
+  automation over ECP do not need it.
+
+### Known Limitations
+
+- Video streaming and remote control are not available for Roku devices (automation only).
+- `KillApp` has no per-app equivalent on Roku; the Home key is sent to exit the active channel.
+- Only the sideloaded dev channel (app id `dev`) can be uninstalled via the web installer.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobwas/ws v1.4.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/icholy/digest v1.1.0
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/pion/webrtc/v3 v3.3.6
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grandcat/zeroconf v1.0.0 h1:uHhahLBKqwWBV6WZUDAT71044vwOTL+McW0mBJvo6kE=
 github.com/grandcat/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/icholy/digest v1.1.0 h1:HfGg9Irj7i+IX1o1QAmPfIBNu/Q5A5Tu3n/MED9k9H4=
+github.com/icholy/digest v1.1.0/go.mod h1:QNrsSGQ5v7v9cReDI0+eyjsXGUoRSUZQHeQ5C4XLa0Y=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -393,6 +395,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 gvisor.dev/gvisor v0.0.0-20240405191320-0878b34101b5 h1:DOUDfNS+CFMM46k18FRF5k/0yz5NhZYMiUQxf4xglIU=
 gvisor.dev/gvisor v0.0.0-20240405191320-0878b34101b5/go.mod h1:NQHVAzMwvZ+Qe3ElSiHmq9RUm1MdNHpUZ52fiEqvn+0=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -540,6 +540,11 @@ func getTargetOSFromCaps(caps models.CommonCapabilities) string {
 		return "webos"
 	}
 
+	if strings.EqualFold(caps.PlatformName, "Roku") ||
+		strings.EqualFold(caps.AutomationName, "roku") {
+		return "roku"
+	}
+
 	return ""
 }
 

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1223,6 +1223,10 @@ func UpdateDevice(c *gin.Context) {
 				dbDevice.WorkspaceID = reqDevice.WorkspaceID
 			}
 
+			if reqDevice.RokuDevPassword != dbDevice.RokuDevPassword {
+				dbDevice.RokuDevPassword = reqDevice.RokuDevPassword
+			}
+
 			// Validate device configuration before saving to DB
 			err = models.ValidateDevice(&dbDevice)
 			if err != nil {

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1223,10 +1223,6 @@ func UpdateDevice(c *gin.Context) {
 				dbDevice.WorkspaceID = reqDevice.WorkspaceID
 			}
 
-			if reqDevice.RokuDevPassword != dbDevice.RokuDevPassword {
-				dbDevice.RokuDevPassword = reqDevice.RokuDevPassword
-			}
-
 			// Validate device configuration before saving to DB
 			err = models.ValidateDevice(&dbDevice)
 			if err != nil {

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -296,6 +296,13 @@ func newPlatformDevice(dbDevice *models.DBDevice, deviceLogger models.CustomLogg
 		d.SemVer = sv
 		d.InitialSetupDone = true
 		return d
+	case "roku":
+		d := &RokuDevice{}
+		d.DBDevice = *dbDevice
+		d.Logger = deviceLogger
+		d.SemVer = sv
+		d.InitialSetupDone = true
+		return d
 	default:
 		return nil
 	}
@@ -388,6 +395,7 @@ func GetConnectedDevicesCommon() []string {
 	var iosDevices []string
 	var tizenDevices []string
 	var webosDevices []string
+	var rokuDevices []string
 
 	// Android TV devices connect over ADB just like Android mobile devices, so the same
 	// `adb devices` listing is used; the concrete device type is resolved from the DB OS field.
@@ -407,10 +415,15 @@ func GetConnectedDevicesCommon() []string {
 		webosDevices = getConnectedDevicesWebOS()
 	}
 
+	if config.ProviderConfig.ProvideRoku {
+		rokuDevices = getConnectedDevicesRoku()
+	}
+
 	connectedDevices = append(connectedDevices, iosDevices...)
 	connectedDevices = append(connectedDevices, androidDevices...)
 	connectedDevices = append(connectedDevices, tizenDevices...)
 	connectedDevices = append(connectedDevices, webosDevices...)
+	connectedDevices = append(connectedDevices, rokuDevices...)
 
 	return connectedDevices
 }

--- a/provider/devices/roku.go
+++ b/provider/devices/roku.go
@@ -41,6 +41,7 @@ type rokuApps struct {
 
 type rokuApp struct {
 	ID   string `xml:"id,attr"`
+	Type string `xml:"type,attr"` // "appl" (channel/app), "tvin" (TV input), "menu"
 	Name string `xml:",chardata"`
 }
 
@@ -152,6 +153,9 @@ func (d *RokuDevice) queryApps() []rokuApp {
 func (d *RokuDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 	var result []models.DeviceApp
 	for _, app := range d.queryApps() {
+		if app.Type != "appl" { // skip TV inputs and menu items — only real channels are apps
+			continue
+		}
 		result = append(result, models.DeviceApp{
 			AppName:          strings.TrimSpace(app.Name),
 			BundleIdentifier: app.ID,
@@ -165,6 +169,9 @@ func (d *RokuDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 func (d *RokuDevice) GetInstalledAppBundleIDs() []string {
 	var ids []string
 	for _, app := range d.queryApps() {
+		if app.Type != "appl" { // skip TV inputs and menu items — only real channels are apps
+			continue
+		}
 		ids = append(ids, app.ID)
 	}
 	return ids

--- a/provider/devices/roku.go
+++ b/provider/devices/roku.go
@@ -1,0 +1,294 @@
+package devices
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/icholy/digest"
+
+	"GADS/common/models"
+	"GADS/provider/logger"
+)
+
+const (
+	rokuECPPort = 8060
+	rokuWebPort = 80
+)
+
+// RokuDevice holds Roku TV-specific runtime state alongside the shared RuntimeState.
+type RokuDevice struct {
+	RuntimeState
+}
+
+var rokuHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+type rokuDeviceInfo struct {
+	ModelName       string `xml:"model-name"`
+	SoftwareVersion string `xml:"software-version"`
+}
+
+type rokuApps struct {
+	Apps []rokuApp `xml:"app"`
+}
+
+type rokuApp struct {
+	ID   string `xml:"id,attr"`
+	Name string `xml:",chardata"`
+}
+
+// rokuHost returns the TV IP from the UDID, stripping the optional ECP port.
+func rokuHost(udid string) string {
+	if host, _, found := strings.Cut(udid, ":"); found {
+		return host
+	}
+	return udid
+}
+
+func rokuECPURL(udid, path string) string {
+	return fmt.Sprintf("http://%s:%d%s", rokuHost(udid), rokuECPPort, path)
+}
+
+// Setup runs the full Roku device provisioning sequence.
+func (d *RokuDevice) Setup() error {
+	d.SetupMutex.Lock()
+	defer d.SetupMutex.Unlock()
+
+	d.SetProviderState("preparing")
+	logger.ProviderLogger.LogInfo("roku_device_setup", fmt.Sprintf("Running setup for Roku device `%v`", d.GetUDID()))
+
+	d.DBDevice.IPAddress = rokuHost(d.GetUDID())
+	d.getTVInfo()
+
+	if err := setupAppiumForDevice(d); err != nil {
+		return err
+	}
+
+	d.SetProviderState("live")
+	return nil
+}
+
+// AppiumCapabilities returns the Roku-specific Appium server capabilities.
+func (d *RokuDevice) AppiumCapabilities() models.AppiumServerCapabilities {
+	return models.AppiumServerCapabilities{
+		AutomationName: "roku",
+		PlatformName:   "Roku",
+		UDID:           d.GetUDID(),
+		DeviceName:     d.DBDevice.Name,
+		RokuHost:       rokuHost(d.GetUDID()),
+		RokuEcpPort:    rokuECPPort,
+		RokuWebPort:    rokuWebPort,
+		RokuUser:       "rokudev",
+		RokuHeaderHost: rokuHost(d.GetUDID()),
+	}
+}
+
+func (d *RokuDevice) getTVInfo() {
+	resp, err := rokuHTTPClient.Get(rokuECPURL(d.GetUDID(), "/query/device-info"))
+	if err != nil {
+		logger.ProviderLogger.LogError("roku_device_setup", fmt.Sprintf("Failed to get device info for Roku device %s: %v", d.GetUDID(), err))
+		return
+	}
+	defer resp.Body.Close()
+
+	var info rokuDeviceInfo
+	if err := xml.NewDecoder(resp.Body).Decode(&info); err != nil {
+		logger.ProviderLogger.LogError("roku_device_setup", fmt.Sprintf("Failed to decode device info for Roku device %s: %v", d.GetUDID(), err))
+		return
+	}
+
+	d.HardwareModel = info.ModelName
+	if info.SoftwareVersion != "" {
+		d.DBDevice.OSVersion = info.SoftwareVersion
+	}
+}
+
+// getConnectedDevicesRoku returns the configured Roku devices whose ECP endpoint responds.
+func getConnectedDevicesRoku() []string {
+	var connectedDevices []string
+	for _, dev := range DevManager.All() {
+		if dev.GetOS() != "roku" {
+			continue
+		}
+
+		udid := dev.GetUDID()
+		resp, err := rokuHTTPClient.Get(rokuECPURL(udid, "/query/device-info"))
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			connectedDevices = append(connectedDevices, udid)
+		}
+	}
+	return connectedDevices
+}
+
+func (d *RokuDevice) queryApps() []rokuApp {
+	resp, err := rokuHTTPClient.Get(rokuECPURL(d.GetUDID(), "/query/apps"))
+	if err != nil {
+		logger.ProviderLogger.LogError("roku_list_apps", fmt.Sprintf("Failed to list apps for Roku device %s: %v", d.GetUDID(), err))
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var apps rokuApps
+	if err := xml.NewDecoder(resp.Body).Decode(&apps); err != nil {
+		logger.ProviderLogger.LogError("roku_list_apps", fmt.Sprintf("Failed to decode apps for Roku device %s: %v", d.GetUDID(), err))
+		return nil
+	}
+	return apps.Apps
+}
+
+// GetInstalledApps returns installed apps info (returns as []models.DeviceApp for the interface).
+func (d *RokuDevice) GetInstalledApps() ([]models.DeviceApp, error) {
+	var result []models.DeviceApp
+	for _, app := range d.queryApps() {
+		result = append(result, models.DeviceApp{
+			AppName:          strings.TrimSpace(app.Name),
+			BundleIdentifier: app.ID,
+			CanUninstall:     app.ID == "dev",
+		})
+	}
+	return result, nil
+}
+
+// GetInstalledAppBundleIDs returns bundle identifiers (channel ids) of installed apps.
+func (d *RokuDevice) GetInstalledAppBundleIDs() []string {
+	var ids []string
+	for _, app := range d.queryApps() {
+		ids = append(ids, app.ID)
+	}
+	return ids
+}
+
+// LaunchApp launches a channel on the Roku device over ECP.
+func (d *RokuDevice) LaunchApp(appID string) error {
+	resp, err := rokuHTTPClient.Post(rokuECPURL(d.GetUDID(), "/launch/"+appID), "", nil)
+	if err != nil {
+		return fmt.Errorf("failed to launch app %s: %w", appID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to launch app %s: ECP returned status %d", appID, resp.StatusCode)
+	}
+	return nil
+}
+
+// KillApp exits the active channel by sending the Home key over ECP.
+func (d *RokuDevice) KillApp(appID string) error {
+	resp, err := rokuHTTPClient.Post(rokuECPURL(d.GetUDID(), "/keypress/Home"), "", nil)
+	if err != nil {
+		return fmt.Errorf("failed to kill app %s: %w", appID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to kill app %s: ECP returned status %d", appID, resp.StatusCode)
+	}
+	return nil
+}
+
+// InstallApp requires the developer password, supplied per request via InstallDevChannel.
+func (d *RokuDevice) InstallApp(appName string) error {
+	return fmt.Errorf("roku channel install requires the developer password")
+}
+
+// UninstallApp requires the developer password, supplied per request via UninstallDevChannel.
+func (d *RokuDevice) UninstallApp(appID string) error {
+	return fmt.Errorf("roku channel uninstall requires the developer password")
+}
+
+// InstallDevChannel sideloads a dev channel .zip through the Roku dev web installer.
+func (d *RokuDevice) InstallDevChannel(zipPath, password string) error {
+	if password == "" {
+		return fmt.Errorf("roku dev password is required to sideload a channel")
+	}
+	return d.rokuWebInstaller("Install", zipPath, password)
+}
+
+// UninstallDevChannel removes the dev channel through the Roku dev web installer.
+func (d *RokuDevice) UninstallDevChannel(password string) error {
+	if password == "" {
+		return fmt.Errorf("roku dev password is required to remove the dev channel")
+	}
+	return d.rokuWebInstaller("Delete", "", password)
+}
+
+func (d *RokuDevice) rokuWebInstaller(submit, zipPath, password string) error {
+	body, contentType, err := buildRokuInstallerBody(submit, zipPath)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("http://%s/plugin_install", rokuHost(d.GetUDID()))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	client := &http.Client{
+		Transport: &digest.Transport{Username: "rokudev", Password: password},
+		Timeout:   30 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to reach Roku web installer: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("roku web installer rejected the developer password")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("roku web installer returned status %d", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if strings.Contains(strings.ToLower(string(respBody)), "failed") {
+		return fmt.Errorf("roku web installer reported a failure (check the developer password and the channel package)")
+	}
+	return nil
+}
+
+func buildRokuInstallerBody(submit, zipPath string) ([]byte, string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	if err := writer.WriteField("mySubmit", submit); err != nil {
+		return nil, "", err
+	}
+
+	if zipPath != "" {
+		file, err := os.Open(zipPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to open channel package: %w", err)
+		}
+		defer file.Close()
+
+		part, err := writer.CreateFormFile("archive", filepath.Base(zipPath))
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := io.Copy(part, file); err != nil {
+			return nil, "", err
+		}
+	} else {
+		if err := writer.WriteField("archive", ""); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return body.Bytes(), writer.FormDataContentType(), nil
+}

--- a/provider/devices/roku.go
+++ b/provider/devices/roku.go
@@ -236,25 +236,37 @@ func (d *RokuDevice) rokuWebInstaller(submit, zipPath, password string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", contentType)
+	// Hold the body until the installer answers its 401 digest challenge, so large
+	// .zip uploads don't break the pipe mid-stream.
+	req.Header.Set("Expect", "100-continue")
 
 	client := &http.Client{
-		Transport: &digest.Transport{Username: "rokudev", Password: password},
-		Timeout:   30 * time.Second,
+		Transport: &digest.Transport{
+			Username:  "rokudev",
+			Password:  password,
+			Transport: &http.Transport{ExpectContinueTimeout: 5 * time.Second},
+		},
+		Timeout: 60 * time.Second,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to reach Roku web installer: %w", err)
+		// Also how the device presents when busy relaunching a channel after a sideload.
+		return fmt.Errorf("could not reach Roku web installer at %s (device off/unreachable, or busy right after a channel install/launch — retry in a few seconds): %w", rokuHost(d.GetUDID()), err)
 	}
 	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	snippet := strings.Join(strings.Fields(string(respBody)), " ")
+	if len(snippet) > 200 {
+		snippet = snippet[:200]
+	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("roku web installer rejected the developer password")
+		return fmt.Errorf("roku web installer rejected the developer password (device %s)", rokuHost(d.GetUDID()))
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("roku web installer returned status %d", resp.StatusCode)
+		return fmt.Errorf("roku web installer returned status %d — the device may be busy right after a channel install/launch, retry in a few seconds; response: %s", resp.StatusCode, snippet)
 	}
-	respBody, _ := io.ReadAll(resp.Body)
 	if strings.Contains(strings.ToLower(string(respBody)), "failed") {
-		return fmt.Errorf("roku web installer reported a failure (check the developer password and the channel package)")
+		return fmt.Errorf("roku web installer reported a failure (check the developer password and the channel package); response: %s", snippet)
 	}
 	return nil
 }

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -156,8 +156,9 @@ func InstallStoredApp(c *gin.Context) {
 	}
 
 	var payload struct {
-		FileID   string `json:"file_id"`
-		Filename string `json:"filename"`
+		FileID          string `json:"file_id"`
+		Filename        string `json:"filename"`
+		RokuDevPassword string `json:"roku_dev_password"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		api.BadRequest(c, fmt.Sprintf("Invalid request body - %s", err))
@@ -185,6 +186,15 @@ func InstallStoredApp(c *gin.Context) {
 	}
 	// Always clean up the downloaded file when done
 	defer os.Remove(uploadDir + localName)
+
+	if roku, ok := platDev.(*devices.RokuDevice); ok {
+		if err := roku.InstallDevChannel(uploadDir+localName, payload.RokuDevPassword); err != nil {
+			api.InternalError(c, fmt.Sprintf("Failed installing app - %s", err))
+			return
+		}
+		api.OKMessage(c, "App installed successfully")
+		return
+	}
 
 	if err := installAppFromDisk(platDev, uploadDir, localName); err != nil {
 		api.InternalError(c, fmt.Sprintf("Failed installing app - %s", err))
@@ -391,7 +401,8 @@ func DevicesInfo(c *gin.Context) {
 }
 
 type ProcessApp struct {
-	App string `json:"app"`
+	App             string `json:"app"`
+	RokuDevPassword string `json:"roku_dev_password,omitempty"`
 }
 
 func UninstallApp(c *gin.Context) {
@@ -419,7 +430,11 @@ func UninstallApp(c *gin.Context) {
 	installedApps := platDev.GetInstalledAppBundleIDs()
 
 	if slices.Contains(installedApps, payloadJson.App) {
-		err = platDev.UninstallApp(payloadJson.App)
+		if roku, ok := platDev.(*devices.RokuDevice); ok {
+			err = roku.UninstallDevChannel(payloadJson.RokuDevPassword)
+		} else {
+			err = platDev.UninstallApp(payloadJson.App)
+		}
 		if err != nil {
 			api.InternalError(c, fmt.Sprintf("Failed to uninstall app `%s`", payloadJson.App))
 			return

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -436,7 +436,7 @@ func UninstallApp(c *gin.Context) {
 			err = platDev.UninstallApp(payloadJson.App)
 		}
 		if err != nil {
-			api.InternalError(c, fmt.Sprintf("Failed to uninstall app `%s`", payloadJson.App))
+			api.InternalError(c, fmt.Sprintf("Failed to uninstall app `%s` - %s", payloadJson.App, err))
 			return
 		}
 		deletedAppIndex := slices.Index(installedApps, payloadJson.App)


### PR DESCRIPTION
Adds Roku TV support, automating Roku devices through @headspinio/appium-roku-driver. Providers can now enable ProvideRoku, register Roku TVs by their IP address, and store a per-device developer password for sideloading dev channels. This unlocks automated Appium testing on Roku, with the setup flow fully documented in docs/provider.md.