### PR TITLE
Centralize WebRTC TURN configuration and add diagnostic logging

### DIFF
--- a/common/utils/webrtc.go
+++ b/common/utils/webrtc.go
@@ -4,6 +4,7 @@ import (
 	"GADS/common/auth"
 	"GADS/common/db"
 	"GADS/provider/config"
+	"GADS/provider/logger"
 	"fmt"
 
 	"github.com/pion/webrtc/v3"
@@ -15,7 +16,14 @@ func GenerateWebRTCConfig() webrtc.Configuration {
 	}
 
 	turnConfig, err := db.GlobalMongoStore.GetTURNConfig()
-	if err == nil && turnConfig.Enabled && turnConfig.Server != "" && turnConfig.SharedSecret != "" {
+	switch {
+	case err != nil:
+		logger.ProviderLogger.LogWarn("webrtc_config", fmt.Sprintf("TURN config unavailable, WebRTC will use STUN only - %v", err))
+	case !turnConfig.Enabled:
+		logger.ProviderLogger.LogWarn("webrtc_config", "TURN disabled in config, WebRTC will use STUN only")
+	case turnConfig.Server == "" || turnConfig.SharedSecret == "":
+		logger.ProviderLogger.LogWarn("webrtc_config", "TURN enabled but server/shared secret missing, WebRTC will use STUN only")
+	default:
 		ttl := turnConfig.TTL
 		if ttl == 0 {
 			ttl = 3600
@@ -30,6 +38,7 @@ func GenerateWebRTCConfig() webrtc.Configuration {
 			Credential: password,
 		}
 		iceServers = append(iceServers, turnIceServer)
+		logger.ProviderLogger.LogInfo("webrtc_config", fmt.Sprintf("Applying TURN relay: server=%s:%d suffix=%s", turnConfig.Server, turnConfig.Port, config.ProviderConfig.TURNUsernameSuffix))
 	}
 
 	return webrtc.Configuration{

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -11,7 +11,6 @@ package devices
 
 import (
 	"GADS/common"
-	"GADS/common/auth"
 	"GADS/common/db"
 	"GADS/common/models"
 	"GADS/provider/config"
@@ -243,13 +242,6 @@ func (d *AndroidDevice) startServicesAndStreaming() error {
 		logger.ProviderLogger.LogError("android_device_setup", fmt.Sprintf("Could not forward GADS streaming port to host port %v for Android device `%v` - %v", d.StreamPort, d.GetUDID(), err))
 		d.Reset("Failed to forward GADS-stream port to host port.")
 		return err
-	}
-
-	// Send TURN configuration to WebRTC service (non-fatal)
-	if models.IsWebRTCStreamType(d.DBDevice.StreamType) {
-		if err := d.UpdateWebRTCTURNConfig(); err != nil {
-			logger.ProviderLogger.LogWarn("android_device_setup", fmt.Sprintf("Could not send TURN config to device `%s` - %v (WebRTC will use STUN only)", d.GetUDID(), err))
-		}
 	}
 
 	// Audio streaming setup (non-fatal): a dedicated AudioService streams PCM over
@@ -808,41 +800,6 @@ func (d *AndroidDevice) UpdateStreamSettingsOnDevice() error {
 
 	if err := wsutil.WriteServerMessage(destConn, ws.OpText, []byte(socketMsg)); err != nil {
 		return fmt.Errorf("failed sending stream settings to stream websocket - %s", err)
-	}
-	return nil
-}
-
-// UpdateWebRTCTURNConfig sends TURN configuration to the WebRTC service on the device.
-func (d *AndroidDevice) UpdateWebRTCTURNConfig() error {
-	turnConfig, err := db.GlobalMongoStore.GetTURNConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get TURN config from DB - %s", err)
-	}
-	if !turnConfig.Enabled {
-		return nil
-	}
-	if turnConfig.Server == "" || turnConfig.SharedSecret == "" {
-		return fmt.Errorf("TURN config incomplete: server=%s, shared_secret configured=%t", turnConfig.Server, turnConfig.SharedSecret != "")
-	}
-
-	ttl := turnConfig.TTL
-	if ttl == 0 {
-		ttl = 3600
-	}
-	username, password, _ := auth.GenerateTURNCredentials(turnConfig.SharedSecret, ttl, config.ProviderConfig.TURNUsernameSuffix)
-
-	u := url.URL{Scheme: "ws", Host: "localhost:" + d.StreamPort, Path: ""}
-	destConn, _, _, err := ws.DefaultDialer.Dial(context.Background(), u.String())
-	if err != nil {
-		return fmt.Errorf("failed connecting to WebRTC service WebSocket - %s", err)
-	}
-	defer destConn.Close()
-
-	turnMsg := fmt.Sprintf(`{"type":"turn","server":"%s","port":%d,"username":"%s","password":"%s"}`,
-		turnConfig.Server, turnConfig.Port, username, password)
-
-	if err := wsutil.WriteServerMessage(destConn, ws.OpText, []byte(turnMsg)); err != nil {
-		return fmt.Errorf("failed sending TURN config to WebSocket - %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
TURN configuration was being resolved in two places: the shared `GenerateWebRTCConfig` helper and the deprecated device-specific `UpdateWebRTCTURNConfig` call that pushed credentials to the Android WebRTC service over WebSocket during device setup. This PR removes the deprecated device-side path, leaving a single source of truth for TURN credentials. It also replaces the silent `if err == nil && ...` fallback with an explicit switch that logs why WebRTC degraded to STUN only (DB error, TURN disabled, or missing server/shared secret) and logs the TURN relay when one is applied, so ICE connectivity issues can be diagnosed straight from the provider logs