### PR TITLE
provider: remove stale adb forward rules on device reset

### DIFF
--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -304,6 +304,13 @@ func (d *AndroidDevice) AppiumCapabilities() models.AppiumServerCapabilities {
 // Reset overrides RuntimeState.Reset to free Android-specific ports.
 func (d *AndroidDevice) Reset(reason string) {
 	if d.ResetBase(reason) {
+		// Remove the actual 'adb forward' rules, otherwise they linger on the host
+		// forever (until provider restart) everi time the device gets re-setup
+		d.removeForwardedPort(d.StreamPort)
+		d.removeForwardedPort(d.AndroidIMEPort)
+		d.removeForwardedPort(d.AndroidRemoteServerPort)
+		d.removeForwardedPort(d.ADBPort)
+
 		common.MutexManager.LocalDevicePorts.Lock()
 		delete(providerutil.UsedPorts, d.StreamPort)
 		delete(providerutil.UsedPorts, d.AndroidIMEPort)
@@ -454,6 +461,17 @@ func (d *AndroidDevice) forwardPort(devicePort, hostPort string) error {
 		return fmt.Errorf("forwardPort: Error forwarding device port %s to host port %s - %s", devicePort, hostPort, err)
 	}
 	return nil
+}
+
+func (d *AndroidDevice) removeForwardedPort(hostPort string) {
+	if hostPort == "" {
+		return
+	}
+	// Use context.Background - d.Context may already be cancelled during Reset.
+	cmd := exec.CommandContext(context.Background(), "adb", "-s", d.GetUDID(), "forward", "--remove", "tcp:"+hostPort)
+	if err := cmd.Run(); err != nil {
+		logger.ProviderLogger.LogDebug("android_device_setup", fmt.Sprintf("removeForwardedPort: Could not remove `adb` forward for host port %s, device `%v`, - %s", hostPort, d.GetUDID(), err))
+	}
 }
 
 func (d *AndroidDevice) forwardStream() error {


### PR DESCRIPTION
AndroidDevice.Reset() only freed host ports from the in-memory UsedPorts map, but never removed the correspoding `adb forward` rules. Since Setup() is retried automatically (backoff, USB hiccups, transpient failures) and always allocates fresh random hosts ports, every re-setup cycle left the previous cycle's forward rules dangling on the host, causing them to accumulate indefinitely until the providerr process was restarted.

Add removeForwardPort() to run `adb -s <serial> forward --remove tcp:<port> for the stream, IME, remote-server and ADB tunnel ports, and callit from Reset() before the ports are freed and resused.