### PR TITLE
Add app version and dev-app indicator in TV device app listings

### DIFF
--- a/common/models/models.go
+++ b/common/models/models.go
@@ -370,5 +370,7 @@ type RunningApp struct {
 type DeviceApp struct {
 	AppName          string `json:"app_name" bson:"-"`
 	BundleIdentifier string `json:"bundle_identifier" bson:"-"`
+	Version          string `json:"version" bson:"-"`
 	CanUninstall     bool   `json:"can_uninstall" bson:"-"`
+	IsDevApp         bool   `json:"is_dev_app" bson:"-"`
 }

--- a/provider/devices/androidtv.go
+++ b/provider/devices/androidtv.go
@@ -129,20 +129,29 @@ func (d *AndroidTvDevice) UninstallApp(packageName string) error {
 // GetInstalledApps returns installed apps info (returns as []models.DeviceApp for the interface).
 func (d *AndroidTvDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 	var result []models.DeviceApp
-	for _, packageName := range d.getInstalledAppsAndroidTv() {
+	versions := d.getAppVersionsAndroidTv()
+	for _, app := range d.getInstalledAppsAndroidTv() {
 		result = append(result, models.DeviceApp{
-			AppName:          packageName,
-			BundleIdentifier: packageName,
+			AppName:          app.packageName,
+			BundleIdentifier: app.packageName,
+			Version:          versions[app.packageName],
 			CanUninstall:     true,
+			// null/shell = adb sideload, packageinstaller = manual APK install; store installs report the store package
+			IsDevApp: app.installer == "null" || app.installer == "com.android.shell" || app.installer == "com.google.android.packageinstaller",
 		})
 	}
 	return result, nil
 }
 
-func (d *AndroidTvDevice) getInstalledAppsAndroidTv() []string {
-	installedApps := make([]string, 0)
+type androidTvPackage struct {
+	packageName string
+	installer   string
+}
 
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "cmd", "package", "list", "packages", "-3")
+func (d *AndroidTvDevice) getInstalledAppsAndroidTv() []androidTvPackage {
+	installedApps := make([]androidTvPackage, 0)
+
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "cmd", "package", "list", "packages", "-3", "-i")
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
@@ -153,17 +162,48 @@ func (d *AndroidTvDevice) getInstalledAppsAndroidTv() []string {
 	result := strings.TrimSpace(outBuffer.String())
 	lines := regexp.MustCompile("\r?\n").Split(result, -1)
 	for _, line := range lines {
-		lineSplit := strings.Split(line, ":")
-		if len(lineSplit) > 1 {
-			installedApps = append(installedApps, lineSplit[1])
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "package:") {
+			continue
 		}
+		packageName, installer, _ := strings.Cut(strings.TrimPrefix(line, "package:"), "installer=")
+		installedApps = append(installedApps, androidTvPackage{
+			packageName: strings.TrimSpace(packageName),
+			installer:   strings.TrimSpace(installer),
+		})
 	}
 	return installedApps
 }
 
+// versionName isn't exposed by `list packages`, so fetch it per package in a single adb roundtrip.
+func (d *AndroidTvDevice) getAppVersionsAndroidTv() map[string]string {
+	versions := map[string]string{}
+
+	script := `for p in $(pm list packages -3); do p=${p#package:}; v=$(dumpsys package $p | grep -m1 versionName); echo "$p ${v#*=}"; done`
+	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", script)
+	var outBuffer bytes.Buffer
+	cmd.Stdout = &outBuffer
+	if err := cmd.Run(); err != nil {
+		logger.ProviderLogger.LogError("androidtv_list_apps", fmt.Sprintf("Failed to get app versions for device %s: %v", d.GetUDID(), err))
+		return versions
+	}
+
+	for _, line := range regexp.MustCompile("\r?\n").Split(strings.TrimSpace(outBuffer.String()), -1) {
+		packageName, version, _ := strings.Cut(strings.TrimSpace(line), " ")
+		if version != "" && version != "null" {
+			versions[packageName] = version
+		}
+	}
+	return versions
+}
+
 // GetInstalledAppBundleIDs returns bundle identifiers (package names) of installed apps.
 func (d *AndroidTvDevice) GetInstalledAppBundleIDs() []string {
-	return d.getInstalledAppsAndroidTv()
+	var ids []string
+	for _, app := range d.getInstalledAppsAndroidTv() {
+		ids = append(ids, app.packageName)
+	}
+	return ids
 }
 
 // LaunchApp launches an app on the Android TV device.

--- a/provider/devices/roku.go
+++ b/provider/devices/roku.go
@@ -40,9 +40,10 @@ type rokuApps struct {
 }
 
 type rokuApp struct {
-	ID   string `xml:"id,attr"`
-	Type string `xml:"type,attr"` // "appl" (channel/app), "tvin" (TV input), "menu"
-	Name string `xml:",chardata"`
+	ID      string `xml:"id,attr"`
+	Type    string `xml:"type,attr"` // "appl" (channel/app), "tvin" (TV input), "menu"
+	Version string `xml:"version,attr"`
+	Name    string `xml:",chardata"`
 }
 
 // rokuHost returns the TV IP from the UDID, stripping the optional ECP port.
@@ -159,7 +160,9 @@ func (d *RokuDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 		result = append(result, models.DeviceApp{
 			AppName:          strings.TrimSpace(app.Name),
 			BundleIdentifier: app.ID,
+			Version:          app.Version,
 			CanUninstall:     app.ID == "dev",
+			IsDevApp:         app.ID == "dev",
 		})
 	}
 	return result, nil

--- a/provider/devices/tizen.go
+++ b/provider/devices/tizen.go
@@ -341,7 +341,9 @@ func (d *TizenDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 		result = append(result, models.DeviceApp{
 			AppName:          app.Title,
 			BundleIdentifier: app.AppID,
+			Version:          app.Version,
 			CanUninstall:     app.IsDevApp,
+			IsDevApp:         app.IsDevApp,
 		})
 	}
 	return result, nil

--- a/provider/devices/webos.go
+++ b/provider/devices/webos.go
@@ -201,7 +201,9 @@ func (d *WebOSDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 		result = append(result, models.DeviceApp{
 			AppName:          app.Title,
 			BundleIdentifier: app.AppID,
+			Version:          app.Version,
 			CanUninstall:     app.IsDevApp,
+			IsDevApp:         !app.SystemApp,
 		})
 	}
 	return result, nil


### PR DESCRIPTION
Adds Version and IsDevApp fields to the installed apps listing for all supported TV platforms (Android TV, Roku, Tizen and webOS)