### PR TITLE
Fix Roku dev channel installation with digest preflight auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,3 +126,5 @@ require (
 	golang.org/x/crypto v0.39.0
 	google.golang.org/protobuf v1.36.6 // indirect
 )
+
+replace github.com/icholy/digest => github.com/gifflet/digest v1.2.0-preflight

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/gifflet/digest v1.2.0-preflight h1:fBq2mjHsB0n2L5IFEMuMZN1MgT+eloWuBbJLj7mUc54=
+github.com/gifflet/digest v1.2.0-preflight/go.mod h1:1P1+LzUv48ybX7bu8tVpZ2QWdd+xRuePNuGawHjwRUE=
 github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0g=
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=

--- a/provider/devices/roku.go
+++ b/provider/devices/roku.go
@@ -235,33 +235,33 @@ func (d *RokuDevice) UninstallDevChannel(password string) error {
 }
 
 func (d *RokuDevice) rokuWebInstaller(submit, zipPath, password string) error {
+	host := rokuHost(d.GetUDID())
+	url := fmt.Sprintf("http://%s/plugin_install", host)
+
 	body, contentType, err := buildRokuInstallerBody(submit, zipPath)
 	if err != nil {
 		return err
 	}
-
-	url := fmt.Sprintf("http://%s/plugin_install", rokuHost(d.GetUDID()))
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", contentType)
-	// Hold the body until the installer answers its 401 digest challenge, so large
-	// .zip uploads don't break the pipe mid-stream.
-	req.Header.Set("Expect", "100-continue")
 
+	// Preflight fetches the challenge with a bodyless request so the package streams
+	// only once authenticated; DisableKeepAlives avoids reusing the 401'd socket.
 	client := &http.Client{
 		Transport: &digest.Transport{
 			Username:  "rokudev",
 			Password:  password,
-			Transport: &http.Transport{ExpectContinueTimeout: 5 * time.Second},
+			Preflight: true,
+			Transport: &http.Transport{DisableKeepAlives: true},
 		},
 		Timeout: 60 * time.Second,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		// Also how the device presents when busy relaunching a channel after a sideload.
-		return fmt.Errorf("could not reach Roku web installer at %s (device off/unreachable, or busy right after a channel install/launch — retry in a few seconds): %w", rokuHost(d.GetUDID()), err)
+		return fmt.Errorf("could not reach Roku web installer at %s (device off/unreachable, or busy right after a channel install/launch — retry in a few seconds): %w", host, err)
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
@@ -270,7 +270,7 @@ func (d *RokuDevice) rokuWebInstaller(submit, zipPath, password string) error {
 		snippet = snippet[:200]
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("roku web installer rejected the developer password (device %s)", rokuHost(d.GetUDID()))
+		return fmt.Errorf("roku web installer rejected the developer password (device %s)", host)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("roku web installer returned status %d — the device may be busy right after a channel install/launch, retry in a few seconds; response: %s", resp.StatusCode, snippet)


### PR DESCRIPTION
Reworks the Roku web installer to authenticate before streaming the channel package, replacing the unreliable Expect: 100-continue approach that broke large .zip uploads. The digest dependency now points to my fork that supports a bodyless preflight challenge.