### PR TITLE
Appium Grid improvements

### DIFF
--- a/appium-plugin/gads-appium-plugin.js
+++ b/appium-plugin/gads-appium-plugin.js
@@ -18,13 +18,8 @@ class GadsAppium extends BasePlugin {
     static apiClient = null;
     // Static property to hold the current Appium session ID
     static currentSessionId = "";
-
-    // New endpoints on the Appium server from the plugin itself
-    static newMethodMap = {
-        '/gads/source': {
-            GET: { command: 'getSourceNoSession', neverProxy: true }, // never proxy → Appium handles it
-        },
-    };
+    // Timestamp of the last throttled command-activity report to the provider
+    static lastCommandReportTs = 0;
 
     /**
      * updateServer
@@ -37,9 +32,11 @@ class GadsAppium extends BasePlugin {
      * @param {object} cliArgs      Parsed CLI arguments
    */
     static async updateServer(_app, _httpServer, cliArgs) {
-        // Load config from --plugin-gads-config or legacy --plugin.gads.config
+        // Load config from --plugin-gads-config, which Appium's CLI parser exposes
+        // as the nested plugin.gads.config; the flat camelCase key is kept as a
+        // fallback for safety
         const cfg = loadConfig(
-            cliArgs.pluginGadsConfig ?? cliArgs.plugin?.gads?.config
+            cliArgs.plugin?.gads?.config ?? cliArgs.pluginGadsConfig
         )
 
         // Create API client
@@ -92,28 +89,29 @@ class GadsAppium extends BasePlugin {
     /**
      * createSession
      *
-     * Wraps the driver.createSession call to capture the generated sessionId and notify the provider
-     * That sessionId is used to tag subsequent log messages.
+     * Wraps session creation to capture the generated sessionId and notify the provider.
+     * That sessionId is used to tag subsequent log messages. The resolved session
+     * capabilities are sent along so GADS knows what the driver actually started with.
      *
-     * @param {Function} next            The next handler in the chain
-     * @param {object} driver            The underlying driver instance
-     * @param {object} jsonwpCaps        JSONWP-style capabilities
-     * @param {object} reqCaps           W3C requested capabilities
-     * @param {object} w3cCapabilities   W3C capabilities object
-     * @returns {object}                 The result of driver.createSession
+     * Calls through via next() (canonical plugin chaining) - the capability arguments
+     * differ between Appium 2 and 3, but the result shape {value: [sessionId, caps,
+     * protocol]} is identical across both majors.
+     *
+     * @param {Function} next   The next handler in the chain
+     * @param {object} driver   The underlying driver instance
+     * @returns {object}        The session creation result
    */
-    async createSession(next, driver, jsonwpCaps, reqCaps, w3cCapabilities) {
+    async createSession(next, driver) {
         // Make sure instance has access to the loaded config
         this.cfg = GadsAppium.cfg
 
-        // Call through to the driver’s createSession
-        const createSessionResult = await driver.createSession?.(jsonwpCaps, reqCaps, w3cCapabilities)
+        const createSessionResult = await next()
 
-        // Extract the sessionId
+        // Extract the sessionId and the resolved capabilities
         const sessionId = createSessionResult?.value?.[0]
         if (sessionId) {
             GadsAppium.currentSessionId = sessionId;
-            await GadsAppium.apiClient.addSession(GadsAppium.currentSessionId)
+            await GadsAppium.apiClient.addSession(sessionId, createSessionResult?.value?.[1])
         }
 
         return createSessionResult
@@ -144,14 +142,26 @@ class GadsAppium extends BasePlugin {
     }
 
     /**
-     * Wraps the handle function for driver commands so we can get data for session logging
-     * @param {*} next 
-     * @param {*} driver 
-     * @param {*} commandName 
-     * @param  {...any} args 
-     * @returns 
+     * Wraps every driver command (including proxied ones, since a generic handle()
+     * disables Appium's direct proxying) and reports activity to the provider,
+     * throttled to at most one report per 2 seconds. The report is fire-and-forget -
+     * awaiting it would add provider round-trip latency to every command.
+     * @param {*} next
+     * @param {*} driver
+     * @param {*} commandName
+     * @param  {...any} args
+     * @returns
      */
     async handle(next, driver, commandName, ...args) {
+        const now = Date.now()
+        if (now - GadsAppium.lastCommandReportTs > 2000) {
+            GadsAppium.lastCommandReportTs = now
+            GadsAppium.apiClient.sendCommand({
+                command: commandName,
+                session_id: GadsAppium.currentSessionId,
+                timestamp: now,
+            })
+        }
         return await next()
     }
 

--- a/appium-plugin/package-lock.json
+++ b/appium-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "appium-gads",
-    "version": "0.0.9",
+    "version": "0.0.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "appium-gads",
-            "version": "0.0.9",
+            "version": "0.0.12",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@appium/base-plugin": "^2.3.7"

--- a/appium-plugin/package.json
+++ b/appium-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "appium-gads",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "type": "module",
     "main": "gads-appium-plugin.js",
     "keywords": [

--- a/appium-plugin/src/api/client.js
+++ b/appium-plugin/src/api/client.js
@@ -33,10 +33,11 @@ export class GadsApiClient {
         }
     }
 
-    // Notify provider about the currently live session
-    async addSession(sessionId) {
+    // Notify provider about the currently live session, including the resolved
+    // session capabilities when available (older providers ignore the body)
+    async addSession(sessionId, capabilities) {
         try {
-            await this.api.post(`/session/add/${sessionId}`);
+            await this.api.post(`/session/add/${sessionId}`, capabilities ?? {});
         } catch (e) {
             throw new Error(`GADS - Add session failed, provider down - ${e.message}`);
         }
@@ -57,6 +58,16 @@ export class GadsApiClient {
             await this.api.post('/log', logData)
         } catch (e) {
             // Silent fail for logs to avoid disrupting main flow
+        }
+    }
+
+    // Report driver command activity to the provider (older providers 404 this
+    // endpoint, which the silent fail also covers)
+    async sendCommand(commandData) {
+        try {
+            await this.api.post('/command', commandData)
+        } catch (e) {
+            // Silent fail - activity reporting must never disrupt the command flow
         }
     }
 

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -40,6 +40,14 @@ type ProviderDeviceSync struct {
 	Host          string `json:"host"`
 	Connected     bool   `json:"connected"`
 	ProviderState string `json:"provider_state"`
+	// Appium session truth as reported by the device's appium-plugin. The marker
+	// field distinguishes a provider that reports these from an older one whose
+	// zero values would be indistinguishable from "no session" - the hub must not
+	// act on the session fields unless the marker is true
+	ReportsAppiumSessionState bool   `json:"reports_appium_session_state"`
+	HasAppiumSession          bool   `json:"has_appium_session"`
+	AppiumSessionID           string `json:"appium_session_id"`
+	AppiumLastCommandTS       int64  `json:"appium_last_command_ts"`
 }
 
 type ProviderData struct {

--- a/common/models/models.go
+++ b/common/models/models.go
@@ -49,7 +49,7 @@ type DBDevice struct {
 	OSVersion    string `json:"os_version" bson:"os_version"`       // OS version of the device
 	IPAddress    string `json:"ip_address" bson:"ip_address"`       // IP address of the device
 	Provider     string `json:"provider" bson:"provider"`           // nickname of the device host(provider)
-	Usage        string `json:"usage" bson:"usage"`                 // what is the device used for: enabled(automation and remote control), automation(only Appium testing), remote(only remote control), disabled
+	Usage        string `json:"usage" bson:"usage"`                 // what is the device used for: enabled(automation and remote control), automation(only Appium testing), control(only remote control), disabled
 	ScreenWidth  string `json:"screen_width" bson:"screen_width"`   // screen width of device
 	ScreenHeight string `json:"screen_height" bson:"screen_height"` // screen height of device
 	DeviceType   string `json:"device_type" bson:"device_type"`     // The type of device - `real` or `emulator`

--- a/docs/appium-credentials.md
+++ b/docs/appium-credentials.md
@@ -44,6 +44,10 @@ The configurable prefix provides valuable flexibility for:
 
 ## 📱 Using Credentials with Appium
 
+### Appium Grid Endpoint
+
+The same `gads:clientSecret` capability authenticates session requests against the hub's Appium grid at `http://gads-hub:10000/grid`, where the device is selected by capabilities (`appium:udid`, `platformName`/`appium:automationName`, optional `appium:platformVersion`) instead of the URL. The grid also understands `gads:queueTimeout` (seconds to wait for a free device, default 10, max 300) and returns `gads:deviceUdid`, `gads:deviceName`, `gads:provider` and `gads:controlUrl` in the session response. All `gads:*` capabilities are stripped before the request reaches Appium, so the secret never appears in Appium logs. See the [hub documentation](./hub.md#appium-grid) for the full grid behavior.
+
 ### Device-Specific Appium Endpoints
 
 In GADS, each device has its own dedicated Appium server endpoint. This means you connect directly to a specific device using its unique ID in the URL:

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -61,6 +61,7 @@ For this reason the hub embeds its own grid implementation - no Selenium Grid re
 - By UDID via `appium:udid`
 - By `platformName` (iOS or Android) or `appium:automationName` (XCUITest or UiAutomator2)
   - Additionally the grid allows filtering by `appium:platformVersion` capability which supports exact version e.g. `17.5.1` or a major version e.g. `17`, `11` etc
+- Devices whose usage is set to `Control` or `Disabled`, and devices on a provider configured without Appium servers, are never dispatched - requests pinned to one by UDID fail immediately with the reason instead of queueing
 
 **Queueing**
 - When no matching device is free the request waits in a FIFO queue - first come, first served
@@ -73,7 +74,7 @@ For this reason the hub embeds its own grid implementation - no Selenium Grid re
 
 **Response enrichment** - a successful session response includes extra `gads:*` capabilities telling you which device you actually got:
 - `gads:deviceUdid`, `gads:deviceName`, `gads:provider`
-- `gads:controlUrl` - a direct link to the hub's remote control UI for the device serving your test; the session owner can also attach from the device list via the `Debug your test` button and watch the test live
+- `gads:controlUrl` - a direct link to the hub's remote control UI for the device serving your test; the session owner can also attach from the device list via the `Use` button (after confirming) and watch the test live
 
 **Observability**
 - `GET /grid/status` (unauthenticated) reports overall grid readiness and per-device availability

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -48,17 +48,36 @@ You have to provide all the required information and assign each device to a pro
 Changes to the device configuration require the respective provider instance restarted.  
 All fields have tooltips to help you with the required information.
 
-### Experimental Appium grid
+### Appium grid
 
 Using Selenium Grid 4 is a bit of a hassle and some versions do not work properly with Appium relay nodes.  
-For this reason I created an experimental grid implementation into the hub itself.  
-I haven't even read the Selenium Grid implementation and made up something myself - it might not work properly but could be the better alternative if it does work properly.  
-The experimental grid was tested only using latest Appium and Selenium Java client versions and with TestNG. Tests can be executed sequentially or in parallel using TestNG with `methods` or `classes` with multiple threads. I assume it should support any type of session creation with any Appium language client
+For this reason the hub embeds its own grid implementation - no Selenium Grid required. Point your Appium/Selenium driver URL at the hub, e.g. `http://192.168.1.6:10000/grid`, and create sessions as you usually would with any Appium language client.
 
-- The grid is accessible on your hub instance e.g. `http://192.168.1.6:10000/grid` and should be used as Appium/Selenium driver URL target. You just try to start a session as you usually do with Selenium Grid
-- The grid allows targeting devices by UDID
-- The grid allows targeting devices by `platformName`(iOS or Android) or `appium:automationName`(XCUITest or UiAutomator2) capabilities during session creation
+**Session requests**
+- Requests must use the W3C `capabilities` format (`alwaysMatch`/`firstMatch`). Legacy `desiredCapabilities`-only requests are rejected with `400 invalid argument` - Appium 2+ does not accept them either
+- Every session request must carry the `gads:clientSecret` capability for authentication - see [Appium client credentials](./appium-credentials.md). All `gads:*` capabilities are stripped before the request is forwarded, so the secret never appears in Appium logs
+
+**Device targeting**
+- By UDID via `appium:udid`
+- By `platformName` (iOS or Android) or `appium:automationName` (XCUITest or UiAutomator2)
   - Additionally the grid allows filtering by `appium:platformVersion` capability which supports exact version e.g. `17.5.1` or a major version e.g. `17`, `11` etc
+
+**Queueing**
+- When no matching device is free the request waits in a FIFO queue - first come, first served
+- The default wait is 10 seconds; the `gads:queueTimeout` capability (seconds, clamped to 300) sets it per request, and `0` means fail immediately when nothing is free
+
+**Session behavior**
+- `appium:newCommandTimeout` is honored by the hub as well (default 60 seconds); an explicit `0` disables idle expiry entirely
+- Only the exact `DELETE /grid/session/{id}` ends a session - DELETEs on subpaths (`/window`, `/cookie`, `/actions`) are proxied as ordinary commands
+- BiDi is not supported: sessions requesting `webSocketUrl: true` still create fine, but the `webSocketUrl` capability is always removed from the response
+
+**Response enrichment** - a successful session response includes extra `gads:*` capabilities telling you which device you actually got:
+- `gads:deviceUdid`, `gads:deviceName`, `gads:provider`
+- `gads:controlUrl` - a direct link to the hub's remote control UI for the device serving your test; the session owner can also attach from the device list via the `Debug your test` button and watch the test live
+
+**Observability**
+- `GET /grid/status` (unauthenticated) reports overall grid readiness and per-device availability
+- `GET /automation-sessions` (authenticated) lists the currently active automation sessions
 
 ### Android devices remote control debugging
 

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -77,7 +77,7 @@ For this reason the hub embeds its own grid implementation - no Selenium Grid re
 - `gads:controlUrl` - a direct link to the hub's remote control UI for the device serving your test; the session owner can also attach from the device list via the `Use` button (after confirming) and watch the test live
 
 **Observability**
-- `GET /grid/status` (unauthenticated) reports overall grid readiness and per-device availability
+- `GET /grid/status` reports overall grid readiness; without credentials that is all it reports. Send your client secret as `Authorization: Bearer <secret>` to also get the per-device availability list and a readiness flag scoped to your tenant's workspaces
 - `GET /automation-sessions` (authenticated) lists the currently active automation sessions
 
 ### Android devices remote control debugging

--- a/hub/devices/availability_signal.go
+++ b/hub/devices/availability_signal.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+// deviceFreedSignal is a coalescing wake-up for the grid session queue - any event
+// that may have made a device available for automation pokes it. Capacity 1 is
+// enough: a pending wake-up already covers every event that raced in before the
+// dispatcher consumes it
+var deviceFreedSignal = make(chan struct{}, 1)
+
+// NotifyDeviceFreed signals that a device may have become available for automation.
+// Non-blocking, so it is safe to call while holding a device mutex
+func NotifyDeviceFreed() {
+	select {
+	case deviceFreedSignal <- struct{}{}:
+	default:
+	}
+}
+
+// DeviceFreedSignal returns the channel the grid session queue dispatcher waits on
+func DeviceFreedSignal() <-chan struct{} {
+	return deviceFreedSignal
+}

--- a/hub/devices/devices.go
+++ b/hub/devices/devices.go
@@ -45,6 +45,17 @@ func GetLatestDBDevices() {
 	for {
 		latestDBDevices, _ = db.GlobalMongoStore.GetDevices()
 
+		// Whether each provider runs Appium servers, by nickname. When the lookup
+		// fails the previous per-device values are kept rather than flipped
+		appiumByProvider := map[string]bool{}
+		providersKnown := false
+		if dbProviders, err := db.GlobalMongoStore.GetAllProviders(); err == nil {
+			providersKnown = true
+			for _, dbProvider := range dbProviders {
+				appiumByProvider[dbProvider.Nickname] = dbProvider.SetupAppiumServers
+			}
+		}
+
 		// Remove devices from the store that are no longer in the DB
 		var toDelete []string
 		for _, hubDevice := range HubDeviceStore.All() {
@@ -89,6 +100,9 @@ func GetLatestDBDevices() {
 				if hubDevice.Device.WorkspaceID != dbDevice.WorkspaceID {
 					hubDevice.Device.WorkspaceID = dbDevice.WorkspaceID
 				}
+				if providersKnown {
+					hubDevice.AppiumEnabled = providerAppiumEnabled(appiumByProvider, dbDevice.Provider)
+				}
 				hubDevice.Mu.Unlock()
 			} else {
 				HubDeviceStore.Set(dbDevice.UDID, &LocalHubDevice{
@@ -96,11 +110,23 @@ func GetLatestDBDevices() {
 					IsRunningAutomation:      false,
 					IsAvailableForAutomation: true,
 					LastAutomationActionTS:   0,
+					AppiumEnabled:            providerAppiumEnabled(appiumByProvider, dbDevice.Provider),
 				})
 			}
 		}
 		time.Sleep(1 * time.Second)
 	}
+}
+
+// providerAppiumEnabled resolves whether a device's provider runs Appium servers.
+// An unknown nickname (deleted provider, failed lookup) defaults to true so a
+// transient gap never hides working devices from the grid or the UI
+func providerAppiumEnabled(appiumByProvider map[string]bool, nickname string) bool {
+	enabled, ok := appiumByProvider[nickname]
+	if !ok {
+		return true
+	}
+	return enabled
 }
 
 func GetHubDeviceByUDID(udid string) *LocalHubDevice {

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -136,6 +136,7 @@ func (d *LocalHubDevice) ClaimForAutomation(newCommandTimeoutMS int64) {
 
 // ReleaseFromAutomation clears the device's automation session state, including its
 // session registry entry, and releases the lock unless a UI or API session holds it.
+// The grid session queue is poked so a queued session request can grab the device.
 func (d *LocalHubDevice) ReleaseFromAutomation() {
 	if d.SessionID != "" {
 		UnregisterSession(d.SessionID)
@@ -145,6 +146,7 @@ func (d *LocalHubDevice) ReleaseFromAutomation() {
 	d.IsRunningAutomation = false
 	d.IsAvailableForAutomation = true
 	d.ReleaseLockIfNotHeld()
+	NotifyDeviceFreed()
 }
 
 // RefreshLock updates InUseTS to now, keeping the lock alive.

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -42,6 +42,7 @@ type LocalHubDevice struct {
 	LockSource               string        `json:"lock_source" bson:"-"` // "ui", "api", or ""
 	LeaseExpiresAt           int64         `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
 	AppiumNewCommandTimeout  int64         `json:"appium_new_command_timeout"`
+	AutomationSessionStartTS int64         `json:"-" bson:"-"` // Unix ms when the current Appium grid session was created, 0 = no session
 	IsAvailableForAutomation bool          `json:"is_available_for_automation"`
 	Available                bool          `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
 	InUseWSConnection        net.Conn      `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
@@ -140,6 +141,7 @@ func (d *LocalHubDevice) ReleaseFromAutomation() {
 		UnregisterSession(d.SessionID)
 	}
 	d.SessionID = ""
+	d.AutomationSessionStartTS = 0
 	d.IsRunningAutomation = false
 	d.IsAvailableForAutomation = true
 	d.ReleaseLockIfNotHeld()

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -52,6 +52,7 @@ type LocalHubDevice struct {
 	ProviderLastCommandTS        int64  `json:"provider_last_command_ts" bson:"-"`
 	ProviderSessionMissingSinceTS int64 `json:"-" bson:"-"` // Unix ms since the provider stopped reporting a session the hub still tracks, 0 = not missing
 	IsAvailableForAutomation bool          `json:"is_available_for_automation"`
+	AppiumEnabled            bool          `json:"appium_enabled" bson:"-"` // whether the device's provider runs Appium servers - devices without one can never serve automation
 	Available                bool          `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
 	InUseWSConnection        net.Conn      `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
 	LastActionTS             int64         `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -43,6 +43,14 @@ type LocalHubDevice struct {
 	LeaseExpiresAt           int64         `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
 	AppiumNewCommandTimeout  int64         `json:"appium_new_command_timeout"`
 	AutomationSessionStartTS int64         `json:"-" bson:"-"` // Unix ms when the current Appium grid session was created, 0 = no session
+	// Appium session truth reported by the provider (via the appium-plugin) - only
+	// meaningful while ProviderReportsSessionState is true (older providers do not
+	// send these fields)
+	ProviderReportsSessionState  bool   `json:"-" bson:"-"`
+	ProviderHasSession           bool   `json:"provider_has_session" bson:"-"`
+	ProviderSessionID            string `json:"-" bson:"-"`
+	ProviderLastCommandTS        int64  `json:"provider_last_command_ts" bson:"-"`
+	ProviderSessionMissingSinceTS int64 `json:"-" bson:"-"` // Unix ms since the provider stopped reporting a session the hub still tracks, 0 = not missing
 	IsAvailableForAutomation bool          `json:"is_available_for_automation"`
 	Available                bool          `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
 	InUseWSConnection        net.Conn      `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
@@ -143,6 +151,7 @@ func (d *LocalHubDevice) ReleaseFromAutomation() {
 	}
 	d.SessionID = ""
 	d.AutomationSessionStartTS = 0
+	d.ProviderSessionMissingSinceTS = 0
 	d.IsRunningAutomation = false
 	d.IsAvailableForAutomation = true
 	d.ReleaseLockIfNotHeld()

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -121,6 +121,30 @@ func (d *LocalHubDevice) HasActiveLease() bool {
 	return d.LockSource == LockSourceAPI && d.LeaseExpiresAt > time.Now().UnixMilli()
 }
 
+// ClaimForAutomation marks the device as running an automation session, before the
+// Appium session request is even forwarded, so no other automation request can grab it.
+// The action timestamp is stamped so the janitor does not reset the device while the
+// session is still being created. A newCommandTimeoutMS of 0 means the client
+// explicitly disabled the idle expiry for this session.
+func (d *LocalHubDevice) ClaimForAutomation(newCommandTimeoutMS int64) {
+	d.IsRunningAutomation = true
+	d.IsAvailableForAutomation = false
+	d.LastAutomationActionTS = time.Now().UnixMilli()
+	d.AppiumNewCommandTimeout = newCommandTimeoutMS
+}
+
+// ReleaseFromAutomation clears the device's automation session state, including its
+// session registry entry, and releases the lock unless a UI or API session holds it.
+func (d *LocalHubDevice) ReleaseFromAutomation() {
+	if d.SessionID != "" {
+		UnregisterSession(d.SessionID)
+	}
+	d.SessionID = ""
+	d.IsRunningAutomation = false
+	d.IsAvailableForAutomation = true
+	d.ReleaseLockIfNotHeld()
+}
+
 // RefreshLock updates InUseTS to now, keeping the lock alive.
 func (d *LocalHubDevice) RefreshLock() {
 	d.InUseTS = time.Now().UnixMilli()

--- a/hub/devices/session_registry.go
+++ b/hub/devices/session_registry.go
@@ -52,3 +52,14 @@ func DeviceBySession(sessionID string) (*LocalHubDevice, bool) {
 	gridSessionsMu.RUnlock()
 	return device, ok
 }
+
+// AllSessions returns a snapshot of the active session index
+func AllSessions() map[string]*LocalHubDevice {
+	gridSessionsMu.RLock()
+	defer gridSessionsMu.RUnlock()
+	snapshot := make(map[string]*LocalHubDevice, len(gridSessions))
+	for sessionID, device := range gridSessions {
+		snapshot[sessionID] = device
+	}
+	return snapshot
+}

--- a/hub/devices/session_registry.go
+++ b/hub/devices/session_registry.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import "sync"
+
+// Index of active Appium grid sessions (session ID -> device), replacing the old
+// linear scan over all hub devices on every proxied session command.
+//
+// The device's `SessionID` field stays the source of truth - this registry is an
+// index over it and both are updated together (create session, ReleaseFromAutomation).
+//
+// Lock ordering: the registry mutex is separate from each device's Mu. Code that
+// needs both must take the device's Mu FIRST and the registry mutex second (this
+// is what happens when ReleaseFromAutomation, called under d.Mu, unregisters the
+// session). Never acquire a device's Mu while holding the registry mutex.
+
+var gridSessionsMu sync.RWMutex
+var gridSessions = map[string]*LocalHubDevice{}
+
+// RegisterSession indexes an Appium session ID to the device serving it
+func RegisterSession(sessionID string, device *LocalHubDevice) {
+	if sessionID == "" {
+		return
+	}
+	gridSessionsMu.Lock()
+	gridSessions[sessionID] = device
+	gridSessionsMu.Unlock()
+}
+
+// UnregisterSession removes a session ID from the index
+func UnregisterSession(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	gridSessionsMu.Lock()
+	delete(gridSessions, sessionID)
+	gridSessionsMu.Unlock()
+}
+
+// DeviceBySession returns the device serving the given Appium session ID
+func DeviceBySession(sessionID string) (*LocalHubDevice, bool) {
+	gridSessionsMu.RLock()
+	device, ok := gridSessions[sessionID]
+	gridSessionsMu.RUnlock()
+	return device, ok
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -96,6 +96,7 @@ func StartHub(flags *pflag.FlagSet, appVersion string, uiFiles fs.FS, resourceFi
 
 	db.InitMongo(mongoDB, "gads")
 	defer db.GlobalMongoStore.Close()
+	router.InitGridStore(db.GlobalMongoStore)
 
 	// Update existing devices with new stream type property
 	err := db.GlobalMongoStore.EnsureDevicesHaveStreamType()

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -216,8 +216,9 @@ func GetAutomationSessions(c *gin.Context) {
 		return sessions[i].SessionID < sessions[j].SessionID
 	})
 
-	// Devices that could take a new automation session this instant - same
-	// eligibility the grid's own dispatch applies - broken down per OS. Every
+	// Automation-capable devices the grid can currently reach (connected and
+	// live), broken down per OS - a device busy with a test still counts, the
+	// Active sessions number tells how many of these are occupied. Every
 	// supported OS is present in the map, so platforms with no devices at all
 	// still report an explicit zero
 	availableDevicesByOS := map[string]int{}
@@ -228,14 +229,10 @@ func GetAutomationSessions(c *gin.Context) {
 		hubDevice.Mu.RLock()
 		if hubDevice.AppiumEnabled &&
 			hubDevice.Device.Usage != "control" &&
-			hubDevice.Device.Usage != "disabled" {
-			deviceOS := strings.ToLower(hubDevice.Device.OS)
-			availableDevicesByOS[deviceOS] += 0
-			if hubDevice.Connected &&
-				hubDevice.ProviderState == "live" &&
-				hubDevice.IsAvailableForAutomation {
-				availableDevicesByOS[deviceOS]++
-			}
+			hubDevice.Device.Usage != "disabled" &&
+			hubDevice.Connected &&
+			hubDevice.ProviderState == "live" {
+			availableDevicesByOS[strings.ToLower(hubDevice.Device.OS)]++
 		}
 		hubDevice.Mu.RUnlock()
 	}

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -10,7 +10,6 @@
 package router
 
 import (
-	"GADS/common/db"
 	"GADS/common/models"
 	"GADS/hub/devices"
 	"bytes"
@@ -82,33 +81,22 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 			defer c.Request.Body.Close()
 
-			// Unmarshal the request sessionRequestBody []byte to <AppiumSession>
-			var appiumSessionBody models.AppiumSession
-			err = json.Unmarshal(sessionRequestBody, &appiumSessionBody)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to unmarshal session request sessionRequestBody", "session not created", err.Error()))
+			// Parse the request body per the W3C capabilities processing rules
+			parsedReq, w3cErr := parseSessionRequest(sessionRequestBody, capabilityPrefix)
+			if w3cErr != nil {
+				writeW3CError(c, w3cErr)
 				return
 			}
 
-			var capsToUse models.CommonCapabilities
-
-			if appiumSessionBody.DesiredCapabilities.PlatformName != "" && appiumSessionBody.DesiredCapabilities.AutomationName != "" {
-				capsToUse = appiumSessionBody.DesiredCapabilities
-			} else if appiumSessionBody.Capabilities.FirstMatch[0].PlatformName != "" && appiumSessionBody.Capabilities.FirstMatch[0].AutomationName != "" {
-				capsToUse = appiumSessionBody.Capabilities.FirstMatch[0]
-			} else if appiumSessionBody.Capabilities.AlwaysMatch.PlatformName != "" && appiumSessionBody.Capabilities.AlwaysMatch.AutomationName != "" {
-				capsToUse = appiumSessionBody.Capabilities.AlwaysMatch
-			} else {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS did not find any suitable capabilities object in the session request, check your setup or open an issues on the project Github page", "session not created", ""))
+			candidate, matched := selectGridCandidate(parsedReq.Candidates)
+			if !matched {
+				writeW3CError(c, w3cSessionNotCreated("GADS could not determine a target device platform from any capabilities candidate in the session request"))
 				return
 			}
 
 			// Extract client secret from capabilities and get allowed workspaces
 			var allowedWorkspaceIDs []string
-			var sessionReq map[string]interface{}
-			json.Unmarshal(sessionRequestBody, &sessionReq)
-			capabilityPrefix := getEnvOrDefault("GADS_CAPABILITY_PREFIX", "gads")
-			clientSecret := models.ExtractClientSecretFromSession(sessionReq, capabilityPrefix)
+			clientSecret := models.ExtractClientSecretFromSession(parsedReq.Raw, capabilityPrefix)
 
 			if clientSecret == "" {
 				c.JSON(http.StatusUnauthorized, createErrorResponse(
@@ -118,19 +106,19 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				return
 			}
 
-			credential, err := db.GlobalMongoStore.GetClientCredentialBySecret(clientSecret)
+			credential, err := gridDB.GetClientCredentialBySecret(clientSecret)
 			if err != nil || !credential.IsActive {
 				c.JSON(http.StatusUnauthorized, createErrorResponse("Invalid client credentials", "session not created", ""))
 				return
 			}
 
 			if credential.Tenant != "" {
-				defaultTenant, _ := db.GlobalMongoStore.GetOrCreateDefaultTenant()
+				defaultTenant, _ := gridDB.GetOrCreateDefaultTenant()
 				useAllTenantWorkspaces := true
 
 				// Check if we need to filter by user workspaces
 				if credential.Tenant == defaultTenant && credential.UserID != "" {
-					user, err := db.GlobalMongoStore.GetUser(credential.UserID)
+					user, err := gridDB.GetUser(credential.UserID)
 					if err != nil {
 						c.JSON(http.StatusUnauthorized, createErrorResponse("User not found", "session not created", ""))
 						return
@@ -139,7 +127,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 					if user.Role != "admin" {
 						// Regular user: only assigned workspaces
 						useAllTenantWorkspaces = false
-						userWorkspaces := db.GlobalMongoStore.GetUserWorkspaces(credential.UserID)
+						userWorkspaces := gridDB.GetUserWorkspaces(credential.UserID)
 						for _, ws := range userWorkspaces {
 							allowedWorkspaceIDs = append(allowedWorkspaceIDs, ws.ID)
 						}
@@ -148,7 +136,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 				// Admin users or non-default tenant: all workspaces of the tenant
 				if useAllTenantWorkspaces {
-					allWorkspaces, _ := db.GlobalMongoStore.GetWorkspaces()
+					allWorkspaces, _ := gridDB.GetWorkspaces()
 					for _, ws := range allWorkspaces {
 						if ws.Tenant == credential.Tenant {
 							allowedWorkspaceIDs = append(allowedWorkspaceIDs, ws.ID)
@@ -161,7 +149,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			var foundDevice *devices.LocalHubDevice
 			var deviceErr error
 
-			foundDevice, deviceErr = findAvailableDevice(capsToUse, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
+			foundDevice, deviceErr = findAvailableDevice(candidate, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
 
 			if deviceErr != nil && strings.Contains(deviceErr.Error(), "No device with udid") {
 				c.JSON(http.StatusNotFound, createErrorResponse("No available device found", "session not created", ""))
@@ -178,7 +166,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				for {
 					select {
 					case <-ticker.C:
-						foundDevice, deviceErr = findAvailableDevice(capsToUse, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
+						foundDevice, deviceErr = findAvailableDevice(candidate, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
 						if foundDevice != nil {
 							break FOR_LOOP
 						}
@@ -214,14 +202,17 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			foundDevice.IsAvailableForAutomation = false
 			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
 			// Update the session timeout values if none were provided
-			if capsToUse.NewCommandTimeout != 0 {
-				foundDevice.AppiumNewCommandTimeout = capsToUse.NewCommandTimeout * 1000
+			// NOTE: explicit `appium:newCommandTimeout: 0` currently falls back to the default like "absent" does - Phase 2 gives it disable semantics
+			if candidate.NewCommandTimeout != nil && *candidate.NewCommandTimeout != 0 {
+				foundDevice.AppiumNewCommandTimeout = *candidate.NewCommandTimeout * 1000
 			} else {
 				foundDevice.AppiumNewCommandTimeout = 60000
 			}
 			foundDevice.Mu.Unlock()
 
-			updatedSessionBody, _ := json.Marshal(sessionReq)
+			// Remove grid-internal `gads:*` capabilities so the client secret never reaches Appium (and its logs)
+			stripGadsCaps(parsedReq.Raw, capabilityPrefix)
+			updatedSessionBody, _ := json.Marshal(parsedReq.Raw)
 			// Create a new request to the device target URL
 			foundDevice.Mu.RLock()
 			deviceHost := foundDevice.Host
@@ -360,7 +351,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				}
 
 				if startIndex == -1 || endIndex == -1 {
-					c.JSON(http.StatusInternalServerError, createErrorResponse(fmt.Sprintf("No session ID could be extracted from the request - %s", c.Request.URL.Path), "", ""))
+					writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID could be extracted from the request - %s", c.Request.URL.Path)))
 					return
 				}
 
@@ -369,7 +360,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 
 			// If no session ID could be parsed from the request
 			if sessionID == "" {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("No session ID could be extracted from the request", "", ""))
+				writeW3CError(c, w3cInvalidSessionID("No session ID could be extracted from the request"))
 				return
 			}
 
@@ -384,7 +375,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			// Check if there is a device in the local session map for that session ID
 			foundDevice, err := getDeviceBySessionID(sessionID)
 			if err != nil {
-				c.JSON(http.StatusNotFound, createErrorResponse(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID), "", ""))
+				writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID)))
 				return
 			}
 
@@ -519,42 +510,10 @@ func getDeviceByUDID(udid string) (*devices.LocalHubDevice, error) {
 	return nil, fmt.Errorf("No device with udid `%s` was found", udid)
 }
 
-func getTargetOSFromCaps(caps models.CommonCapabilities) string {
-	if strings.EqualFold(caps.PlatformName, "iOS") ||
-		strings.EqualFold(caps.AutomationName, "XCUITest") {
-		return "ios"
-	}
-
-	if strings.EqualFold(caps.PlatformName, "Android") ||
-		strings.EqualFold(caps.AutomationName, "UiAutomator2") {
-		return "android"
-	}
-
-	if strings.EqualFold(caps.PlatformName, "TizenTV") ||
-		strings.EqualFold(caps.AutomationName, "TizenTV") {
-		return "tizen"
-	}
-
-	if strings.EqualFold(caps.PlatformName, "lgtv") ||
-		strings.EqualFold(caps.AutomationName, "webos") {
-		return "webos"
-	}
-
-	if strings.EqualFold(caps.PlatformName, "Roku") ||
-		strings.EqualFold(caps.AutomationName, "roku") {
-		return "roku"
-	}
-
-	return ""
-}
-
-func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []string, userID string, userTenant string) (*devices.LocalHubDevice, error) {
+func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, userID string, userTenant string) (*devices.LocalHubDevice, error) {
 	var foundDevice *devices.LocalHubDevice
 
-	var deviceUDID = ""
-	if caps.DeviceUDID != "" {
-		deviceUDID = caps.DeviceUDID
-	}
+	deviceUDID := candidate.DeviceUDID
 
 	if len(allowedWorkspaceIDs) == 0 {
 		return nil, fmt.Errorf("No device with udid `%s` was found in allowed workspaces", deviceUDID)
@@ -594,7 +553,7 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 
 	var availableDevices []*devices.LocalHubDevice
 
-	targetOS := getTargetOSFromCaps(caps)
+	targetOS := candidateTargetOS(candidate)
 	if targetOS != "" {
 		for _, localDevice := range devices.HubDeviceStore.All() {
 			localDevice.Mu.RLock()
@@ -637,14 +596,14 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 		}
 	}
 
-	if caps.PlatformVersion != "" {
+	if candidate.PlatformVersion != "" {
 		// First try exact version match
 		for _, device := range availableDevices {
 			device.Mu.RLock()
 			osVersion := device.Device.OSVersion
 			device.Mu.RUnlock()
 
-			if osVersion == caps.PlatformVersion {
+			if osVersion == candidate.PlatformVersion {
 				device.Mu.Lock()
 				if device.IsAvailableForAutomation {
 					device.IsAvailableForAutomation = false
@@ -658,7 +617,7 @@ func findAvailableDevice(caps models.CommonCapabilities, allowedWorkspaceIDs []s
 
 		// Fall back to major version match
 		if foundDevice == nil {
-			v, _ := semver.NewVersion(caps.PlatformVersion)
+			v, _ := semver.NewVersion(candidate.PlatformVersion)
 			requestedMajorVersion := fmt.Sprintf("%d", v.Major())
 			constraint, _ := semver.NewConstraint(fmt.Sprintf("^%s.0.0", requestedMajorVersion))
 

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -16,12 +16,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/gin-gonic/gin"
+)
+
+// Shared HTTP clients for proxying grid traffic to providers, reusing the same
+// connection pool as the device proxy (proxyTransport). Session creation gets a
+// generous timeout because driver/WDA startup can take minutes; ordinary session
+// commands are bounded lower but still allow slow calls like screen recordings
+// and source dumps
+var (
+	gridSessionClient = &http.Client{Transport: proxyTransport, Timeout: 240 * time.Second}
+	gridCommandClient = &http.Client{Transport: proxyTransport, Timeout: 90 * time.Second}
 )
 
 type AppiumSessionValue struct {
@@ -42,32 +53,65 @@ type SeleniumSessionErrorResponseValue struct {
 	StackTrace string `json:"stacktrace"`
 }
 
-// Every 3 seconds check the devices
-// And clean the automation session if no action was taken in the timeout limit
+// Every second sweep the devices and clean up automation sessions
+// that expired or whose device is gone
 func UpdateExpiredGridSessions() {
 	for {
-		now := time.Now().UnixMilli()
-		for _, hubDevice := range devices.HubDeviceStore.All() {
-			hubDevice.Mu.Lock()
-			// Release expired API leases
-			if hubDevice.LockSource == devices.LockSourceAPI && hubDevice.LeaseExpiresAt > 0 && hubDevice.LeaseExpiresAt < now {
-				hubDevice.ReleaseLock()
-			}
-			// Reset device if its not connected
-			// Or it hasn't received any Appium requests in the command timeout and is running automation
-			// Or if its provider state is not "live" - device was re-provisioned for example
-			if !hubDevice.Connected ||
-				(hubDevice.LastAutomationActionTS <= (time.Now().UnixMilli()-hubDevice.AppiumNewCommandTimeout) && hubDevice.IsRunningAutomation) ||
-				hubDevice.ProviderState != "live" {
-				hubDevice.IsRunningAutomation = false
-				hubDevice.IsAvailableForAutomation = true
-				hubDevice.SessionID = ""
-				hubDevice.ReleaseLockIfNotHeld()
-			}
-			hubDevice.Mu.Unlock()
-		}
+		sweepExpiredGridSessions()
 		time.Sleep(1 * time.Second)
 	}
+}
+
+// sweepExpiredGridSessions does one janitor pass over all hub devices:
+// releases expired API leases and resets devices that disconnected, went
+// non-live (re-provisioned for example) or idled past their Appium new-command timeout
+func sweepExpiredGridSessions() {
+	now := time.Now().UnixMilli()
+	for _, hubDevice := range devices.HubDeviceStore.All() {
+		hubDevice.Mu.Lock()
+		// Release expired API leases
+		if hubDevice.LockSource == devices.LockSourceAPI && hubDevice.LeaseExpiresAt > 0 && hubDevice.LeaseExpiresAt < now {
+			hubDevice.ReleaseLock()
+		}
+		// A new-command timeout of 0 means the client explicitly disabled the idle
+		// timer (`appium:newCommandTimeout: 0`) - such sessions live until they are
+		// deleted or the device disconnects
+		idleExpired := hubDevice.IsRunningAutomation &&
+			hubDevice.AppiumNewCommandTimeout > 0 &&
+			hubDevice.LastAutomationActionTS <= (now-hubDevice.AppiumNewCommandTimeout)
+		if !hubDevice.Connected || hubDevice.ProviderState != "live" || idleExpired {
+			// Ask the provider to actually close the expired Appium session (best
+			// effort, in the background) - otherwise the app under test keeps running
+			// on the device until the next session overrides it
+			if hubDevice.SessionID != "" && hubDevice.Connected && hubDevice.ProviderState == "live" {
+				go killProviderAppiumSession(hubDevice.Host, hubDevice.Device.UDID, hubDevice.SessionID)
+			}
+			hubDevice.IsRunningAutomation = false
+			hubDevice.IsAvailableForAutomation = true
+			hubDevice.SessionID = ""
+			hubDevice.ReleaseLockIfNotHeld()
+		}
+		hubDevice.Mu.Unlock()
+	}
+}
+
+// killProviderAppiumSession sends a session DELETE to the device's provider,
+// used when the hub expires a session on its side. Best effort - failures are
+// only logged, the janitor keeps running either way
+func killProviderAppiumSession(deviceHost string, deviceUDID string, sessionID string) {
+	deleteURL := fmt.Sprintf("http://%s/device/%s/appium/session/%s", deviceHost, deviceUDID, sessionID)
+	deleteReq, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Failed to create cleanup request for expired Appium session `%s` on device `%s` - %s", sessionID, deviceUDID, err))
+		return
+	}
+	resp, err := gridCommandClient.Do(deleteReq)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Failed to delete expired Appium session `%s` on device `%s` - %s", sessionID, deviceUDID, err))
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
 }
 
 func AppiumGridMiddleware() gin.HandlerFunc {
@@ -201,9 +245,10 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			foundDevice.IsRunningAutomation = true
 			foundDevice.IsAvailableForAutomation = false
 			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-			// Update the session timeout values if none were provided
-			// NOTE: explicit `appium:newCommandTimeout: 0` currently falls back to the default like "absent" does - Phase 2 gives it disable semantics
-			if candidate.NewCommandTimeout != nil && *candidate.NewCommandTimeout != 0 {
+			// `appium:newCommandTimeout` semantics: absent -> 60s default; explicit 0 ->
+			// idle timeout disabled on the hub too (0 makes the janitor skip the idle
+			// check, matching Appium disabling its own timer); anything else -> as given
+			if candidate.NewCommandTimeout != nil {
 				foundDevice.AppiumNewCommandTimeout = *candidate.NewCommandTimeout * 1000
 			} else {
 				foundDevice.AppiumNewCommandTimeout = 60000
@@ -235,8 +280,7 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 
 			// Send the request
-			client := &http.Client{}
-			resp, err := client.Do(proxyReq)
+			resp, err := gridSessionClient.Do(proxyReq)
 			if err != nil {
 				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
@@ -333,29 +377,21 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 		} else {
 			// If this is not a request for a new session
 			var sessionID = ""
+			// Whether this request ends the session - only an exact `DELETE /session/{id}` does.
+			// A DELETE on a subpath (/window, /cookie, /cookie/{name}, /actions) is an
+			// ordinary WebDriver command and must not release the device
+			var isSessionEndRequest = false
 
-			// Check if the call uses session ID
+			// The session ID is the path segment right after `/session/`, regardless of method
 			if strings.Contains(c.Request.URL.Path, "/session/") {
-				var startIndex int
-				var endIndex int
-
-				// Extract the session ID from the call URL path
-				if c.Request.Method == http.MethodDelete {
-					// Find the start and end of the session ID
-					startIndex = strings.Index(c.Request.URL.Path, "/session/") + len("/session/")
-					endIndex = len(c.Request.URL.Path)
+				sessionIDStart := strings.Index(c.Request.URL.Path, "/session/") + len("/session/")
+				sessionIDAndRest := c.Request.URL.Path[sessionIDStart:]
+				if slashIndex := strings.Index(sessionIDAndRest, "/"); slashIndex != -1 {
+					sessionID = sessionIDAndRest[:slashIndex]
 				} else {
-					// Find the start and end of the session ID
-					startIndex = strings.Index(c.Request.URL.Path, "/session/") + len("/session/")
-					endIndex = strings.Index(c.Request.URL.Path[startIndex:], "/") + startIndex
+					sessionID = sessionIDAndRest
+					isSessionEndRequest = c.Request.Method == http.MethodDelete
 				}
-
-				if startIndex == -1 || endIndex == -1 {
-					writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID could be extracted from the request - %s", c.Request.URL.Path)))
-					return
-				}
-
-				sessionID = c.Request.URL.Path[startIndex:endIndex]
 			}
 
 			// If no session ID could be parsed from the request
@@ -411,16 +447,15 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 			}
 
 			// Send the request
-			client := &http.Client{}
-			resp, err := client.Do(proxyReq)
+			resp, err := gridCommandClient.Do(proxyReq)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to failed to execute the proxy request to the device respective provider Appium endpoint", "", err.Error()))
+				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium endpoint", "", err.Error()))
 				return
 			}
 			defer resp.Body.Close()
 
-			// If the request succeeded and was a delete request, remove the session ID from the map
-			if c.Request.Method == http.MethodDelete {
+			// Release the device when the session itself was deleted
+			if isSessionEndRequest {
 				foundDevice.Mu.Lock()
 				foundDevice.IsAvailableForAutomation = true
 				foundDevice.Mu.Unlock()
@@ -525,11 +560,16 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 			return nil, err
 		}
 
-		// Check if device is in allowed workspaces
 		d.Mu.RLock()
 		wsID := d.Device.WorkspaceID
+		connected := d.Connected
+		state := d.ProviderState
+		lastUpdated := d.LastUpdatedTimestamp
+		usage := d.Device.Usage
+		isLockedByOther := d.IsLockedByOther(userID, userTenant)
 		d.Mu.RUnlock()
 
+		// Check if device is in allowed workspaces
 		deviceAllowed := false
 		for _, allowedWsID := range allowedWorkspaceIDs {
 			if wsID == allowedWsID {
@@ -539,6 +579,19 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 		}
 		if !deviceAllowed {
 			return nil, fmt.Errorf("No device with udid `%s` was found", deviceUDID)
+		}
+
+		// A UDID-pinned device must pass the same eligibility checks as the generic
+		// search below - without them a client could start automation on a device
+		// another user is actively controlling. The exact reason is deliberately
+		// not exposed to the client
+		if !connected ||
+			state != "live" ||
+			lastUpdated < (time.Now().UnixMilli()-3000) ||
+			usage == "control" ||
+			usage == "disabled" ||
+			isLockedByOther {
+			return nil, fmt.Errorf("Device is currently not available for automation")
 		}
 
 		d.Mu.Lock()

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -13,11 +13,14 @@ import (
 	"GADS/common/models"
 	"GADS/hub/devices"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,14 +28,16 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Timeout for proxied session commands - generous because calls like screen
+// recordings and source dumps can be slow
+const gridCommandTimeout = 90 * time.Second
+
 // Shared HTTP clients for proxying grid traffic to providers, reusing the same
 // connection pool as the device proxy (proxyTransport). Session creation gets a
-// generous timeout because driver/WDA startup can take minutes; ordinary session
-// commands are bounded lower but still allow slow calls like screen recordings
-// and source dumps
+// generous timeout because driver/WDA startup can take minutes
 var (
 	gridSessionClient = &http.Client{Transport: proxyTransport, Timeout: 240 * time.Second}
-	gridCommandClient = &http.Client{Transport: proxyTransport, Timeout: 90 * time.Second}
+	gridCommandClient = &http.Client{Transport: proxyTransport, Timeout: gridCommandTimeout}
 )
 
 type AppiumSessionValue struct {
@@ -51,6 +56,27 @@ type SeleniumSessionErrorResponseValue struct {
 	Error      string `json:"error"`
 	Message    string `json:"message"`
 	StackTrace string `json:"stacktrace"`
+}
+
+// registerGridRoutes mounts the Appium grid endpoints on the `/grid` group. The URL
+// surface is identical to the old catch-all middleware. Shared between the hub
+// router and handler-level tests
+func registerGridRoutes(grid *gin.RouterGroup) {
+	grid.GET("/status", GridStatus)
+	grid.POST("/session", GridCreateSession)
+	grid.DELETE("/session/:sessionId", GridDeleteSession)
+	// A bare `/session/{id}` with any other method (e.g. `GET /session/{id}`) is an
+	// ordinary WebDriver command - only the exact DELETE above ends the session
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodHead, http.MethodOptions} {
+		grid.Handle(method, "/session/:sessionId", GridSessionCommand)
+	}
+	grid.Any("/session/:sessionId/*path", GridSessionCommand)
+}
+
+// GridStatus is the W3C status endpoint (`GET /grid/status`). Currently a static
+// readiness stub - Phase 4 of the grid rework fills in real device information
+func GridStatus(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"value": gin.H{"ready": true, "message": "GADS grid ready"}})
 }
 
 // Every second sweep the devices and clean up automation sessions
@@ -86,10 +112,7 @@ func sweepExpiredGridSessions() {
 			if hubDevice.SessionID != "" && hubDevice.Connected && hubDevice.ProviderState == "live" {
 				go killProviderAppiumSession(hubDevice.Host, hubDevice.Device.UDID, hubDevice.SessionID)
 			}
-			hubDevice.IsRunningAutomation = false
-			hubDevice.IsAvailableForAutomation = true
-			hubDevice.SessionID = ""
-			hubDevice.ReleaseLockIfNotHeld()
+			hubDevice.ReleaseFromAutomation()
 		}
 		hubDevice.Mu.Unlock()
 	}
@@ -114,407 +137,406 @@ func killProviderAppiumSession(deviceHost string, deviceUDID string, sessionID s
 	io.Copy(io.Discard, resp.Body)
 }
 
-func AppiumGridMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if strings.HasSuffix(c.Request.URL.Path, "/session") {
-			// Read the request sessionRequestBody
-			sessionRequestBody, err := readBody(c.Request.Body)
+// gridUser is the automation client identity resolved from its `gads:clientSecret`,
+// with the workspaces its sessions are allowed to claim devices from
+type gridUser struct {
+	UserID              string
+	Tenant              string
+	AllowedWorkspaceIDs []string
+}
+
+// resolveGridUser validates the client secret extracted from the session capabilities
+// and resolves the workspaces the client may use devices from
+func resolveGridUser(clientSecret string) (gridUser, *W3CError) {
+	if clientSecret == "" {
+		return gridUser{}, &W3CError{
+			HTTPStatus: http.StatusUnauthorized,
+			Code:       "session not created",
+			Message:    fmt.Sprintf("Client credentials are required. Provide %s:clientSecret in the capabilities.", capabilityPrefix),
+		}
+	}
+
+	credential, err := gridDB.GetClientCredentialBySecret(clientSecret)
+	if err != nil || !credential.IsActive {
+		return gridUser{}, &W3CError{HTTPStatus: http.StatusUnauthorized, Code: "session not created", Message: "Invalid client credentials"}
+	}
+
+	user := gridUser{UserID: credential.UserID, Tenant: credential.Tenant}
+
+	if credential.Tenant != "" {
+		defaultTenant, _ := gridDB.GetOrCreateDefaultTenant()
+		useAllTenantWorkspaces := true
+
+		// Check if we need to filter by user workspaces
+		if credential.Tenant == defaultTenant && credential.UserID != "" {
+			dbUser, err := gridDB.GetUser(credential.UserID)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read session request sessionRequestBody", "session not created", err.Error()))
-				return
-			}
-			defer c.Request.Body.Close()
-
-			// Parse the request body per the W3C capabilities processing rules
-			parsedReq, w3cErr := parseSessionRequest(sessionRequestBody, capabilityPrefix)
-			if w3cErr != nil {
-				writeW3CError(c, w3cErr)
-				return
+				return gridUser{}, &W3CError{HTTPStatus: http.StatusUnauthorized, Code: "session not created", Message: "User not found"}
 			}
 
-			candidate, matched := selectGridCandidate(parsedReq.Candidates)
-			if !matched {
-				writeW3CError(c, w3cSessionNotCreated("GADS could not determine a target device platform from any capabilities candidate in the session request"))
-				return
-			}
-
-			// Extract client secret from capabilities and get allowed workspaces
-			var allowedWorkspaceIDs []string
-			clientSecret := models.ExtractClientSecretFromSession(parsedReq.Raw, capabilityPrefix)
-
-			if clientSecret == "" {
-				c.JSON(http.StatusUnauthorized, createErrorResponse(
-					fmt.Sprintf("Client credentials are required. Provide %s:clientSecret in the capabilities.", capabilityPrefix),
-					"session not created",
-					""))
-				return
-			}
-
-			credential, err := gridDB.GetClientCredentialBySecret(clientSecret)
-			if err != nil || !credential.IsActive {
-				c.JSON(http.StatusUnauthorized, createErrorResponse("Invalid client credentials", "session not created", ""))
-				return
-			}
-
-			if credential.Tenant != "" {
-				defaultTenant, _ := gridDB.GetOrCreateDefaultTenant()
-				useAllTenantWorkspaces := true
-
-				// Check if we need to filter by user workspaces
-				if credential.Tenant == defaultTenant && credential.UserID != "" {
-					user, err := gridDB.GetUser(credential.UserID)
-					if err != nil {
-						c.JSON(http.StatusUnauthorized, createErrorResponse("User not found", "session not created", ""))
-						return
-					}
-
-					if user.Role != "admin" {
-						// Regular user: only assigned workspaces
-						useAllTenantWorkspaces = false
-						userWorkspaces := gridDB.GetUserWorkspaces(credential.UserID)
-						for _, ws := range userWorkspaces {
-							allowedWorkspaceIDs = append(allowedWorkspaceIDs, ws.ID)
-						}
-					}
-				}
-
-				// Admin users or non-default tenant: all workspaces of the tenant
-				if useAllTenantWorkspaces {
-					allWorkspaces, _ := gridDB.GetWorkspaces()
-					for _, ws := range allWorkspaces {
-						if ws.Tenant == credential.Tenant {
-							allowedWorkspaceIDs = append(allowedWorkspaceIDs, ws.ID)
-						}
-					}
+			if dbUser.Role != "admin" {
+				// Regular user: only assigned workspaces
+				useAllTenantWorkspaces = false
+				userWorkspaces := gridDB.GetUserWorkspaces(credential.UserID)
+				for _, ws := range userWorkspaces {
+					user.AllowedWorkspaceIDs = append(user.AllowedWorkspaceIDs, ws.ID)
 				}
 			}
+		}
 
-			// Check for available device
-			var foundDevice *devices.LocalHubDevice
-			var deviceErr error
-
-			foundDevice, deviceErr = findAvailableDevice(candidate, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
-
-			if deviceErr != nil && strings.Contains(deviceErr.Error(), "No device with udid") {
-				c.JSON(http.StatusNotFound, createErrorResponse("No available device found", "session not created", ""))
-				return
-			}
-
-			// Usage misconfiguration cannot resolve by waiting - fail immediately
-			// with the reason instead of entering the retry loop
-			if deviceErr != nil && strings.Contains(deviceErr.Error(), "is not enabled for automation") {
-				writeW3CError(c, w3cSessionNotCreated(deviceErr.Error()))
-				return
-			}
-
-			// If no device is available start checking each second for 10 seconds
-			// If no device is available after 10 seconds - return error
-			if foundDevice == nil {
-				ticker := time.NewTicker(100 * time.Millisecond)
-				timeout := time.After(10 * time.Second)
-				notify := c.Writer.CloseNotify()
-			FOR_LOOP:
-				for {
-					select {
-					case <-ticker.C:
-						foundDevice, deviceErr = findAvailableDevice(candidate, allowedWorkspaceIDs, credential.UserID, credential.Tenant)
-						if foundDevice != nil {
-							break FOR_LOOP
-						}
-					case <-timeout:
-						ticker.Stop()
-						if deviceErr != nil {
-							c.JSON(http.StatusInternalServerError, createErrorResponse(deviceErr.Error(), "session not created", ""))
-						} else {
-							c.JSON(http.StatusInternalServerError, createErrorResponse("No available device found", "session not created", ""))
-						}
-						return
-					case <-notify:
-						ticker.Stop()
-						return
-					}
+		// Admin users or non-default tenant: all workspaces of the tenant
+		if useAllTenantWorkspaces {
+			allWorkspaces, _ := gridDB.GetWorkspaces()
+			for _, ws := range allWorkspaces {
+				if ws.Tenant == credential.Tenant {
+					user.AllowedWorkspaceIDs = append(user.AllowedWorkspaceIDs, ws.ID)
 				}
 			}
+		}
+	}
 
-			if foundDevice == nil {
+	return user, nil
+}
+
+// abortAutomationClaim undoes a pre-session device claim after a failed session
+// create. The lock fields are left untouched on purpose - no session was
+// established, so there is nothing to release beyond the availability flags
+func abortAutomationClaim(foundDevice *devices.LocalHubDevice) {
+	foundDevice.Mu.Lock()
+	foundDevice.IsAvailableForAutomation = true
+	foundDevice.IsRunningAutomation = false
+	foundDevice.Mu.Unlock()
+}
+
+// GridCreateSession handles `POST /grid/session` - authenticates the client via its
+// `gads:clientSecret` capability, finds and claims a matching device, forwards the
+// session request to the device's provider Appium endpoint and records the created
+// session in the session registry
+func GridCreateSession(c *gin.Context) {
+	sessionRequestBody, err := readBody(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read session request sessionRequestBody", "session not created", err.Error()))
+		return
+	}
+	defer c.Request.Body.Close()
+
+	// Parse the request body per the W3C capabilities processing rules
+	parsedReq, w3cErr := parseSessionRequest(sessionRequestBody, capabilityPrefix)
+	if w3cErr != nil {
+		writeW3CError(c, w3cErr)
+		return
+	}
+
+	candidate, matched := selectGridCandidate(parsedReq.Candidates)
+	if !matched {
+		writeW3CError(c, w3cSessionNotCreated("GADS could not determine a target device platform from any capabilities candidate in the session request"))
+		return
+	}
+
+	// Extract client secret from capabilities and resolve the allowed workspaces
+	clientSecret := models.ExtractClientSecretFromSession(parsedReq.Raw, capabilityPrefix)
+	user, w3cErr := resolveGridUser(clientSecret)
+	if w3cErr != nil {
+		writeW3CError(c, w3cErr)
+		return
+	}
+
+	// Check for available device
+	foundDevice, deviceErr := findAvailableDevice(candidate, user.AllowedWorkspaceIDs, user.UserID, user.Tenant)
+
+	if deviceErr != nil && strings.Contains(deviceErr.Error(), "No device with udid") {
+		c.JSON(http.StatusNotFound, createErrorResponse("No available device found", "session not created", ""))
+		return
+	}
+
+	// Usage misconfiguration cannot resolve by waiting - fail immediately
+	// with the reason instead of entering the retry loop
+	if deviceErr != nil && strings.Contains(deviceErr.Error(), "is not enabled for automation") {
+		writeW3CError(c, w3cSessionNotCreated(deviceErr.Error()))
+		return
+	}
+
+	// If no device is available start checking each second for 10 seconds
+	// If no device is available after 10 seconds - return error
+	if foundDevice == nil {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		timeout := time.After(10 * time.Second)
+		notify := c.Writer.CloseNotify()
+	FOR_LOOP:
+		for {
+			select {
+			case <-ticker.C:
+				foundDevice, deviceErr = findAvailableDevice(candidate, user.AllowedWorkspaceIDs, user.UserID, user.Tenant)
+				if foundDevice != nil {
+					break FOR_LOOP
+				}
+			case <-timeout:
+				ticker.Stop()
 				if deviceErr != nil {
 					c.JSON(http.StatusInternalServerError, createErrorResponse(deviceErr.Error(), "session not created", ""))
 				} else {
 					c.JSON(http.StatusInternalServerError, createErrorResponse("No available device found", "session not created", ""))
 				}
 				return
-			}
-
-			foundDevice.Mu.Lock()
-			// Set device found as running automation and is not available for automation
-			// Before even starting the Appium session creation request
-			// Also set an automation action timestamp so that the goroutine does not reset it while session is being created
-			foundDevice.IsRunningAutomation = true
-			foundDevice.IsAvailableForAutomation = false
-			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-			// `appium:newCommandTimeout` semantics: absent -> 60s default; explicit 0 ->
-			// idle timeout disabled on the hub too (0 makes the janitor skip the idle
-			// check, matching Appium disabling its own timer); anything else -> as given
-			if candidate.NewCommandTimeout != nil {
-				foundDevice.AppiumNewCommandTimeout = *candidate.NewCommandTimeout * 1000
-			} else {
-				foundDevice.AppiumNewCommandTimeout = 60000
-			}
-			foundDevice.Mu.Unlock()
-
-			// Remove grid-internal `gads:*` capabilities so the client secret never reaches Appium (and its logs)
-			stripGadsCaps(parsedReq.Raw, capabilityPrefix)
-			updatedSessionBody, _ := json.Marshal(parsedReq.Raw)
-			// Create a new request to the device target URL
-			foundDevice.Mu.RLock()
-			deviceHost := foundDevice.Host
-			deviceUDID := foundDevice.Device.UDID
-			foundDevice.Mu.RUnlock()
-
-			proxyReq, err := http.NewRequest(c.Request.Method, fmt.Sprintf("http://%s/device/%s/appium%s", deviceHost, deviceUDID, strings.Replace(c.Request.URL.Path, "/grid", "", -1)), bytes.NewBuffer(updatedSessionBody))
-			if err != nil {
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.IsRunningAutomation = false
-				foundDevice.Mu.Unlock()
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to create http request to proxy the call to the device respective provider Appium session endpoint", "session not created", err.Error()))
+			case <-notify:
+				ticker.Stop()
 				return
 			}
-
-			// Copy headers from the original request to the new request
-			for k, v := range c.Request.Header {
-				proxyReq.Header[k] = v
-			}
-
-			// Send the request
-			resp, err := gridSessionClient.Do(proxyReq)
-			if err != nil {
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.IsRunningAutomation = false
-				foundDevice.Mu.Unlock()
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium session endpoint", "session not created", err.Error()))
-				return
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode >= 400 {
-				// Release device for any error status
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.IsRunningAutomation = false
-				if resp.StatusCode != http.StatusInternalServerError {
-					foundDevice.ReleaseLockIfNotHeld()
-				}
-				foundDevice.Mu.Unlock()
-
-				// For 500 errors, keep the existing behavior with goroutine
-				if resp.StatusCode == http.StatusInternalServerError {
-					go func() {
-						time.Sleep(10 * time.Second)
-						foundDevice.Mu.Lock()
-						if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 5000) {
-							foundDevice.IsAvailableForAutomation = true
-							foundDevice.SessionID = ""
-							foundDevice.IsRunningAutomation = false
-							foundDevice.ReleaseLockIfNotHeld()
-						}
-						foundDevice.Mu.Unlock()
-					}()
-				}
-
-				// Read and pass the error response
-				proxiedResponseBody, _ := readBody(resp.Body)
-				for k, v := range resp.Header {
-					c.Writer.Header()[k] = v
-				}
-				c.Writer.WriteHeader(resp.StatusCode)
-				c.Writer.Write(proxiedResponseBody)
-				return
-			}
-
-			// Read the response sessionRequestBody from the proxied request
-			proxiedSessionResponseBody, err := readBody(resp.Body)
-			if err != nil {
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.IsRunningAutomation = false
-				foundDevice.Mu.Unlock()
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
-				return
-			}
-
-			// Unmarshal the response sessionRequestBody to AppiumSessionResponse
-			var proxySessionResponse AppiumSessionResponse
-			err = json.Unmarshal(proxiedSessionResponseBody, &proxySessionResponse)
-			if err != nil {
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.IsRunningAutomation = false
-				foundDevice.Mu.Unlock()
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to unmarshal the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
-				return
-			}
-
-			foundDevice.Mu.Lock()
-			foundDevice.SessionID = proxySessionResponse.Value.SessionID
-			foundDevice.Mu.Unlock()
-
-			// Copy the response back to the original client
-			for k, v := range resp.Header {
-				c.Writer.Header()[k] = v
-			}
-			c.Writer.WriteHeader(resp.StatusCode)
-			c.Writer.Write(proxiedSessionResponseBody)
-
-			foundDevice.Mu.Lock()
-			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-			// Set InUseBy with user ID and tenant for tracking
-			automationUser := credential.UserID
-			if automationUser == "" {
-				automationUser = "unknown"
-			}
-			// Only update InUseBy if no UI or API session is active
-			if !foundDevice.HasUISession() && !foundDevice.HasActiveLease() {
-				foundDevice.InUseBy = automationUser
-				foundDevice.InUseByTenant = credential.Tenant
-				foundDevice.InUseTS = time.Now().UnixMilli()
-			}
-			foundDevice.Mu.Unlock()
-		} else {
-			// If this is not a request for a new session
-			var sessionID = ""
-			// Whether this request ends the session - only an exact `DELETE /session/{id}` does.
-			// A DELETE on a subpath (/window, /cookie, /cookie/{name}, /actions) is an
-			// ordinary WebDriver command and must not release the device
-			var isSessionEndRequest = false
-
-			// The session ID is the path segment right after `/session/`, regardless of method
-			if strings.Contains(c.Request.URL.Path, "/session/") {
-				sessionIDStart := strings.Index(c.Request.URL.Path, "/session/") + len("/session/")
-				sessionIDAndRest := c.Request.URL.Path[sessionIDStart:]
-				if slashIndex := strings.Index(sessionIDAndRest, "/"); slashIndex != -1 {
-					sessionID = sessionIDAndRest[:slashIndex]
-				} else {
-					sessionID = sessionIDAndRest
-					isSessionEndRequest = c.Request.Method == http.MethodDelete
-				}
-			}
-
-			// If no session ID could be parsed from the request
-			if sessionID == "" {
-				writeW3CError(c, w3cInvalidSessionID("No session ID could be extracted from the request"))
-				return
-			}
-
-			// Read the request origRequestBody
-			origRequestBody, err := readBody(c.Request.Body)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read the proxied Appium request origRequestBody", "", err.Error()))
-				return
-			}
-			defer c.Request.Body.Close()
-
-			// Check if there is a device in the local session map for that session ID
-			foundDevice, err := getDeviceBySessionID(sessionID)
-			if err != nil {
-				writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID)))
-				return
-			}
-
-			// Set the device last automation action timestamp when call returns
-			defer func() {
-				foundDevice.Mu.Lock()
-				foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-				foundDevice.Mu.Unlock()
-			}()
-
-			foundDevice.Mu.RLock()
-			deviceHost := foundDevice.Host
-			deviceUDID := foundDevice.Device.UDID
-			foundDevice.Mu.RUnlock()
-
-			// Create a new request to the device target URL on its provider instance
-			proxyReq, err := http.NewRequest(
-				c.Request.Method,
-				fmt.Sprintf("http://%s/device/%s/appium%s",
-					deviceHost,
-					deviceUDID,
-					strings.Replace(c.Request.URL.Path, "/grid", "", -1)),
-				bytes.NewBuffer(origRequestBody),
-			)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to create proxy request for this call", "", err.Error()))
-				return
-			}
-
-			// Copy headers
-			for k, v := range c.Request.Header {
-				proxyReq.Header[k] = v
-			}
-
-			// Send the request
-			resp, err := gridCommandClient.Do(proxyReq)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium endpoint", "", err.Error()))
-				return
-			}
-			defer resp.Body.Close()
-
-			// Release the device when the session itself was deleted
-			if isSessionEndRequest {
-				foundDevice.Mu.Lock()
-				foundDevice.IsAvailableForAutomation = true
-				foundDevice.Mu.Unlock()
-				// Start a goroutine that will release the device after 1 second if no other actions were taken
-				go func() {
-					time.Sleep(1 * time.Second)
-					foundDevice.Mu.Lock()
-					if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 1000) {
-						foundDevice.SessionID = ""
-						foundDevice.IsRunningAutomation = false
-						foundDevice.ReleaseLockIfNotHeld()
-					}
-					foundDevice.Mu.Unlock()
-				}()
-			}
-
-			if resp.StatusCode == http.StatusInternalServerError {
-				// Start a goroutine that will release the device after 10 seconds if no other actions were taken
-				go func() {
-					time.Sleep(10 * time.Second)
-					foundDevice.Mu.Lock()
-					if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 10000) {
-						foundDevice.SessionID = ""
-						foundDevice.IsAvailableForAutomation = true
-						foundDevice.IsRunningAutomation = false
-						foundDevice.ReleaseLockIfNotHeld()
-					}
-					foundDevice.Mu.Unlock()
-				}()
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS got an internal server error from the proxy request to the device respective provider Appium endpoint", "", ""))
-				return
-			}
-
-			// Read the response origRequestBody of the proxied request
-			proxiedRequestBody, err := readBody(resp.Body)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read the response origRequestBody of the proxied Appium request", "", err.Error()))
-				return
-			}
-
-			// Copy the response back to the original client
-			for k, v := range resp.Header {
-				c.Writer.Header()[k] = v
-			}
-			c.Writer.WriteHeader(resp.StatusCode)
-			c.Writer.Write(proxiedRequestBody)
-
-			foundDevice.Mu.Lock()
-			foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-			foundDevice.Mu.Unlock()
 		}
 	}
+
+	if foundDevice == nil {
+		if deviceErr != nil {
+			c.JSON(http.StatusInternalServerError, createErrorResponse(deviceErr.Error(), "session not created", ""))
+		} else {
+			c.JSON(http.StatusInternalServerError, createErrorResponse("No available device found", "session not created", ""))
+		}
+		return
+	}
+
+	// `appium:newCommandTimeout` semantics: absent -> 60s default; explicit 0 ->
+	// idle timeout disabled on the hub too (0 makes the janitor skip the idle
+	// check, matching Appium disabling its own timer); anything else -> as given
+	newCommandTimeoutMS := int64(60000)
+	if candidate.NewCommandTimeout != nil {
+		newCommandTimeoutMS = *candidate.NewCommandTimeout * 1000
+	}
+	foundDevice.Mu.Lock()
+	foundDevice.ClaimForAutomation(newCommandTimeoutMS)
+	foundDevice.Mu.Unlock()
+
+	// Remove grid-internal `gads:*` capabilities so the client secret never reaches Appium (and its logs)
+	stripGadsCaps(parsedReq.Raw, capabilityPrefix)
+	updatedSessionBody, _ := json.Marshal(parsedReq.Raw)
+
+	foundDevice.Mu.RLock()
+	deviceHost := foundDevice.Host
+	deviceUDID := foundDevice.Device.UDID
+	foundDevice.Mu.RUnlock()
+
+	// Create a new request to the device target URL
+	proxyReq, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/device/%s/appium/session", deviceHost, deviceUDID), bytes.NewBuffer(updatedSessionBody))
+	if err != nil {
+		abortAutomationClaim(foundDevice)
+		c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to create http request to proxy the call to the device respective provider Appium session endpoint", "session not created", err.Error()))
+		return
+	}
+
+	// Copy headers from the original request to the new request
+	for k, v := range c.Request.Header {
+		proxyReq.Header[k] = v
+	}
+
+	// Send the request
+	resp, err := gridSessionClient.Do(proxyReq)
+	if err != nil {
+		abortAutomationClaim(foundDevice)
+		c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium session endpoint", "session not created", err.Error()))
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		// Release the claim for any error status. On a 500 the lock fields are kept
+		// for a grace period (the delayed goroutine below) so a quick retry by the
+		// same client is not raced; any other error releases the lock right away
+		if resp.StatusCode == http.StatusInternalServerError {
+			abortAutomationClaim(foundDevice)
+			go func() {
+				time.Sleep(10 * time.Second)
+				foundDevice.Mu.Lock()
+				if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 5000) {
+					foundDevice.ReleaseFromAutomation()
+				}
+				foundDevice.Mu.Unlock()
+			}()
+		} else {
+			foundDevice.Mu.Lock()
+			foundDevice.ReleaseFromAutomation()
+			foundDevice.Mu.Unlock()
+		}
+
+		// Read and pass the error response
+		proxiedResponseBody, _ := readBody(resp.Body)
+		for k, v := range resp.Header {
+			c.Writer.Header()[k] = v
+		}
+		c.Writer.WriteHeader(resp.StatusCode)
+		c.Writer.Write(proxiedResponseBody)
+		return
+	}
+
+	// Read the response sessionRequestBody from the proxied request
+	proxiedSessionResponseBody, err := readBody(resp.Body)
+	if err != nil {
+		abortAutomationClaim(foundDevice)
+		c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to read the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
+		return
+	}
+
+	// Unmarshal the response sessionRequestBody to AppiumSessionResponse
+	var proxySessionResponse AppiumSessionResponse
+	err = json.Unmarshal(proxiedSessionResponseBody, &proxySessionResponse)
+	if err != nil {
+		abortAutomationClaim(foundDevice)
+		c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to unmarshal the response sessionRequestBody of the proxied Appium session request", "session not created", err.Error()))
+		return
+	}
+
+	foundDevice.Mu.Lock()
+	// A leftover session ID from a just-ended session must leave the registry
+	// before the new one is indexed
+	if foundDevice.SessionID != "" && foundDevice.SessionID != proxySessionResponse.Value.SessionID {
+		devices.UnregisterSession(foundDevice.SessionID)
+	}
+	foundDevice.SessionID = proxySessionResponse.Value.SessionID
+	devices.RegisterSession(foundDevice.SessionID, foundDevice)
+	foundDevice.Mu.Unlock()
+
+	// Copy the response back to the original client
+	for k, v := range resp.Header {
+		c.Writer.Header()[k] = v
+	}
+	c.Writer.WriteHeader(resp.StatusCode)
+	c.Writer.Write(proxiedSessionResponseBody)
+
+	foundDevice.Mu.Lock()
+	foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
+	// Set InUseBy with user ID and tenant for tracking
+	automationUser := user.UserID
+	if automationUser == "" {
+		automationUser = "unknown"
+	}
+	// Only update InUseBy if no UI or API session is active
+	if !foundDevice.HasUISession() && !foundDevice.HasActiveLease() {
+		foundDevice.InUseBy = automationUser
+		foundDevice.InUseByTenant = user.Tenant
+		foundDevice.InUseTS = time.Now().UnixMilli()
+	}
+	foundDevice.Mu.Unlock()
+}
+
+// GridSessionCommand proxies an ordinary WebDriver command (anything under
+// `/grid/session/{id}` that is not the exact session DELETE) to the device's
+// provider Appium endpoint via a streaming reverse proxy
+func GridSessionCommand(c *gin.Context) {
+	sessionID := c.Param("sessionId")
+	// Empty on the bare `/session/{id}` route (e.g. `GET /session/{id}`)
+	commandPath := c.Param("path")
+
+	foundDevice, ok := devices.DeviceBySession(sessionID)
+	if !ok {
+		writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID)))
+		return
+	}
+
+	proxyGridSessionRequest(c, foundDevice, sessionID, commandPath, func(statusCode int) {
+		if statusCode == http.StatusInternalServerError {
+			releaseAfterProviderError(foundDevice)
+		}
+	})
+}
+
+// GridDeleteSession handles the exact `DELETE /grid/session/{id}` - the only request
+// that ends a session and releases its device
+func GridDeleteSession(c *gin.Context) {
+	sessionID := c.Param("sessionId")
+
+	foundDevice, ok := devices.DeviceBySession(sessionID)
+	if !ok {
+		writeW3CError(c, w3cInvalidSessionID(fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", sessionID)))
+		return
+	}
+
+	proxyGridSessionRequest(c, foundDevice, sessionID, "", func(statusCode int) {
+		// The session was deleted - mark the device available right away and fully
+		// release it after a second if no new session claims it in the meantime
+		foundDevice.Mu.Lock()
+		foundDevice.IsAvailableForAutomation = true
+		foundDevice.Mu.Unlock()
+		go func() {
+			time.Sleep(1 * time.Second)
+			foundDevice.Mu.Lock()
+			if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 1000) {
+				foundDevice.ReleaseFromAutomation()
+			}
+			foundDevice.Mu.Unlock()
+		}()
+		if statusCode == http.StatusInternalServerError {
+			releaseAfterProviderError(foundDevice)
+		}
+	})
+}
+
+// releaseAfterProviderError starts the delayed device release used when the provider
+// answers a session request with a 500 - if no further automation activity happens
+// within 10 seconds the session is considered dead and the device is freed
+func releaseAfterProviderError(foundDevice *devices.LocalHubDevice) {
+	go func() {
+		time.Sleep(10 * time.Second)
+		foundDevice.Mu.Lock()
+		if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 10000) {
+			foundDevice.ReleaseFromAutomation()
+		}
+		foundDevice.Mu.Unlock()
+	}()
+}
+
+// proxyGridSessionRequest forwards a session-scoped request to the Appium endpoint of
+// the device's provider through a streaming reverse proxy, bounded by the same command
+// timeout the old shared client enforced. onResponse runs on the provider's response
+// status before the response is written back to the client
+func proxyGridSessionRequest(c *gin.Context, foundDevice *devices.LocalHubDevice, sessionID string, commandPath string, onResponse func(statusCode int)) {
+	foundDevice.Mu.RLock()
+	deviceHost := foundDevice.Host
+	deviceUDID := foundDevice.Device.UDID
+	foundDevice.Mu.RUnlock()
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = deviceHost
+			req.URL.Path = fmt.Sprintf("/device/%s/appium/session/%s%s", deviceUDID, sessionID, commandPath)
+		},
+		Transport: proxyTransport,
+		ModifyResponse: func(resp *http.Response) error {
+			if onResponse != nil {
+				onResponse(resp.StatusCode)
+			}
+			resp.Header.Del("Access-Control-Allow-Origin")
+			// Long-standing behavior: a provider 500 is masked with a GADS error body
+			if resp.StatusCode == http.StatusInternalServerError {
+				replaceResponseBody(resp, createErrorResponse("GADS got an internal server error from the proxy request to the device respective provider Appium endpoint", "", ""))
+			}
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, proxyErr error) {
+			c.JSON(http.StatusInternalServerError, createErrorResponse("GADS failed to execute the proxy request to the device respective provider Appium endpoint", "", proxyErr.Error()))
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), gridCommandTimeout)
+	defer cancel()
+	proxy.ServeHTTP(c.Writer, c.Request.WithContext(ctx))
+
+	// Record the automation activity so the janitor's idle expiry starts counting
+	// from the end of this command
+	foundDevice.Mu.Lock()
+	foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
+	foundDevice.Mu.Unlock()
+}
+
+// replaceResponseBody swaps a proxied response's body for a GADS error body,
+// draining the original so the upstream connection can be reused
+func replaceResponseBody(resp *http.Response, errorResponse SeleniumSessionErrorResponse) {
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	newBody, _ := json.Marshal(errorResponse)
+	resp.Body = io.NopCloser(bytes.NewReader(newBody))
+	resp.ContentLength = int64(len(newBody))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(newBody)))
+	resp.Header.Set("Content-Type", "application/json; charset=utf-8")
 }
 
 func readBody(r io.Reader) ([]byte, error) {
@@ -524,18 +546,6 @@ func readBody(r io.Reader) ([]byte, error) {
 	}
 
 	return body, nil
-}
-
-func getDeviceBySessionID(sessionID string) (*devices.LocalHubDevice, error) {
-	for _, localDevice := range devices.HubDeviceStore.All() {
-		localDevice.Mu.RLock()
-		sid := localDevice.SessionID
-		localDevice.Mu.RUnlock()
-		if sid == sessionID {
-			return localDevice, nil
-		}
-	}
-	return nil, fmt.Errorf("No device with session ID `%s` was found", sessionID)
 }
 
 func getDeviceByUDID(udid string) (*devices.LocalHubDevice, error) {

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -82,9 +82,11 @@ func registerGridRoutes(grid *gin.RouterGroup) {
 }
 
 // GridStatus is the W3C status endpoint (`GET /grid/status`) - reports whether the
-// grid can serve sessions plus a per-device readiness list. Like the rest of /grid
-// it is unauthenticated, so it deliberately exposes no workspace, tenant or user
-// information
+// grid can serve sessions. Without credentials only the readiness flag is returned,
+// keeping healthchecks credential-free. With a valid client secret sent as
+// `Authorization: Bearer <secret>` (the same credential used for session creation)
+// the response also carries the per-device list plus a readiness flag scoped to
+// that credential's workspaces - other tenants' devices are never revealed
 func GridStatus(c *gin.Context) {
 	type gridStatusDevice struct {
 		UDID              string `json:"udid"`
@@ -94,6 +96,26 @@ func GridStatus(c *gin.Context) {
 		Provider          string `json:"provider"`
 		Available         bool   `json:"available"`
 		InUseByAutomation bool   `json:"in_use_by_automation"`
+	}
+
+	secret := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(c.GetHeader("Authorization")), "Bearer"))
+	var scopedUser *gridUser
+	if secret != "" {
+		user, w3cErr := resolveGridUser(secret)
+		if w3cErr != nil {
+			writeW3CError(c, &W3CError{HTTPStatus: http.StatusUnauthorized, Code: "invalid argument", Message: w3cErr.Message})
+			return
+		}
+		scopedUser = &user
+	}
+
+	inAllowedWorkspace := func(workspaceID string) bool {
+		for _, allowedID := range scopedUser.AllowedWorkspaceIDs {
+			if workspaceID == allowedID {
+				return true
+			}
+		}
+		return false
 	}
 
 	ready := false
@@ -106,17 +128,23 @@ func GridStatus(c *gin.Context) {
 			hubDevice.Mu.RUnlock()
 			continue
 		}
+		if scopedUser != nil && !inAllowedWorkspace(hubDevice.Device.WorkspaceID) {
+			hubDevice.Mu.RUnlock()
+			continue
+		}
 		connectedAndLive := hubDevice.Connected && hubDevice.ProviderState == "live"
 		usageAllowsAutomation := hubDevice.Device.Usage != "control" && hubDevice.Device.Usage != "disabled"
-		statusDevices = append(statusDevices, gridStatusDevice{
-			UDID:              hubDevice.Device.UDID,
-			Name:              hubDevice.Device.Name,
-			OS:                hubDevice.Device.OS,
-			OSVersion:         hubDevice.Device.OSVersion,
-			Provider:          hubDevice.Device.Provider,
-			Available:         connectedAndLive && usageAllowsAutomation && hubDevice.IsAvailableForAutomation,
-			InUseByAutomation: hubDevice.IsRunningAutomation,
-		})
+		if scopedUser != nil {
+			statusDevices = append(statusDevices, gridStatusDevice{
+				UDID:              hubDevice.Device.UDID,
+				Name:              hubDevice.Device.Name,
+				OS:                hubDevice.Device.OS,
+				OSVersion:         hubDevice.Device.OSVersion,
+				Provider:          hubDevice.Device.Provider,
+				Available:         connectedAndLive && usageAllowsAutomation && hubDevice.IsAvailableForAutomation,
+				InUseByAutomation: hubDevice.IsRunningAutomation,
+			})
+		}
 		if connectedAndLive {
 			ready = true
 		}
@@ -127,7 +155,11 @@ func GridStatus(c *gin.Context) {
 	if !ready {
 		message = "no devices available"
 	}
-	c.JSON(http.StatusOK, gin.H{"value": gin.H{"ready": ready, "message": message, "devices": statusDevices}})
+	value := gin.H{"ready": ready, "message": message}
+	if scopedUser != nil {
+		value["devices"] = statusDevices
+	}
+	c.JSON(http.StatusOK, gin.H{"value": value})
 }
 
 type automationSession struct {

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -164,14 +164,21 @@ func GridStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"value": value})
 }
 
+// All device OS values GADS can serve automation on - keep in sync with the
+// OS-specific validation in models.ValidateDeviceUsageForOS
+var automationDeviceOSes = []string{"android", "ios", "tizen", "webos", "androidtv", "roku"}
+
 type automationSession struct {
-	SessionID     string `json:"session_id"`
-	DeviceUDID    string `json:"device_udid"`
-	DeviceName    string `json:"device_name"`
-	InUseBy       string `json:"in_use_by"`
-	InUseByTenant string `json:"in_use_by_tenant"`
-	StartedTS     int64  `json:"started_ts"`
-	LastCommandTS int64  `json:"last_command_ts"`
+	SessionID       string `json:"session_id"`
+	DeviceUDID      string `json:"device_udid"`
+	DeviceName      string `json:"device_name"`
+	DeviceOS        string `json:"device_os"`
+	DeviceOSVersion string `json:"device_os_version"`
+	Provider        string `json:"provider"`
+	InUseBy         string `json:"in_use_by"`
+	InUseByTenant   string `json:"in_use_by_tenant"`
+	StartedTS       int64  `json:"started_ts"`
+	LastCommandTS   int64  `json:"last_command_ts"`
 }
 
 // GetAutomationSessions godoc
@@ -188,13 +195,16 @@ func GetAutomationSessions(c *gin.Context) {
 	for sessionID, sessionDevice := range devices.AllSessions() {
 		sessionDevice.Mu.RLock()
 		sessions = append(sessions, automationSession{
-			SessionID:     sessionID,
-			DeviceUDID:    sessionDevice.Device.UDID,
-			DeviceName:    sessionDevice.Device.Name,
-			InUseBy:       sessionDevice.InUseBy,
-			InUseByTenant: sessionDevice.InUseByTenant,
-			StartedTS:     sessionDevice.AutomationSessionStartTS,
-			LastCommandTS: sessionDevice.LastAutomationActionTS,
+			SessionID:       sessionID,
+			DeviceUDID:      sessionDevice.Device.UDID,
+			DeviceName:      sessionDevice.Device.Name,
+			DeviceOS:        sessionDevice.Device.OS,
+			DeviceOSVersion: sessionDevice.Device.OSVersion,
+			Provider:        sessionDevice.Device.Provider,
+			InUseBy:         sessionDevice.InUseBy,
+			InUseByTenant:   sessionDevice.InUseByTenant,
+			StartedTS:       sessionDevice.AutomationSessionStartTS,
+			LastCommandTS:   sessionDevice.LastAutomationActionTS,
 		})
 		sessionDevice.Mu.RUnlock()
 	}
@@ -206,24 +216,34 @@ func GetAutomationSessions(c *gin.Context) {
 		return sessions[i].SessionID < sessions[j].SessionID
 	})
 
-	// Same overall-readiness notion as /grid/status: any connected, live device
-	// whose provider runs Appium servers
-	ready := false
+	// Devices that could take a new automation session this instant - same
+	// eligibility the grid's own dispatch applies - broken down per OS. Every
+	// supported OS is present in the map, so platforms with no devices at all
+	// still report an explicit zero
+	availableDevicesByOS := map[string]int{}
+	for _, deviceOS := range automationDeviceOSes {
+		availableDevicesByOS[deviceOS] = 0
+	}
 	for _, hubDevice := range devices.HubDeviceStore.All() {
 		hubDevice.Mu.RLock()
-		if hubDevice.AppiumEnabled && hubDevice.Connected && hubDevice.ProviderState == "live" {
-			ready = true
+		if hubDevice.AppiumEnabled &&
+			hubDevice.Device.Usage != "control" &&
+			hubDevice.Device.Usage != "disabled" {
+			deviceOS := strings.ToLower(hubDevice.Device.OS)
+			availableDevicesByOS[deviceOS] += 0
+			if hubDevice.Connected &&
+				hubDevice.ProviderState == "live" &&
+				hubDevice.IsAvailableForAutomation {
+				availableDevicesByOS[deviceOS]++
+			}
 		}
 		hubDevice.Mu.RUnlock()
-		if ready {
-			break
-		}
 	}
 
 	api.OK(c, "Automation sessions overview", gin.H{
-		"ready":    ready,
-		"queued":   gridQueue.depth(),
-		"sessions": sessions,
+		"available_devices_by_os": availableDevicesByOS,
+		"queued":                  gridQueue.depth(),
+		"sessions":                sessions,
 	})
 }
 

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -34,6 +34,12 @@ import (
 // recordings and source dumps can be slow
 const gridCommandTimeout = 90 * time.Second
 
+// After a session DELETE the device stays visibly busy (running automation, lock
+// held) for this cool-down so it cannot be grabbed for remote control between
+// back-to-back tests of a suite. Automation is not delayed by it - the device is
+// claimable for a new session right away, which also cancels the cool-down
+const postSessionReleaseCooldown = 5 * time.Second
+
 // Shared HTTP clients for proxying grid traffic to providers, reusing the same
 // connection pool as the device proxy (proxyTransport). Session creation gets a
 // generous timeout because driver/WDA startup can take minutes
@@ -298,12 +304,13 @@ func resolveGridUser(clientSecret string) (gridUser, *W3CError) {
 }
 
 // abortAutomationClaim undoes a pre-session device claim after a failed session
-// create. The lock fields are left untouched on purpose - no session was
-// established, so there is nothing to release beyond the availability flags
+// create, including the identity stamped at claim time - unless the device is
+// still held via a UI WebSocket or an API lease, whose lock must survive
 func abortAutomationClaim(foundDevice *devices.LocalHubDevice) {
 	foundDevice.Mu.Lock()
 	foundDevice.IsAvailableForAutomation = true
 	foundDevice.IsRunningAutomation = false
+	foundDevice.ReleaseLockIfNotHeld()
 	foundDevice.Mu.Unlock()
 	devices.NotifyDeviceFreed()
 }
@@ -377,8 +384,21 @@ func GridCreateSession(c *gin.Context) {
 	if candidate.NewCommandTimeout != nil {
 		newCommandTimeoutMS = *candidate.NewCommandTimeout * 1000
 	}
+	// Stamp who claimed the device together with the claim itself - the session
+	// create below can take several seconds and the device must not show as busy
+	// without a user for that window. When the same user already holds the device
+	// via a UI or API lock, that lock's identity is kept untouched
+	automationUser := user.UserID
+	if automationUser == "" {
+		automationUser = "unknown"
+	}
 	foundDevice.Mu.Lock()
 	foundDevice.ClaimForAutomation(newCommandTimeoutMS)
+	if !foundDevice.HasUISession() && !foundDevice.HasActiveLease() {
+		foundDevice.InUseBy = automationUser
+		foundDevice.InUseByTenant = user.Tenant
+		foundDevice.InUseTS = time.Now().UnixMilli()
+	}
 	foundDevice.Mu.Unlock()
 
 	// Remove grid-internal `gads:*` capabilities so the client secret never reaches Appium (and its logs)
@@ -417,7 +437,11 @@ func GridCreateSession(c *gin.Context) {
 		// for a grace period (the delayed goroutine below) so a quick retry by the
 		// same client is not raced; any other error releases the lock right away
 		if resp.StatusCode == http.StatusInternalServerError {
-			abortAutomationClaim(foundDevice)
+			foundDevice.Mu.Lock()
+			foundDevice.IsAvailableForAutomation = true
+			foundDevice.IsRunningAutomation = false
+			foundDevice.Mu.Unlock()
+			devices.NotifyDeviceFreed()
 			go func() {
 				time.Sleep(10 * time.Second)
 				foundDevice.Mu.Lock()
@@ -485,15 +509,9 @@ func GridCreateSession(c *gin.Context) {
 
 	foundDevice.Mu.Lock()
 	foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
-	// Set InUseBy with user ID and tenant for tracking
-	automationUser := user.UserID
-	if automationUser == "" {
-		automationUser = "unknown"
-	}
-	// Only update InUseBy if no UI or API session is active
+	// Identity was stamped at claim time - only refresh the in-use timestamp now
+	// that the session is established
 	if !foundDevice.HasUISession() && !foundDevice.HasActiveLease() {
-		foundDevice.InUseBy = automationUser
-		foundDevice.InUseByTenant = user.Tenant
 		foundDevice.InUseTS = time.Now().UnixMilli()
 	}
 	foundDevice.Mu.Unlock()
@@ -593,16 +611,17 @@ func GridDeleteSession(c *gin.Context) {
 	}
 
 	proxyGridSessionRequest(c, foundDevice, sessionID, "", func(statusCode int) {
-		// The session was deleted - mark the device available right away and fully
-		// release it after a second if no new session claims it in the meantime
+		// The session was deleted - mark the device claimable for automation right
+		// away, but keep it visibly busy for the cool-down and fully release it
+		// only if no new session claims it in the meantime
 		foundDevice.Mu.Lock()
 		foundDevice.IsAvailableForAutomation = true
 		foundDevice.Mu.Unlock()
 		devices.NotifyDeviceFreed()
 		go func() {
-			time.Sleep(1 * time.Second)
+			time.Sleep(postSessionReleaseCooldown)
 			foundDevice.Mu.Lock()
-			if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - 1000) {
+			if foundDevice.LastAutomationActionTS <= (time.Now().UnixMilli() - postSessionReleaseCooldown.Milliseconds()) {
 				foundDevice.ReleaseFromAutomation()
 			}
 			foundDevice.Mu.Unlock()

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -10,6 +10,7 @@
 package router
 
 import (
+	"GADS/common/api"
 	"GADS/common/models"
 	"GADS/hub/devices"
 	"bytes"
@@ -20,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -73,10 +75,91 @@ func registerGridRoutes(grid *gin.RouterGroup) {
 	grid.Any("/session/:sessionId/*path", GridSessionCommand)
 }
 
-// GridStatus is the W3C status endpoint (`GET /grid/status`). Currently a static
-// readiness stub - Phase 4 of the grid rework fills in real device information
+// GridStatus is the W3C status endpoint (`GET /grid/status`) - reports whether the
+// grid can serve sessions plus a per-device readiness list. Like the rest of /grid
+// it is unauthenticated, so it deliberately exposes no workspace, tenant or user
+// information
 func GridStatus(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"value": gin.H{"ready": true, "message": "GADS grid ready"}})
+	type gridStatusDevice struct {
+		UDID              string `json:"udid"`
+		Name              string `json:"name"`
+		OS                string `json:"os"`
+		OSVersion         string `json:"os_version"`
+		Provider          string `json:"provider"`
+		Available         bool   `json:"available"`
+		InUseByAutomation bool   `json:"in_use_by_automation"`
+	}
+
+	ready := false
+	statusDevices := []gridStatusDevice{}
+	for _, hubDevice := range devices.HubDeviceStore.AllSorted() {
+		hubDevice.Mu.RLock()
+		connectedAndLive := hubDevice.Connected && hubDevice.ProviderState == "live"
+		usageAllowsAutomation := hubDevice.Device.Usage != "control" && hubDevice.Device.Usage != "disabled"
+		statusDevices = append(statusDevices, gridStatusDevice{
+			UDID:              hubDevice.Device.UDID,
+			Name:              hubDevice.Device.Name,
+			OS:                hubDevice.Device.OS,
+			OSVersion:         hubDevice.Device.OSVersion,
+			Provider:          hubDevice.Device.Provider,
+			Available:         connectedAndLive && usageAllowsAutomation && hubDevice.IsAvailableForAutomation,
+			InUseByAutomation: hubDevice.IsRunningAutomation,
+		})
+		if connectedAndLive {
+			ready = true
+		}
+		hubDevice.Mu.RUnlock()
+	}
+
+	message := "GADS grid ready"
+	if !ready {
+		message = "no devices available"
+	}
+	c.JSON(http.StatusOK, gin.H{"value": gin.H{"ready": ready, "message": message, "devices": statusDevices}})
+}
+
+type automationSession struct {
+	SessionID     string `json:"session_id"`
+	DeviceUDID    string `json:"device_udid"`
+	DeviceName    string `json:"device_name"`
+	InUseBy       string `json:"in_use_by"`
+	InUseByTenant string `json:"in_use_by_tenant"`
+	StartedTS     int64  `json:"started_ts"`
+	LastCommandTS int64  `json:"last_command_ts"`
+}
+
+// GetAutomationSessions godoc
+// @Summary      List active automation sessions
+// @Description  Retrieve the currently active Appium grid sessions and the devices serving them
+// @Tags         Hub - Devices
+// @Produce      json
+// @Success      200  {object}  models.APIResponse
+// @Failure      401  {object}  models.ErrorResponse
+// @Security     BearerAuth
+// @Router       /automation-sessions [get]
+func GetAutomationSessions(c *gin.Context) {
+	sessions := []automationSession{}
+	for sessionID, sessionDevice := range devices.AllSessions() {
+		sessionDevice.Mu.RLock()
+		sessions = append(sessions, automationSession{
+			SessionID:     sessionID,
+			DeviceUDID:    sessionDevice.Device.UDID,
+			DeviceName:    sessionDevice.Device.Name,
+			InUseBy:       sessionDevice.InUseBy,
+			InUseByTenant: sessionDevice.InUseByTenant,
+			StartedTS:     sessionDevice.AutomationSessionStartTS,
+			LastCommandTS: sessionDevice.LastAutomationActionTS,
+		})
+		sessionDevice.Mu.RUnlock()
+	}
+	// Map iteration order is random - keep the output stable for consumers
+	sort.Slice(sessions, func(i, j int) bool {
+		if sessions[i].StartedTS != sessions[j].StartedTS {
+			return sessions[i].StartedTS < sessions[j].StartedTS
+		}
+		return sessions[i].SessionID < sessions[j].SessionID
+	})
+	api.OK(c, "Active automation sessions", sessions)
 }
 
 // Every second sweep the devices and clean up automation sessions
@@ -390,15 +473,22 @@ func GridCreateSession(c *gin.Context) {
 		devices.UnregisterSession(foundDevice.SessionID)
 	}
 	foundDevice.SessionID = proxySessionResponse.Value.SessionID
+	foundDevice.AutomationSessionStartTS = time.Now().UnixMilli()
 	devices.RegisterSession(foundDevice.SessionID, foundDevice)
 	foundDevice.Mu.Unlock()
+
+	// Enrich the returned capabilities with grid-level `gads:*` entries (spec-legal
+	// for intermediary nodes) so the client knows which device it actually got
+	responseBody := enrichSessionResponse(proxiedSessionResponseBody, foundDevice, hubBaseURL(c))
 
 	// Copy the response back to the original client
 	for k, v := range resp.Header {
 		c.Writer.Header()[k] = v
 	}
+	// The body may have grown past the provider's Content-Length
+	c.Writer.Header().Set("Content-Length", strconv.Itoa(len(responseBody)))
 	c.Writer.WriteHeader(resp.StatusCode)
-	c.Writer.Write(proxiedSessionResponseBody)
+	c.Writer.Write(responseBody)
 
 	foundDevice.Mu.Lock()
 	foundDevice.LastAutomationActionTS = time.Now().UnixMilli()
@@ -414,6 +504,60 @@ func GridCreateSession(c *gin.Context) {
 		foundDevice.InUseTS = time.Now().UnixMilli()
 	}
 	foundDevice.Mu.Unlock()
+}
+
+// hubBaseURL derives the hub's base URL from the incoming request - the address the
+// client used to reach the hub is by definition reachable for whoever ran the test.
+// The hub itself only serves plain HTTP; a TLS-terminating reverse proxy announces
+// itself via X-Forwarded-Proto
+func hubBaseURL(c *gin.Context) string {
+	if c.Request.Host == "" {
+		return ""
+	}
+	scheme := "http"
+	if forwardedProto := c.Request.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
+		scheme = forwardedProto
+	}
+	return fmt.Sprintf("%s://%s", scheme, c.Request.Host)
+}
+
+// enrichSessionResponse injects grid-level `<prefix>:*` capabilities into a successful
+// session-create response: the served device's UDID, name and provider, plus a link to
+// the hub's device control UI for the device. The response is parsed as a generic map
+// so every capability Appium returned survives untouched; on any unexpected shape the
+// original body is returned as-is
+func enrichSessionResponse(responseBody []byte, foundDevice *devices.LocalHubDevice, hubURL string) []byte {
+	var response map[string]interface{}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return responseBody
+	}
+	value, ok := response["value"].(map[string]interface{})
+	if !ok {
+		return responseBody
+	}
+	caps, ok := value["capabilities"].(map[string]interface{})
+	if !ok {
+		return responseBody
+	}
+
+	foundDevice.Mu.RLock()
+	deviceUDID := foundDevice.Device.UDID
+	deviceName := foundDevice.Device.Name
+	deviceProvider := foundDevice.Device.Provider
+	foundDevice.Mu.RUnlock()
+
+	caps[capabilityPrefix+":deviceUdid"] = deviceUDID
+	caps[capabilityPrefix+":deviceName"] = deviceName
+	caps[capabilityPrefix+":provider"] = deviceProvider
+	if hubURL != "" {
+		caps[capabilityPrefix+":controlUrl"] = fmt.Sprintf("%s/devices/control/%s", hubURL, deviceUDID)
+	}
+
+	enriched, err := json.Marshal(response)
+	if err != nil {
+		return responseBody
+	}
+	return enriched
 }
 
 // GridSessionCommand proxies an ordinary WebDriver command (anything under

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -200,6 +200,13 @@ func AppiumGridMiddleware() gin.HandlerFunc {
 				return
 			}
 
+			// Usage misconfiguration cannot resolve by waiting - fail immediately
+			// with the reason instead of entering the retry loop
+			if deviceErr != nil && strings.Contains(deviceErr.Error(), "is not enabled for automation") {
+				writeW3CError(c, w3cSessionNotCreated(deviceErr.Error()))
+				return
+			}
+
 			// If no device is available start checking each second for 10 seconds
 			// If no device is available after 10 seconds - return error
 			if foundDevice == nil {
@@ -581,15 +588,20 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 			return nil, fmt.Errorf("No device with udid `%s` was found", deviceUDID)
 		}
 
-		// A UDID-pinned device must pass the same eligibility checks as the generic
-		// search below - without them a client could start automation on a device
-		// another user is actively controlling. The exact reason is deliberately
-		// not exposed to the client
+		// Usage is static configuration - a device set to remote-control-only or
+		// disabled can never serve automation, so tell the client the reason and
+		// let the middleware fail fast instead of retrying
+		if usage == "control" || usage == "disabled" {
+			return nil, fmt.Errorf("Device with udid `%s` is not enabled for automation, its usage is set to `%s`", deviceUDID, usage)
+		}
+
+		// A UDID-pinned device must pass the same runtime eligibility checks as the
+		// generic search below - without them a client could start automation on a
+		// device another user is actively controlling. The exact reason is
+		// deliberately not exposed to the client
 		if !connected ||
 			state != "live" ||
 			lastUpdated < (time.Now().UnixMilli()-3000) ||
-			usage == "control" ||
-			usage == "disabled" ||
 			isLockedByOther {
 			return nil, fmt.Errorf("Device is currently not available for automation")
 		}

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -100,6 +100,12 @@ func GridStatus(c *gin.Context) {
 	statusDevices := []gridStatusDevice{}
 	for _, hubDevice := range devices.HubDeviceStore.AllSorted() {
 		hubDevice.Mu.RLock()
+		// Devices on a provider without Appium servers can never serve a session -
+		// they are not part of the grid's world at all
+		if !hubDevice.AppiumEnabled {
+			hubDevice.Mu.RUnlock()
+			continue
+		}
 		connectedAndLive := hubDevice.Connected && hubDevice.ProviderState == "live"
 		usageAllowsAutomation := hubDevice.Device.Usage != "control" && hubDevice.Device.Usage != "disabled"
 		statusDevices = append(statusDevices, gridStatusDevice{
@@ -747,6 +753,7 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 		state := d.ProviderState
 		lastUpdated := d.LastUpdatedTimestamp
 		usage := d.Device.Usage
+		appiumEnabled := d.AppiumEnabled
 		isLockedByOther := d.IsLockedByOther(userID, userTenant)
 		d.Mu.RUnlock()
 
@@ -767,6 +774,13 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 		// let the middleware fail fast instead of retrying
 		if usage == "control" || usage == "disabled" {
 			return nil, fmt.Errorf("Device with udid `%s` is not enabled for automation, its usage is set to `%s`", deviceUDID, usage)
+		}
+
+		// Same static-configuration reasoning: a provider that does not run Appium
+		// servers can never serve a session for this device. The error phrasing must
+		// keep "is not enabled for automation" so the queue fails fast on it
+		if !appiumEnabled {
+			return nil, fmt.Errorf("Device with udid `%s` is not enabled for automation, its provider does not run Appium servers", deviceUDID)
 		}
 
 		// A UDID-pinned device must pass the same runtime eligibility checks as the
@@ -802,6 +816,7 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 			lastUpdated := localDevice.LastUpdatedTimestamp
 			available := localDevice.IsAvailableForAutomation
 			usage := localDevice.Device.Usage
+			appiumEnabled := localDevice.AppiumEnabled
 			wsID := localDevice.Device.WorkspaceID
 			isLockedByOther := localDevice.IsLockedByOther(userID, userTenant)
 			localDevice.Mu.RUnlock()
@@ -811,6 +826,7 @@ func findAvailableDevice(candidate gridCandidate, allowedWorkspaceIDs []string, 
 				state != "live" ||
 				lastUpdated < (time.Now().UnixMilli()-3000) ||
 				!available ||
+				!appiumEnabled ||
 				usage == "control" ||
 				usage == "disabled" {
 				continue

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -546,6 +546,13 @@ func enrichSessionResponse(responseBody []byte, foundDevice *devices.LocalHubDev
 		caps[capabilityPrefix+":controlUrl"] = fmt.Sprintf("%s/devices/control/%s", hubURL, deviceUDID)
 	}
 
+	// GADS does not support BiDi - Appium's webSocketUrl points at the provider's
+	// localhost, so returning it would leave clients hanging on a dead WS connect
+	if _, hasWebSocketURL := caps["webSocketUrl"]; hasWebSocketURL {
+		slog.Warn(fmt.Sprintf("BiDi is not supported by the GADS grid; webSocketUrl stripped from the session response for device `%s`", deviceUDID))
+		delete(caps, "webSocketUrl")
+	}
+
 	enriched, err := json.Marshal(response)
 	if err != nil {
 		return responseBody

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -289,6 +289,7 @@ func abortAutomationClaim(foundDevice *devices.LocalHubDevice) {
 	foundDevice.IsAvailableForAutomation = true
 	foundDevice.IsRunningAutomation = false
 	foundDevice.Mu.Unlock()
+	devices.NotifyDeviceFreed()
 }
 
 // GridCreateSession handles `POST /grid/session` - authenticates the client via its
@@ -324,51 +325,27 @@ func GridCreateSession(c *gin.Context) {
 		return
 	}
 
-	// Check for available device
-	foundDevice, deviceErr := findAvailableDevice(candidate, user.AllowedWorkspaceIDs, user.UserID, user.Tenant)
-
-	if deviceErr != nil && strings.Contains(deviceErr.Error(), "No device with udid") {
-		c.JSON(http.StatusNotFound, createErrorResponse("No available device found", "session not created", ""))
+	// Find and claim a matching device, waiting in FIFO order behind earlier
+	// requests when none is free - `gads:queueTimeout` controls how long
+	foundDevice, deviceErr, clientGone := gridQueue.Acquire(candidate, user, queueWaitDuration(candidate), c.Request.Context().Done())
+	if clientGone {
+		// The client went away while queued - nobody is left to answer
 		return
 	}
 
-	// Usage misconfiguration cannot resolve by waiting - fail immediately
-	// with the reason instead of entering the retry loop
-	if deviceErr != nil && strings.Contains(deviceErr.Error(), "is not enabled for automation") {
-		writeW3CError(c, w3cSessionNotCreated(deviceErr.Error()))
-		return
-	}
-
-	// If no device is available start checking each second for 10 seconds
-	// If no device is available after 10 seconds - return error
 	if foundDevice == nil {
-		ticker := time.NewTicker(100 * time.Millisecond)
-		timeout := time.After(10 * time.Second)
-		notify := c.Writer.CloseNotify()
-	FOR_LOOP:
-		for {
-			select {
-			case <-ticker.C:
-				foundDevice, deviceErr = findAvailableDevice(candidate, user.AllowedWorkspaceIDs, user.UserID, user.Tenant)
-				if foundDevice != nil {
-					break FOR_LOOP
-				}
-			case <-timeout:
-				ticker.Stop()
-				if deviceErr != nil {
-					c.JSON(http.StatusInternalServerError, createErrorResponse(deviceErr.Error(), "session not created", ""))
-				} else {
-					c.JSON(http.StatusInternalServerError, createErrorResponse("No available device found", "session not created", ""))
-				}
-				return
-			case <-notify:
-				ticker.Stop()
-				return
-			}
+		if deviceErr != nil && strings.Contains(deviceErr.Error(), "No device with udid") {
+			c.JSON(http.StatusNotFound, createErrorResponse("No available device found", "session not created", ""))
+			return
 		}
-	}
 
-	if foundDevice == nil {
+		// Usage misconfiguration cannot resolve by waiting - the queue fails fast
+		// and the reason goes to the client
+		if deviceErr != nil && strings.Contains(deviceErr.Error(), "is not enabled for automation") {
+			writeW3CError(c, w3cSessionNotCreated(deviceErr.Error()))
+			return
+		}
+
 		if deviceErr != nil {
 			c.JSON(http.StatusInternalServerError, createErrorResponse(deviceErr.Error(), "session not created", ""))
 		} else {
@@ -598,6 +575,7 @@ func GridDeleteSession(c *gin.Context) {
 		foundDevice.Mu.Lock()
 		foundDevice.IsAvailableForAutomation = true
 		foundDevice.Mu.Unlock()
+		devices.NotifyDeviceFreed()
 		go func() {
 			time.Sleep(1 * time.Second)
 			foundDevice.Mu.Lock()

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -182,17 +182,33 @@ func sweepExpiredGridSessions() {
 		if hubDevice.LockSource == devices.LockSourceAPI && hubDevice.LeaseExpiresAt > 0 && hubDevice.LeaseExpiresAt < now {
 			hubDevice.ReleaseLock()
 		}
+		// The idle check prefers the freshest activity signal: hub-side proxy traffic
+		// or, when the provider reports Appium session truth, command activity seen
+		// by the appium-plugin (covers clients whose commands keep the driver busy
+		// while the hub-side connection is quiet, e.g. long implicit waits)
+		lastActivityTS := hubDevice.LastAutomationActionTS
+		if hubDevice.ProviderReportsSessionState && hubDevice.ProviderLastCommandTS > lastActivityTS {
+			lastActivityTS = hubDevice.ProviderLastCommandTS
+		}
 		// A new-command timeout of 0 means the client explicitly disabled the idle
 		// timer (`appium:newCommandTimeout: 0`) - such sessions live until they are
 		// deleted or the device disconnects
 		idleExpired := hubDevice.IsRunningAutomation &&
 			hubDevice.AppiumNewCommandTimeout > 0 &&
-			hubDevice.LastAutomationActionTS <= (now-hubDevice.AppiumNewCommandTimeout)
-		if !hubDevice.Connected || hubDevice.ProviderState != "live" || idleExpired {
+			lastActivityTS <= (now-hubDevice.AppiumNewCommandTimeout)
+		// The provider is the ground truth for whether an Appium session actually
+		// exists - if it has reported the session gone for over 10 seconds the hub
+		// entry is stale (crashed driver, externally killed session)
+		providerSaysSessionGone := hubDevice.IsRunningAutomation &&
+			hubDevice.SessionID != "" &&
+			hubDevice.ProviderSessionMissingSinceTS > 0 &&
+			hubDevice.ProviderSessionMissingSinceTS <= (now-10000)
+		if !hubDevice.Connected || hubDevice.ProviderState != "live" || idleExpired || providerSaysSessionGone {
 			// Ask the provider to actually close the expired Appium session (best
 			// effort, in the background) - otherwise the app under test keeps running
-			// on the device until the next session overrides it
-			if hubDevice.SessionID != "" && hubDevice.Connected && hubDevice.ProviderState == "live" {
+			// on the device until the next session overrides it. Pointless when the
+			// provider itself reported the session gone
+			if hubDevice.SessionID != "" && hubDevice.Connected && hubDevice.ProviderState == "live" && !providerSaysSessionGone {
 				go killProviderAppiumSession(hubDevice.Host, hubDevice.Device.UDID, hubDevice.SessionID)
 			}
 			hubDevice.ReleaseFromAutomation()

--- a/hub/router/appiumgrid.go
+++ b/hub/router/appiumgrid.go
@@ -155,7 +155,9 @@ func GridStatus(c *gin.Context) {
 	if !ready {
 		message = "no devices available"
 	}
-	value := gin.H{"ready": ready, "message": message}
+	// The queue depth is a global count - it reveals nothing tenant-specific,
+	// so it is reported to anonymous callers too
+	value := gin.H{"ready": ready, "message": message, "queued": gridQueue.depth()}
 	if scopedUser != nil {
 		value["devices"] = statusDevices
 	}
@@ -173,8 +175,8 @@ type automationSession struct {
 }
 
 // GetAutomationSessions godoc
-// @Summary      List active automation sessions
-// @Description  Retrieve the currently active Appium grid sessions and the devices serving them
+// @Summary      Automation sessions overview
+// @Description  Retrieve grid readiness, the queued session request count and the currently active Appium grid sessions
 // @Tags         Hub - Devices
 // @Produce      json
 // @Success      200  {object}  models.APIResponse
@@ -203,7 +205,26 @@ func GetAutomationSessions(c *gin.Context) {
 		}
 		return sessions[i].SessionID < sessions[j].SessionID
 	})
-	api.OK(c, "Active automation sessions", sessions)
+
+	// Same overall-readiness notion as /grid/status: any connected, live device
+	// whose provider runs Appium servers
+	ready := false
+	for _, hubDevice := range devices.HubDeviceStore.All() {
+		hubDevice.Mu.RLock()
+		if hubDevice.AppiumEnabled && hubDevice.Connected && hubDevice.ProviderState == "live" {
+			ready = true
+		}
+		hubDevice.Mu.RUnlock()
+		if ready {
+			break
+		}
+	}
+
+	api.OK(c, "Automation sessions overview", gin.H{
+		"ready":    ready,
+		"queued":   gridQueue.depth(),
+		"sessions": sessions,
+	})
 }
 
 // Every second sweep the devices and clean up automation sessions

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -106,15 +106,18 @@ func TestFindAvailableDeviceByUDIDEligibility(t *testing.T) {
 	// search - a pinned device that is disconnected, controlled or locked by
 	// another user must not be handed out
 	tests := []struct {
-		name   string
-		mutate func(d *devices.LocalHubDevice)
+		name string
+		// Usage-based rejections carry the reason (static config, middleware fails
+		// fast on them); runtime rejections use the generic non-leaking message
+		wantErrContains string
+		mutate          func(d *devices.LocalHubDevice)
 	}{
-		{"disconnected device", func(d *devices.LocalHubDevice) { d.Connected = false }},
-		{"provider state not live", func(d *devices.LocalHubDevice) { d.ProviderState = "init" }},
-		{"stale provider update", func(d *devices.LocalHubDevice) { d.LastUpdatedTimestamp = time.Now().UnixMilli() - 10000 }},
-		{"usage control", func(d *devices.LocalHubDevice) { d.Device.Usage = "control" }},
-		{"usage disabled", func(d *devices.LocalHubDevice) { d.Device.Usage = "disabled" }},
-		{"locked by another user", func(d *devices.LocalHubDevice) {
+		{"disconnected device", "not available", func(d *devices.LocalHubDevice) { d.Connected = false }},
+		{"provider state not live", "not available", func(d *devices.LocalHubDevice) { d.ProviderState = "init" }},
+		{"stale provider update", "not available", func(d *devices.LocalHubDevice) { d.LastUpdatedTimestamp = time.Now().UnixMilli() - 10000 }},
+		{"usage control", "is not enabled for automation", func(d *devices.LocalHubDevice) { d.Device.Usage = "control" }},
+		{"usage disabled", "is not enabled for automation", func(d *devices.LocalHubDevice) { d.Device.Usage = "disabled" }},
+		{"locked by another user", "not available", func(d *devices.LocalHubDevice) {
 			d.InUseBy = "other-user"
 			d.InUseByTenant = "tenant1"
 			d.InUseTS = time.Now().UnixMilli()
@@ -134,10 +137,41 @@ func TestFindAvailableDeviceByUDIDEligibility(t *testing.T) {
 			found, err := findAvailableDevice(gridCandidate{DeviceUDID: udid}, []string{"ws1"}, "test-user", "tenant1")
 			assert.Nil(t, found)
 			if assert.Error(t, err) {
-				assert.Equal(t, "Device is currently not available for automation", err.Error())
+				assert.Contains(t, err.Error(), tt.wantErrContains)
 			}
 		})
 	}
+
+	t.Run("usage misconfiguration fails the session request fast with the reason", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		prevGridDB := gridDB
+		defer func() { gridDB = prevGridDB }()
+		gridDB = &fakeGridStore{
+			credential: models.ClientCredentials{UserID: "test-user", Tenant: "tenant1", IsActive: true},
+			workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+		}
+
+		udid := "udid-control-usage-device"
+		device, cleanup := newGridSessionDevice(udid, "", "fake-host")
+		defer cleanup()
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+		device.Device.Usage = "control"
+
+		sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret","appium:udid":"` + udid + `"}}}`
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+		start := time.Now()
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		// Must not sit in the 10-second no-device retry loop - usage cannot change by waiting
+		assert.Less(t, time.Since(start), 2*time.Second)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "is not enabled for automation")
+		assert.Contains(t, w.Body.String(), "session not created")
+	})
 
 	t.Run("eligible pinned device is claimed", func(t *testing.T) {
 		udid := "udid-eligible-device"

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -14,6 +14,7 @@ import (
 	"GADS/hub/auth"
 	"GADS/hub/devices"
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -429,18 +430,57 @@ func TestSyncDeviceFieldsProviderTruth(t *testing.T) {
 func TestGridStatus(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("no devices means not ready", func(t *testing.T) {
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "status-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	// statusRequest hits /grid/status, with the client secret header when given
+	statusRequest := func(secret string) *httptest.ResponseRecorder {
 		router := newGridTestRouter()
 		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+		if secret != "" {
+			req.Header.Set("Authorization", "Bearer "+secret)
+		}
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("no devices means not ready", func(t *testing.T) {
+		w := statusRequest("")
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), `"ready":false`)
 		assert.Contains(t, w.Body.String(), "no devices available")
 	})
 
-	t.Run("live device makes the grid ready and is listed", func(t *testing.T) {
+	t.Run("without credentials only readiness is reported, never the device list", func(t *testing.T) {
+		_, cleanup := newGridSessionDevice("status-anon-device", "", "fake-host")
+		defer cleanup()
+
+		w := statusRequest("")
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"ready":true`)
+		assert.NotContains(t, w.Body.String(), "devices")
+		assert.NotContains(t, w.Body.String(), "status-anon-device")
+	})
+
+	t.Run("an invalid client secret is rejected", func(t *testing.T) {
+		prevStore := gridDB
+		defer func() { gridDB = prevStore }()
+		gridDB = &fakeGridStore{credentialErr: fmt.Errorf("not found")}
+
+		w := statusRequest("wrong-secret")
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid client credentials")
+	})
+
+	t.Run("live device makes the grid ready and is listed with credentials", func(t *testing.T) {
 		device, cleanup := newGridSessionDevice("status-live-device", "", "fake-host")
 		defer cleanup()
 		device.Device.Name = "Status Phone"
@@ -449,10 +489,7 @@ func TestGridStatus(t *testing.T) {
 		device.IsRunningAutomation = false
 		device.IsAvailableForAutomation = true
 
-		router := newGridTestRouter()
-		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+		w := statusRequest("status-secret")
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), `"ready":true`)
@@ -464,14 +501,26 @@ func TestGridStatus(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"in_use_by_automation":false`)
 	})
 
+	t.Run("devices outside the credential's workspaces are not listed and do not count as ready", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("status-foreign-device", "", "fake-host")
+		defer cleanup()
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+		device.Device.WorkspaceID = "other-tenant-ws"
+
+		w := statusRequest("status-secret")
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NotContains(t, w.Body.String(), "status-foreign-device")
+		assert.Contains(t, w.Body.String(), `"ready":false`)
+	})
+
 	t.Run("device running automation is ready but not available", func(t *testing.T) {
 		_, cleanup := newGridSessionDevice("status-busy-device", "status-busy-session", "fake-host")
 		defer cleanup()
 
-		router := newGridTestRouter()
-		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+		w := statusRequest("status-secret")
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), `"ready":true`)
@@ -487,10 +536,7 @@ func TestGridStatus(t *testing.T) {
 		device.IsAvailableForAutomation = true
 		device.AppiumEnabled = false
 
-		router := newGridTestRouter()
-		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
+		w := statusRequest("status-secret")
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.NotContains(t, w.Body.String(), "status-no-appium-device")

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -594,6 +594,29 @@ func TestEnrichSessionResponse(t *testing.T) {
 
 		assert.Contains(t, body, `"gads:controlUrl":"https://gads.example.com/devices/control/enrichment-url-device"`)
 	})
+
+	t.Run("webSocketUrl is stripped - BiDi is not supported", func(t *testing.T) {
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":{"sessionId":"enrich-bidi-session","capabilities":{"platformName":"Android","webSocketUrl":"ws://localhost:4723/bidi/enrich-bidi-session","appium:automationName":"UiAutomator2"}}}`))
+		}))
+		defer fakeProvider.Close()
+
+		udid := "enrichment-bidi-device"
+		_, cleanup := newEnrichmentDevice(udid, strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		defer devices.UnregisterSession("enrich-bidi-session")
+
+		body := createSession(t, udid)
+
+		// The provider-localhost WS URL must never reach the client
+		assert.NotContains(t, body, "webSocketUrl")
+		assert.NotContains(t, body, "ws://")
+		// The session is otherwise normal - other caps and the enrichment survive
+		assert.Contains(t, body, `"sessionId":"enrich-bidi-session"`)
+		assert.Contains(t, body, `"appium:automationName":"UiAutomator2"`)
+		assert.Contains(t, body, `"gads:deviceUdid":"enrichment-bidi-device"`)
+	})
 }
 
 func TestGridSessionLifecycleFlow(t *testing.T) {

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -260,6 +260,154 @@ func TestSweepExpiredGridSessions(t *testing.T) {
 		_, stillRegistered := devices.DeviceBySession("orphan-session")
 		assert.False(t, stillRegistered)
 	})
+
+	t.Run("provider-reported command activity keeps a hub-quiet session alive", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("janitor-provider-active-device", "provider-active-session", "fake-host")
+		defer cleanup()
+		// Idle-expired by hub-side traffic alone, but the plugin saw a command just now
+		device.AppiumNewCommandTimeout = 100
+		device.LastAutomationActionTS = time.Now().UnixMilli() - 5000
+		device.ProviderReportsSessionState = true
+		device.ProviderHasSession = true
+		device.ProviderLastCommandTS = time.Now().UnixMilli()
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.True(t, device.IsRunningAutomation)
+		assert.Equal(t, "provider-active-session", device.SessionID)
+	})
+
+	t.Run("provider command activity is ignored for old providers without session truth", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("janitor-old-provider-device", "old-provider-session", "fake-host")
+		defer cleanup()
+		device.AppiumNewCommandTimeout = 100
+		device.LastAutomationActionTS = time.Now().UnixMilli() - 5000
+		device.ProviderReportsSessionState = false
+		device.ProviderLastCommandTS = time.Now().UnixMilli()
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.False(t, device.IsRunningAutomation)
+		assert.True(t, device.IsAvailableForAutomation)
+	})
+
+	t.Run("session the provider has reported gone for over 10s is released without a provider DELETE", func(t *testing.T) {
+		providerRequests := make(chan string, 1)
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				providerRequests <- r.URL.Path
+			}
+			w.Write([]byte(`{"value":null}`))
+		}))
+		defer fakeProvider.Close()
+
+		device, cleanup := newGridSessionDevice("janitor-gone-session-device", "gone-session", strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		device.ProviderReportsSessionState = true
+		device.ProviderHasSession = false
+		device.ProviderSessionMissingSinceTS = time.Now().UnixMilli() - 11000
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		assert.False(t, device.IsRunningAutomation)
+		assert.True(t, device.IsAvailableForAutomation)
+		assert.Equal(t, "", device.SessionID)
+		device.Mu.RUnlock()
+
+		// The provider already reported the session gone - deleting it there is pointless
+		select {
+		case path := <-providerRequests:
+			t.Fatalf("the janitor sent an unnecessary session DELETE to the provider - %s", path)
+		case <-time.After(500 * time.Millisecond):
+		}
+	})
+
+	t.Run("session missing on the provider for under 10s survives the grace period", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("janitor-grace-device", "grace-session", "fake-host")
+		defer cleanup()
+		device.ProviderReportsSessionState = true
+		device.ProviderHasSession = false
+		device.ProviderSessionMissingSinceTS = time.Now().UnixMilli() - 3000
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.True(t, device.IsRunningAutomation)
+		assert.Equal(t, "grace-session", device.SessionID)
+	})
+}
+
+func TestSyncDeviceFieldsProviderTruth(t *testing.T) {
+	t.Run("session truth fields are copied and missing-session tracking starts", func(t *testing.T) {
+		device := &devices.LocalHubDevice{
+			SessionID:           "hub-session",
+			IsRunningAutomation: true,
+		}
+		syncDeviceFields(device, &models.ProviderDeviceSync{
+			Connected:                 true,
+			ProviderState:             "live",
+			ReportsAppiumSessionState: true,
+			HasAppiumSession:          false,
+			AppiumLastCommandTS:       1234,
+		})
+
+		assert.True(t, device.ProviderReportsSessionState)
+		assert.False(t, device.ProviderHasSession)
+		assert.Equal(t, int64(1234), device.ProviderLastCommandTS)
+		assert.NotZero(t, device.ProviderSessionMissingSinceTS)
+
+		// The missing-since timestamp must hold its first value across pushes, not
+		// restart the grace period every second
+		firstMissingTS := device.ProviderSessionMissingSinceTS
+		syncDeviceFields(device, &models.ProviderDeviceSync{
+			Connected:                 true,
+			ProviderState:             "live",
+			ReportsAppiumSessionState: true,
+			HasAppiumSession:          false,
+		})
+		assert.Equal(t, firstMissingTS, device.ProviderSessionMissingSinceTS)
+
+		// The provider reporting the session again clears the tracking
+		syncDeviceFields(device, &models.ProviderDeviceSync{
+			Connected:                 true,
+			ProviderState:             "live",
+			ReportsAppiumSessionState: true,
+			HasAppiumSession:          true,
+			AppiumSessionID:           "hub-session",
+		})
+		assert.True(t, device.ProviderHasSession)
+		assert.Equal(t, "hub-session", device.ProviderSessionID)
+		assert.Zero(t, device.ProviderSessionMissingSinceTS)
+	})
+
+	t.Run("no tracking starts without a hub-side session", func(t *testing.T) {
+		device := &devices.LocalHubDevice{}
+		syncDeviceFields(device, &models.ProviderDeviceSync{
+			Connected:                 true,
+			ProviderState:             "live",
+			ReportsAppiumSessionState: true,
+			HasAppiumSession:          false,
+		})
+		assert.Zero(t, device.ProviderSessionMissingSinceTS)
+	})
+
+	t.Run("old provider without the marker clears any tracking", func(t *testing.T) {
+		device := &devices.LocalHubDevice{
+			SessionID:                     "hub-session",
+			IsRunningAutomation:           true,
+			ProviderSessionMissingSinceTS: 1234,
+		}
+		syncDeviceFields(device, &models.ProviderDeviceSync{Connected: true, ProviderState: "live"})
+
+		assert.False(t, device.ProviderReportsSessionState)
+		assert.Zero(t, device.ProviderSessionMissingSinceTS)
+	})
 }
 
 func TestGridStatus(t *testing.T) {

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -11,6 +11,7 @@ package router
 
 import (
 	"GADS/common/models"
+	"GADS/hub/auth"
 	"GADS/hub/devices"
 	"bytes"
 	"net/http"
@@ -264,14 +265,187 @@ func TestSweepExpiredGridSessions(t *testing.T) {
 func TestGridStatus(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	router := newGridTestRouter()
-	req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	t.Run("no devices means not ready", func(t *testing.T) {
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"ready":true`)
-	assert.Contains(t, w.Body.String(), `"message"`)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"ready":false`)
+		assert.Contains(t, w.Body.String(), "no devices available")
+	})
+
+	t.Run("live device makes the grid ready and is listed", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("status-live-device", "", "fake-host")
+		defer cleanup()
+		device.Device.Name = "Status Phone"
+		device.Device.Provider = "provider1"
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"ready":true`)
+		assert.Contains(t, w.Body.String(), "GADS grid ready")
+		assert.Contains(t, w.Body.String(), `"udid":"status-live-device"`)
+		assert.Contains(t, w.Body.String(), `"name":"Status Phone"`)
+		assert.Contains(t, w.Body.String(), `"provider":"provider1"`)
+		assert.Contains(t, w.Body.String(), `"available":true`)
+		assert.Contains(t, w.Body.String(), `"in_use_by_automation":false`)
+	})
+
+	t.Run("device running automation is ready but not available", func(t *testing.T) {
+		_, cleanup := newGridSessionDevice("status-busy-device", "status-busy-session", "fake-host")
+		defer cleanup()
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"ready":true`)
+		assert.Contains(t, w.Body.String(), `"available":false`)
+		assert.Contains(t, w.Body.String(), `"in_use_by_automation":true`)
+	})
+}
+
+func TestGetAutomationSessions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("lists active sessions with device and user info", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("sessions-list-device", "sessions-list-session", "fake-host")
+		defer cleanup()
+		device.Device.Name = "Sessions Phone"
+		device.InUseBy = "session-user"
+		device.InUseByTenant = "tenant1"
+		device.AutomationSessionStartTS = time.Now().UnixMilli()
+
+		router := gin.New()
+		router.GET("/automation-sessions", GetAutomationSessions)
+		req, _ := http.NewRequest("GET", "/automation-sessions", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"session_id":"sessions-list-session"`)
+		assert.Contains(t, w.Body.String(), `"device_udid":"sessions-list-device"`)
+		assert.Contains(t, w.Body.String(), `"device_name":"Sessions Phone"`)
+		assert.Contains(t, w.Body.String(), `"in_use_by":"session-user"`)
+		assert.Contains(t, w.Body.String(), `"started_ts"`)
+		assert.Contains(t, w.Body.String(), `"last_command_ts"`)
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		router := gin.New()
+		router.Use(auth.AuthMiddleware())
+		router.GET("/automation-sessions", GetAutomationSessions)
+		req, _ := http.NewRequest("GET", "/automation-sessions", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}
+
+func TestEnrichSessionResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "test-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	newEnrichmentDevice := func(udid string, providerHost string) (*devices.LocalHubDevice, func()) {
+		device := &devices.LocalHubDevice{
+			Device: models.DBDevice{
+				UDID:        udid,
+				OS:          "android",
+				OSVersion:   "14.0.0",
+				WorkspaceID: "ws1",
+				Name:        "Enrichment Phone",
+				Provider:    "provider1",
+			},
+			Host:                     providerHost,
+			Connected:                true,
+			ProviderState:            "live",
+			LastUpdatedTimestamp:     time.Now().UnixMilli(),
+			IsAvailableForAutomation: true,
+		}
+		devices.HubDeviceStore.Set(udid, device)
+		return device, func() { devices.HubDeviceStore.Delete(udid) }
+	}
+
+	createSession := func(t *testing.T, udid string, requestMutators ...func(req *http.Request)) string {
+		t.Helper()
+		router := newGridTestRouter()
+		sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret","appium:udid":"` + udid + `"}}}`
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+		req.Host = "hub.example.com:10000"
+		for _, mutate := range requestMutators {
+			mutate(req)
+		}
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		return w.Body.String()
+	}
+
+	t.Run("device info caps are injected and Appium caps survive", func(t *testing.T) {
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":{"sessionId":"enrich-session","capabilities":{"platformName":"Android","appium:automationName":"UiAutomator2","appium:deviceApiLevel":34}}}`))
+		}))
+		defer fakeProvider.Close()
+
+		udid := "enrichment-device"
+		_, cleanup := newEnrichmentDevice(udid, strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		defer devices.UnregisterSession("enrich-session")
+
+		body := createSession(t, udid)
+
+		// Everything Appium returned must survive the enrichment untouched
+		assert.Contains(t, body, `"sessionId":"enrich-session"`)
+		assert.Contains(t, body, `"appium:automationName":"UiAutomator2"`)
+		assert.Contains(t, body, `"appium:deviceApiLevel":34`)
+		// The grid's own capabilities are added
+		assert.Contains(t, body, `"gads:deviceUdid":"enrichment-device"`)
+		assert.Contains(t, body, `"gads:deviceName":"Enrichment Phone"`)
+		assert.Contains(t, body, `"gads:provider":"provider1"`)
+		// The control link is built from the address the client reached the hub on
+		assert.Contains(t, body, `"gads:controlUrl":"http://hub.example.com:10000/devices/control/enrichment-device"`)
+		// The client secret must never be echoed back
+		assert.NotContains(t, body, "test-secret")
+	})
+
+	t.Run("control URL respects X-Forwarded-Proto from a TLS-terminating proxy", func(t *testing.T) {
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":{"sessionId":"enrich-url-session","capabilities":{"platformName":"Android"}}}`))
+		}))
+		defer fakeProvider.Close()
+
+		udid := "enrichment-url-device"
+		_, cleanup := newEnrichmentDevice(udid, strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		defer devices.UnregisterSession("enrich-url-session")
+
+		body := createSession(t, udid, func(req *http.Request) {
+			req.Host = "gads.example.com"
+			req.Header.Set("X-Forwarded-Proto", "https")
+		})
+
+		assert.Contains(t, body, `"gads:controlUrl":"https://gads.example.com/devices/control/enrichment-url-device"`)
+	})
 }
 
 func TestGridSessionLifecycleFlow(t *testing.T) {

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -557,18 +557,21 @@ func TestGetAutomationSessions(t *testing.T) {
 		device.InUseByTenant = "tenant1"
 		device.AutomationSessionStartTS = time.Now().UnixMilli()
 
-		// A second, idle device - the only one counting as available since the
-		// session device is claimed
+		// A second, idle device - available counts the whole reachable pool, so
+		// both this and the busy session device above are included
 		freeDevice, freeCleanup := newGridSessionDevice("sessions-free-device", "", "fake-host")
 		defer freeCleanup()
 		freeDevice.SessionID = ""
 		freeDevice.IsRunningAutomation = false
 		freeDevice.IsAvailableForAutomation = true
 
-		// An iOS device with no free capacity - its OS must still appear with a zero
-		busyIOSDevice, busyIOSCleanup := newGridSessionDevice("sessions-busy-ios-device", "sessions-busy-ios-session", "fake-host")
-		defer busyIOSCleanup()
-		busyIOSDevice.Device.OS = "ios"
+		// A disconnected iOS device - not reachable, so its OS reports zero
+		offlineIOSDevice, offlineIOSCleanup := newGridSessionDevice("sessions-offline-ios-device", "", "fake-host")
+		defer offlineIOSCleanup()
+		offlineIOSDevice.SessionID = ""
+		offlineIOSDevice.IsRunningAutomation = false
+		offlineIOSDevice.Device.OS = "ios"
+		offlineIOSDevice.Connected = false
 
 		router := gin.New()
 		router.GET("/automation-sessions", GetAutomationSessions)
@@ -585,8 +588,9 @@ func TestGetAutomationSessions(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"in_use_by":"session-user"`)
 		assert.Contains(t, w.Body.String(), `"started_ts"`)
 		assert.Contains(t, w.Body.String(), `"last_command_ts"`)
-		// Every supported OS is present - the ones without devices as explicit zeroes
-		assert.Contains(t, w.Body.String(), `"available_devices_by_os":{"android":1,"androidtv":0,"ios":0,"roku":0,"tizen":0,"webos":0}`)
+		// Every supported OS is present - the ones without reachable devices as
+		// explicit zeroes; the busy session device still counts for android
+		assert.Contains(t, w.Body.String(), `"available_devices_by_os":{"android":2,"androidtv":0,"ios":0,"roku":0,"tizen":0,"webos":0}`)
 		assert.Contains(t, w.Body.String(), `"queued":0`)
 	})
 

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -465,6 +465,7 @@ func TestGridStatus(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), `"ready":true`)
+		assert.Contains(t, w.Body.String(), `"queued":0`)
 		assert.NotContains(t, w.Body.String(), "devices")
 		assert.NotContains(t, w.Body.String(), "status-anon-device")
 	})
@@ -548,7 +549,7 @@ func TestGridStatus(t *testing.T) {
 func TestGetAutomationSessions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("lists active sessions with device and user info", func(t *testing.T) {
+	t.Run("lists active sessions with device and user info plus readiness and queue depth", func(t *testing.T) {
 		device, cleanup := newGridSessionDevice("sessions-list-device", "sessions-list-session", "fake-host")
 		defer cleanup()
 		device.Device.Name = "Sessions Phone"
@@ -569,6 +570,9 @@ func TestGetAutomationSessions(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"in_use_by":"session-user"`)
 		assert.Contains(t, w.Body.String(), `"started_ts"`)
 		assert.Contains(t, w.Body.String(), `"last_command_ts"`)
+		// The fixture device is connected and live, so the grid reports ready
+		assert.Contains(t, w.Body.String(), `"ready":true`)
+		assert.Contains(t, w.Body.String(), `"queued":0`)
 	})
 
 	t.Run("requires authentication", func(t *testing.T) {

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -1,0 +1,221 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/common/models"
+	"GADS/hub/devices"
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// newGridSessionDevice returns a connected, live device fixture with an active
+// Appium session, registered in the hub device store. Callers must defer the
+// returned cleanup func
+func newGridSessionDevice(udid string, sessionID string, providerHost string) (*devices.LocalHubDevice, func()) {
+	device := &devices.LocalHubDevice{
+		Device: models.DBDevice{
+			UDID:        udid,
+			OS:          "android",
+			OSVersion:   "14.0.0",
+			WorkspaceID: "ws1",
+		},
+		Host:                     providerHost,
+		Connected:                true,
+		ProviderState:            "live",
+		LastUpdatedTimestamp:     time.Now().UnixMilli(),
+		SessionID:                sessionID,
+		IsRunningAutomation:      true,
+		IsAvailableForAutomation: false,
+		LastAutomationActionTS:   time.Now().UnixMilli(),
+		AppiumNewCommandTimeout:  60000,
+	}
+	devices.HubDeviceStore.Set(udid, device)
+	return device, func() { devices.HubDeviceStore.Delete(udid) }
+}
+
+func TestGridSessionDeleteRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("DELETE on a session subpath proxies the command and does not release the device", func(t *testing.T) {
+		var proxiedPath string
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proxiedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":null}`))
+		}))
+		defer fakeProvider.Close()
+
+		device, cleanup := newGridSessionDevice("delete-subpath-device", "subpath-session", strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("DELETE", "/grid/session/subpath-session/actions", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "/device/delete-subpath-device/appium/session/subpath-session/actions", proxiedPath)
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.Equal(t, "subpath-session", device.SessionID)
+		assert.True(t, device.IsRunningAutomation)
+		assert.False(t, device.IsAvailableForAutomation)
+	})
+
+	t.Run("exact session DELETE releases the device", func(t *testing.T) {
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":null}`))
+		}))
+		defer fakeProvider.Close()
+
+		device, cleanup := newGridSessionDevice("delete-session-device", "ending-session", strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("DELETE", "/grid/session/ending-session", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.True(t, device.IsAvailableForAutomation)
+	})
+}
+
+func TestFindAvailableDeviceByUDIDEligibility(t *testing.T) {
+	// The UDID-pinned path must enforce the same eligibility checks as the generic
+	// search - a pinned device that is disconnected, controlled or locked by
+	// another user must not be handed out
+	tests := []struct {
+		name   string
+		mutate func(d *devices.LocalHubDevice)
+	}{
+		{"disconnected device", func(d *devices.LocalHubDevice) { d.Connected = false }},
+		{"provider state not live", func(d *devices.LocalHubDevice) { d.ProviderState = "init" }},
+		{"stale provider update", func(d *devices.LocalHubDevice) { d.LastUpdatedTimestamp = time.Now().UnixMilli() - 10000 }},
+		{"usage control", func(d *devices.LocalHubDevice) { d.Device.Usage = "control" }},
+		{"usage disabled", func(d *devices.LocalHubDevice) { d.Device.Usage = "disabled" }},
+		{"locked by another user", func(d *devices.LocalHubDevice) {
+			d.InUseBy = "other-user"
+			d.InUseByTenant = "tenant1"
+			d.InUseTS = time.Now().UnixMilli()
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			udid := "udid-eligibility-device"
+			device, cleanup := newGridSessionDevice(udid, "", "fake-host")
+			defer cleanup()
+			device.SessionID = ""
+			device.IsRunningAutomation = false
+			device.IsAvailableForAutomation = true
+			tt.mutate(device)
+
+			found, err := findAvailableDevice(gridCandidate{DeviceUDID: udid}, []string{"ws1"}, "test-user", "tenant1")
+			assert.Nil(t, found)
+			if assert.Error(t, err) {
+				assert.Equal(t, "Device is currently not available for automation", err.Error())
+			}
+		})
+	}
+
+	t.Run("eligible pinned device is claimed", func(t *testing.T) {
+		udid := "udid-eligible-device"
+		device, cleanup := newGridSessionDevice(udid, "", "fake-host")
+		defer cleanup()
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+
+		found, err := findAvailableDevice(gridCandidate{DeviceUDID: udid}, []string{"ws1"}, "test-user", "tenant1")
+		assert.NoError(t, err)
+		if assert.NotNil(t, found) {
+			found.Mu.RLock()
+			defer found.Mu.RUnlock()
+			assert.Equal(t, udid, found.Device.UDID)
+			assert.False(t, found.IsAvailableForAutomation)
+		}
+	})
+}
+
+func TestSweepExpiredGridSessions(t *testing.T) {
+	t.Run("idled-out session is reset and the provider Appium session is deleted", func(t *testing.T) {
+		providerRequests := make(chan string, 1)
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				providerRequests <- r.URL.Path
+			}
+			w.Write([]byte(`{"value":null}`))
+		}))
+		defer fakeProvider.Close()
+
+		device, cleanup := newGridSessionDevice("janitor-expired-device", "expired-session", strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		device.AppiumNewCommandTimeout = 100
+		device.LastAutomationActionTS = time.Now().UnixMilli() - 5000
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		assert.False(t, device.IsRunningAutomation)
+		assert.True(t, device.IsAvailableForAutomation)
+		assert.Equal(t, "", device.SessionID)
+		device.Mu.RUnlock()
+
+		// The provider-side session DELETE is fired in a background goroutine
+		select {
+		case path := <-providerRequests:
+			assert.Equal(t, "/device/janitor-expired-device/appium/session/expired-session", path)
+		case <-time.After(3 * time.Second):
+			t.Fatal("the janitor never sent the session DELETE to the provider")
+		}
+	})
+
+	t.Run("newCommandTimeout 0 disables the idle expiry", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("janitor-disabled-timeout-device", "long-lived-session", "fake-host")
+		defer cleanup()
+		device.AppiumNewCommandTimeout = 0
+		device.LastAutomationActionTS = time.Now().UnixMilli() - 24*60*60*1000
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.True(t, device.IsRunningAutomation)
+		assert.Equal(t, "long-lived-session", device.SessionID)
+	})
+
+	t.Run("disconnected device is reset without contacting the provider", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("janitor-disconnected-device", "orphan-session", "fake-host")
+		defer cleanup()
+		device.Connected = false
+
+		sweepExpiredGridSessions()
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.False(t, device.IsRunningAutomation)
+		assert.True(t, device.IsAvailableForAutomation)
+		assert.Equal(t, "", device.SessionID)
+	})
+}

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -619,6 +619,92 @@ func TestEnrichSessionResponse(t *testing.T) {
 	})
 }
 
+func TestGridCreateSessionStampsIdentityAtClaimTime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "claim-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	newClaimDevice := func(udid string, providerHost string) (*devices.LocalHubDevice, func()) {
+		device := &devices.LocalHubDevice{
+			Device: models.DBDevice{
+				UDID:        udid,
+				OS:          "android",
+				OSVersion:   "14.0.0",
+				WorkspaceID: "ws1",
+			},
+			Host:                     providerHost,
+			Connected:                true,
+			ProviderState:            "live",
+			LastUpdatedTimestamp:     time.Now().UnixMilli(),
+			IsAvailableForAutomation: true,
+		}
+		devices.HubDeviceStore.Set(udid, device)
+		return device, func() { devices.HubDeviceStore.Delete(udid) }
+	}
+
+	createSession := func(udid string) *httptest.ResponseRecorder {
+		router := newGridTestRouter()
+		sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret","appium:udid":"` + udid + `"}}}`
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("the automation user is visible on the device before the provider responds", func(t *testing.T) {
+		udid := "claim-stamp-device"
+		// Capture what the device selection UI would show while the provider is
+		// still busy creating the session
+		var inUseByDuringCreate, inUseByTenantDuringCreate string
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claimedDevice, _ := devices.HubDeviceStore.Get(udid)
+			claimedDevice.Mu.RLock()
+			inUseByDuringCreate = claimedDevice.InUseBy
+			inUseByTenantDuringCreate = claimedDevice.InUseByTenant
+			claimedDevice.Mu.RUnlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":{"sessionId":"claim-stamp-session","capabilities":{"platformName":"Android"}}}`))
+		}))
+		defer fakeProvider.Close()
+
+		_, cleanup := newClaimDevice(udid, strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+		defer devices.UnregisterSession("claim-stamp-session")
+
+		w := createSession(udid)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "claim-user", inUseByDuringCreate)
+		assert.Equal(t, "tenant1", inUseByTenantDuringCreate)
+	})
+
+	t.Run("a failed session create clears the stamped identity", func(t *testing.T) {
+		// A non-JSON provider response aborts the claim after the identity stamp
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`not json`))
+		}))
+		defer fakeProvider.Close()
+
+		device, cleanup := newClaimDevice("claim-abort-device", strings.TrimPrefix(fakeProvider.URL, "http://"))
+		defer cleanup()
+
+		w := createSession("claim-abort-device")
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.Equal(t, "", device.InUseBy)
+		assert.Equal(t, "", device.InUseByTenant)
+		assert.False(t, device.IsRunningAutomation)
+		assert.True(t, device.IsAvailableForAutomation)
+	})
+}
+
 func TestGridSessionLifecycleFlow(t *testing.T) {
 	// Full create -> command -> delete flow through the real routes, asserting the
 	// session registry entry appears and disappears with the session
@@ -699,11 +785,12 @@ func TestGridSessionLifecycleFlow(t *testing.T) {
 	assert.True(t, device.IsAvailableForAutomation)
 	device.Mu.RUnlock()
 
-	// The full release (session cleared, registry entry removed) happens on a 1 second delay
+	// The full release (session cleared, registry entry removed) happens only after
+	// the post-session cool-down
 	assert.Eventually(t, func() bool {
 		_, stillRegistered := devices.DeviceBySession("flow-session")
 		device.Mu.RLock()
 		defer device.Mu.RUnlock()
 		return !stillRegistered && !device.IsRunningAutomation && device.SessionID == ""
-	}, 3*time.Second, 100*time.Millisecond)
+	}, postSessionReleaseCooldown+3*time.Second, 100*time.Millisecond)
 }

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -42,6 +42,7 @@ func newGridSessionDevice(udid string, sessionID string, providerHost string) (*
 		SessionID:                sessionID,
 		IsRunningAutomation:      true,
 		IsAvailableForAutomation: false,
+		AppiumEnabled:            true,
 		LastAutomationActionTS:   time.Now().UnixMilli(),
 		AppiumNewCommandTimeout:  60000,
 	}
@@ -122,6 +123,7 @@ func TestFindAvailableDeviceByUDIDEligibility(t *testing.T) {
 		{"stale provider update", "not available", func(d *devices.LocalHubDevice) { d.LastUpdatedTimestamp = time.Now().UnixMilli() - 10000 }},
 		{"usage control", "is not enabled for automation", func(d *devices.LocalHubDevice) { d.Device.Usage = "control" }},
 		{"usage disabled", "is not enabled for automation", func(d *devices.LocalHubDevice) { d.Device.Usage = "disabled" }},
+		{"provider without Appium servers", "is not enabled for automation", func(d *devices.LocalHubDevice) { d.AppiumEnabled = false }},
 		{"locked by another user", "not available", func(d *devices.LocalHubDevice) {
 			d.InUseBy = "other-user"
 			d.InUseByTenant = "tenant1"
@@ -176,6 +178,20 @@ func TestFindAvailableDeviceByUDIDEligibility(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		assert.Contains(t, w.Body.String(), "is not enabled for automation")
 		assert.Contains(t, w.Body.String(), "session not created")
+	})
+
+	t.Run("generic search skips devices whose provider has no Appium servers", func(t *testing.T) {
+		udid := "generic-no-appium-device"
+		device, cleanup := newGridSessionDevice(udid, "", "fake-host")
+		defer cleanup()
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+		device.AppiumEnabled = false
+
+		found, err := findAvailableDevice(gridCandidate{PlatformName: "Android"}, []string{"ws1"}, "test-user", "tenant1")
+		assert.Nil(t, found)
+		assert.Error(t, err)
 	})
 
 	t.Run("eligible pinned device is claimed", func(t *testing.T) {
@@ -462,6 +478,25 @@ func TestGridStatus(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"available":false`)
 		assert.Contains(t, w.Body.String(), `"in_use_by_automation":true`)
 	})
+
+	t.Run("device on a provider without Appium servers is not listed at all", func(t *testing.T) {
+		device, cleanup := newGridSessionDevice("status-no-appium-device", "", "fake-host")
+		defer cleanup()
+		device.SessionID = ""
+		device.IsRunningAutomation = false
+		device.IsAvailableForAutomation = true
+		device.AppiumEnabled = false
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NotContains(t, w.Body.String(), "status-no-appium-device")
+		// A grid whose only device cannot serve automation is not ready either
+		assert.Contains(t, w.Body.String(), `"ready":false`)
+	})
 }
 
 func TestGetAutomationSessions(t *testing.T) {
@@ -527,6 +562,7 @@ func TestEnrichSessionResponse(t *testing.T) {
 			ProviderState:            "live",
 			LastUpdatedTimestamp:     time.Now().UnixMilli(),
 			IsAvailableForAutomation: true,
+			AppiumEnabled:            true,
 		}
 		devices.HubDeviceStore.Set(udid, device)
 		return device, func() { devices.HubDeviceStore.Delete(udid) }
@@ -642,6 +678,7 @@ func TestGridCreateSessionStampsIdentityAtClaimTime(t *testing.T) {
 			ProviderState:            "live",
 			LastUpdatedTimestamp:     time.Now().UnixMilli(),
 			IsAvailableForAutomation: true,
+			AppiumEnabled:            true,
 		}
 		devices.HubDeviceStore.Set(udid, device)
 		return device, func() { devices.HubDeviceStore.Delete(udid) }
@@ -742,6 +779,7 @@ func TestGridSessionLifecycleFlow(t *testing.T) {
 		ProviderState:            "live",
 		LastUpdatedTimestamp:     time.Now().UnixMilli(),
 		IsAvailableForAutomation: true,
+		AppiumEnabled:            true,
 	}
 	devices.HubDeviceStore.Set(udid, device)
 	defer devices.HubDeviceStore.Delete(udid)

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -549,13 +549,26 @@ func TestGridStatus(t *testing.T) {
 func TestGetAutomationSessions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("lists active sessions with device and user info plus readiness and queue depth", func(t *testing.T) {
+	t.Run("lists active sessions with device and user info plus availability and queue depth", func(t *testing.T) {
 		device, cleanup := newGridSessionDevice("sessions-list-device", "sessions-list-session", "fake-host")
 		defer cleanup()
 		device.Device.Name = "Sessions Phone"
 		device.InUseBy = "session-user"
 		device.InUseByTenant = "tenant1"
 		device.AutomationSessionStartTS = time.Now().UnixMilli()
+
+		// A second, idle device - the only one counting as available since the
+		// session device is claimed
+		freeDevice, freeCleanup := newGridSessionDevice("sessions-free-device", "", "fake-host")
+		defer freeCleanup()
+		freeDevice.SessionID = ""
+		freeDevice.IsRunningAutomation = false
+		freeDevice.IsAvailableForAutomation = true
+
+		// An iOS device with no free capacity - its OS must still appear with a zero
+		busyIOSDevice, busyIOSCleanup := newGridSessionDevice("sessions-busy-ios-device", "sessions-busy-ios-session", "fake-host")
+		defer busyIOSCleanup()
+		busyIOSDevice.Device.OS = "ios"
 
 		router := gin.New()
 		router.GET("/automation-sessions", GetAutomationSessions)
@@ -567,11 +580,13 @@ func TestGetAutomationSessions(t *testing.T) {
 		assert.Contains(t, w.Body.String(), `"session_id":"sessions-list-session"`)
 		assert.Contains(t, w.Body.String(), `"device_udid":"sessions-list-device"`)
 		assert.Contains(t, w.Body.String(), `"device_name":"Sessions Phone"`)
+		assert.Contains(t, w.Body.String(), `"device_os":"android"`)
+		assert.Contains(t, w.Body.String(), `"device_os_version":"14.0.0"`)
 		assert.Contains(t, w.Body.String(), `"in_use_by":"session-user"`)
 		assert.Contains(t, w.Body.String(), `"started_ts"`)
 		assert.Contains(t, w.Body.String(), `"last_command_ts"`)
-		// The fixture device is connected and live, so the grid reports ready
-		assert.Contains(t, w.Body.String(), `"ready":true`)
+		// Every supported OS is present - the ones without devices as explicit zeroes
+		assert.Contains(t, w.Body.String(), `"available_devices_by_os":{"android":1,"androidtv":0,"ios":0,"roku":0,"tizen":0,"webos":0}`)
 		assert.Contains(t, w.Body.String(), `"queued":0`)
 	})
 

--- a/hub/router/appiumgrid_test.go
+++ b/hub/router/appiumgrid_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 // newGridSessionDevice returns a connected, live device fixture with an active
-// Appium session, registered in the hub device store. Callers must defer the
-// returned cleanup func
+// Appium session, registered in the hub device store and the session registry.
+// Callers must defer the returned cleanup func
 func newGridSessionDevice(udid string, sessionID string, providerHost string) (*devices.LocalHubDevice, func()) {
 	device := &devices.LocalHubDevice{
 		Device: models.DBDevice{
@@ -45,7 +45,11 @@ func newGridSessionDevice(udid string, sessionID string, providerHost string) (*
 		AppiumNewCommandTimeout:  60000,
 	}
 	devices.HubDeviceStore.Set(udid, device)
-	return device, func() { devices.HubDeviceStore.Delete(udid) }
+	devices.RegisterSession(sessionID, device)
+	return device, func() {
+		devices.UnregisterSession(sessionID)
+		devices.HubDeviceStore.Delete(udid)
+	}
 }
 
 func TestGridSessionDeleteRouting(t *testing.T) {
@@ -251,5 +255,110 @@ func TestSweepExpiredGridSessions(t *testing.T) {
 		assert.False(t, device.IsRunningAutomation)
 		assert.True(t, device.IsAvailableForAutomation)
 		assert.Equal(t, "", device.SessionID)
+
+		_, stillRegistered := devices.DeviceBySession("orphan-session")
+		assert.False(t, stillRegistered)
 	})
+}
+
+func TestGridStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := newGridTestRouter()
+	req, _ := http.NewRequest("GET", "/grid/status", bytes.NewBufferString(""))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"ready":true`)
+	assert.Contains(t, w.Body.String(), `"message"`)
+}
+
+func TestGridSessionLifecycleFlow(t *testing.T) {
+	// Full create -> command -> delete flow through the real routes, asserting the
+	// session registry entry appears and disappears with the session
+	gin.SetMode(gin.TestMode)
+
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "test-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	var proxiedRequests []string
+	fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxiedRequests = append(proxiedRequests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/appium/session") {
+			w.Write([]byte(`{"value":{"sessionId":"flow-session","capabilities":{"platformName":"Android"}}}`))
+			return
+		}
+		w.Write([]byte(`{"value":null}`))
+	}))
+	defer fakeProvider.Close()
+
+	udid := "lifecycle-flow-device"
+	device := &devices.LocalHubDevice{
+		Device: models.DBDevice{
+			UDID:        udid,
+			OS:          "android",
+			OSVersion:   "14.0.0",
+			WorkspaceID: "ws1",
+		},
+		Host:                     strings.TrimPrefix(fakeProvider.URL, "http://"),
+		Connected:                true,
+		ProviderState:            "live",
+		LastUpdatedTimestamp:     time.Now().UnixMilli(),
+		IsAvailableForAutomation: true,
+	}
+	devices.HubDeviceStore.Set(udid, device)
+	defer devices.HubDeviceStore.Delete(udid)
+	defer devices.UnregisterSession("flow-session")
+
+	router := newGridTestRouter()
+
+	sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret"}}}`
+	req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	registeredDevice, ok := devices.DeviceBySession("flow-session")
+	if assert.True(t, ok, "the created session must be indexed in the session registry") {
+		assert.Same(t, device, registeredDevice)
+	}
+
+	req, _ = http.NewRequest("POST", "/grid/session/flow-session/url", bytes.NewBufferString(`{"url":"https://example.com"}`))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, proxiedRequests, "POST /device/lifecycle-flow-device/appium/session/flow-session/url")
+
+	// A bare `GET /session/{id}` is an ordinary command, not a session end
+	req, _ = http.NewRequest("GET", "/grid/session/flow-session", bytes.NewBufferString(""))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, proxiedRequests, "GET /device/lifecycle-flow-device/appium/session/flow-session")
+	_, ok = devices.DeviceBySession("flow-session")
+	assert.True(t, ok)
+
+	req, _ = http.NewRequest("DELETE", "/grid/session/flow-session", bytes.NewBufferString(""))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, proxiedRequests, "DELETE /device/lifecycle-flow-device/appium/session/flow-session")
+
+	device.Mu.RLock()
+	assert.True(t, device.IsAvailableForAutomation)
+	device.Mu.RUnlock()
+
+	// The full release (session cleared, registry entry removed) happens on a 1 second delay
+	assert.Eventually(t, func() bool {
+		_, stillRegistered := devices.DeviceBySession("flow-session")
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		return !stillRegistered && !device.IsRunningAutomation && device.SessionID == ""
+	}, 3*time.Second, 100*time.Millisecond)
 }

--- a/hub/router/client_credentials_test.go
+++ b/hub/router/client_credentials_test.go
@@ -40,10 +40,11 @@ func TestCreateClientCredential_Unauthorized(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	var response models.OAuthErrorResponse
+	var response models.APIResponse[any]
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "unauthorized", response.Error)
+	assert.False(t, response.Success)
+	assert.Equal(t, "unauthorized", response.Message)
 }
 
 func TestListClientCredentials_Unauthorized(t *testing.T) {
@@ -58,10 +59,11 @@ func TestListClientCredentials_Unauthorized(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	var response models.OAuthErrorResponse
+	var response models.APIResponse[any]
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "unauthorized", response.Error)
+	assert.False(t, response.Success)
+	assert.Equal(t, "unauthorized", response.Message)
 }
 
 func TestOAuth2TokenEndpoint_InvalidJSON(t *testing.T) {

--- a/hub/router/gridcapabilities.go
+++ b/hub/router/gridcapabilities.go
@@ -1,0 +1,289 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/common/models"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// W3C WebDriver error codes and their HTTP statuses (https://www.w3.org/TR/webdriver2/#errors)
+type W3CError struct {
+	HTTPStatus int
+	Code       string
+	Message    string
+}
+
+func w3cInvalidArgument(msg string) *W3CError {
+	return &W3CError{HTTPStatus: 400, Code: "invalid argument", Message: msg}
+}
+
+func w3cInvalidSessionID(msg string) *W3CError {
+	return &W3CError{HTTPStatus: 404, Code: "invalid session id", Message: msg}
+}
+
+func w3cSessionNotCreated(msg string) *W3CError {
+	return &W3CError{HTTPStatus: 500, Code: "session not created", Message: msg}
+}
+
+func writeW3CError(c *gin.Context, e *W3CError) {
+	c.JSON(e.HTTPStatus, createErrorResponse(e.Message, e.Code, ""))
+}
+
+// gridStore is the subset of db.GlobalMongoStore the grid handlers use,
+// as a seam so handlers can be tested with a fake store
+type gridStore interface {
+	GetClientCredentialBySecret(clientSecret string) (models.ClientCredentials, error)
+	GetUser(username string) (models.User, error)
+	GetUserWorkspaces(username string) []models.Workspace
+	GetWorkspaces() ([]models.Workspace, error)
+	GetOrCreateDefaultTenant() (string, error)
+}
+
+var gridDB gridStore
+
+// InitGridStore sets the store used by the Appium grid handlers, called once at hub startup
+func InitGridStore(store gridStore) {
+	gridDB = store
+}
+
+// gridCandidate is one merged capabilities candidate (alwaysMatch merged into a firstMatch entry,
+// or the legacy desiredCapabilities object) with the fields the grid matches on extracted
+type gridCandidate struct {
+	Caps map[string]interface{}
+
+	PlatformName    string
+	AutomationName  string
+	PlatformVersion string
+	DeviceUDID      string
+	// Seconds; nil when the capability is absent, explicit 0 means Appium's idle timer is disabled
+	NewCommandTimeout *int64
+	// Seconds; nil when absent, from `<prefix>:queueTimeout` (consumed by the session queue)
+	QueueTimeout *int64
+}
+
+type GridSessionRequest struct {
+	// The full session request body as sent by the client
+	Raw map[string]interface{}
+	// Merged candidates in W3C matching order
+	Candidates []gridCandidate
+}
+
+// parseSessionRequest parses a new-session request body per the W3C capabilities
+// processing rules (https://www.w3.org/TR/webdriver2/#processing-capabilities), with a
+// legacy fallback to `desiredCapabilities` when no W3C `capabilities` object is present
+func parseSessionRequest(body []byte, prefix string) (*GridSessionRequest, *W3CError) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, w3cInvalidArgument(fmt.Sprintf("Failed to parse the session request body as JSON - %s", err.Error()))
+	}
+
+	req := &GridSessionRequest{Raw: raw}
+
+	capsValue, hasCaps := raw["capabilities"]
+	if hasCaps {
+		caps, ok := capsValue.(map[string]interface{})
+		if !ok {
+			return nil, w3cInvalidArgument("`capabilities` in the session request is not a JSON object")
+		}
+
+		alwaysMatch := map[string]interface{}{}
+		if amValue, ok := caps["alwaysMatch"]; ok {
+			am, ok := amValue.(map[string]interface{})
+			if !ok {
+				return nil, w3cInvalidArgument("`capabilities.alwaysMatch` is not a JSON object")
+			}
+			alwaysMatch = am
+		}
+
+		firstMatch := []interface{}{map[string]interface{}{}}
+		if fmValue, ok := caps["firstMatch"]; ok {
+			fm, ok := fmValue.([]interface{})
+			if !ok {
+				return nil, w3cInvalidArgument("`capabilities.firstMatch` is not a JSON list")
+			}
+			if len(fm) > 0 {
+				firstMatch = fm
+			}
+		}
+
+		for i, entryValue := range firstMatch {
+			entry, ok := entryValue.(map[string]interface{})
+			if !ok {
+				return nil, w3cInvalidArgument(fmt.Sprintf("`capabilities.firstMatch[%d]` is not a JSON object", i))
+			}
+
+			merged := make(map[string]interface{}, len(alwaysMatch)+len(entry))
+			for k, v := range alwaysMatch {
+				merged[k] = v
+			}
+			for k, v := range entry {
+				if _, exists := merged[k]; exists {
+					return nil, w3cInvalidArgument(fmt.Sprintf("Capability `%s` is present in both alwaysMatch and firstMatch[%d]", k, i))
+				}
+				merged[k] = v
+			}
+
+			candidate, w3cErr := extractCandidate(merged, prefix)
+			if w3cErr != nil {
+				return nil, w3cErr
+			}
+			req.Candidates = append(req.Candidates, candidate)
+		}
+
+		return req, nil
+	}
+
+	// Legacy fallback - no W3C `capabilities` object at all, use `desiredCapabilities` as a single candidate
+	if desiredValue, ok := raw["desiredCapabilities"]; ok {
+		desired, ok := desiredValue.(map[string]interface{})
+		if !ok {
+			return nil, w3cInvalidArgument("`desiredCapabilities` in the session request is not a JSON object")
+		}
+		candidate, w3cErr := extractCandidate(desired, prefix)
+		if w3cErr != nil {
+			return nil, w3cErr
+		}
+		req.Candidates = append(req.Candidates, candidate)
+		return req, nil
+	}
+
+	return nil, w3cInvalidArgument("The session request contains neither a `capabilities` nor a `desiredCapabilities` object")
+}
+
+func extractCandidate(caps map[string]interface{}, prefix string) (gridCandidate, *W3CError) {
+	candidate := gridCandidate{
+		Caps:            caps,
+		PlatformName:    capString(caps, "platformName"),
+		AutomationName:  capString(caps, "appium:automationName"),
+		PlatformVersion: capString(caps, "appium:platformVersion"),
+		DeviceUDID:      capString(caps, "appium:udid"),
+	}
+
+	newCommandTimeout, w3cErr := capSeconds(caps, "appium:newCommandTimeout")
+	if w3cErr != nil {
+		return candidate, w3cErr
+	}
+	candidate.NewCommandTimeout = newCommandTimeout
+
+	queueTimeout, w3cErr := capSeconds(caps, fmt.Sprintf("%s:queueTimeout", prefix))
+	if w3cErr != nil {
+		return candidate, w3cErr
+	}
+	candidate.QueueTimeout = queueTimeout
+
+	return candidate, nil
+}
+
+func capString(caps map[string]interface{}, key string) string {
+	if value, ok := caps[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+// capSeconds reads a duration-in-seconds capability that clients send either
+// as a JSON number or as a numeric string (Appium tolerates both, so must we).
+// Returns nil when the capability is absent
+func capSeconds(caps map[string]interface{}, key string) (*int64, *W3CError) {
+	value, ok := caps[key]
+	if !ok {
+		return nil, nil
+	}
+
+	switch v := value.(type) {
+	case float64:
+		seconds := int64(v)
+		return &seconds, nil
+	case string:
+		seconds, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return nil, w3cInvalidArgument(fmt.Sprintf("Capability `%s` is not a valid number - `%s`", key, v))
+		}
+		return &seconds, nil
+	default:
+		return nil, w3cInvalidArgument(fmt.Sprintf("Capability `%s` must be a number or a numeric string", key))
+	}
+}
+
+// candidateTargetOS derives the device OS a candidate targets - either platformName
+// or appium:automationName suffices (requiring both is stricter than Appium itself)
+func candidateTargetOS(candidate gridCandidate) string {
+	if strings.EqualFold(candidate.PlatformName, "iOS") ||
+		strings.EqualFold(candidate.AutomationName, "XCUITest") {
+		return "ios"
+	}
+
+	if strings.EqualFold(candidate.PlatformName, "Android") ||
+		strings.EqualFold(candidate.AutomationName, "UiAutomator2") {
+		return "android"
+	}
+
+	if strings.EqualFold(candidate.PlatformName, "TizenTV") ||
+		strings.EqualFold(candidate.AutomationName, "TizenTV") {
+		return "tizen"
+	}
+
+	if strings.EqualFold(candidate.PlatformName, "lgtv") ||
+		strings.EqualFold(candidate.AutomationName, "webos") {
+		return "webos"
+	}
+
+	if strings.EqualFold(candidate.PlatformName, "Roku") ||
+		strings.EqualFold(candidate.AutomationName, "roku") {
+		return "roku"
+	}
+
+	return ""
+}
+
+// selectGridCandidate returns the first candidate, in firstMatch order, that either
+// pins a device by UDID or targets a known device OS. A candidate that matches
+// nothing is not an error per spec - the next one is tried
+func selectGridCandidate(candidates []gridCandidate) (gridCandidate, bool) {
+	for _, candidate := range candidates {
+		if candidate.DeviceUDID != "" || candidateTargetOS(candidate) != "" {
+			return candidate, true
+		}
+	}
+	return gridCandidate{}, false
+}
+
+// stripGadsCaps removes all `<prefix>:*` capabilities (client secret, grid directives)
+// from every capabilities location in the session request before it is forwarded to
+// Appium - they are grid-internal and the secret must never reach provider Appium logs
+func stripGadsCaps(sessionReq map[string]interface{}, prefix string) {
+	keyPrefix := prefix + ":"
+
+	stripFromMap := func(value interface{}) {
+		if m, ok := value.(map[string]interface{}); ok {
+			for k := range m {
+				if strings.HasPrefix(k, keyPrefix) {
+					delete(m, k)
+				}
+			}
+		}
+	}
+
+	if caps, ok := sessionReq["capabilities"].(map[string]interface{}); ok {
+		stripFromMap(caps["alwaysMatch"])
+		if firstMatch, ok := caps["firstMatch"].([]interface{}); ok {
+			for _, entry := range firstMatch {
+				stripFromMap(entry)
+			}
+		}
+	}
+	stripFromMap(sessionReq["desiredCapabilities"])
+}

--- a/hub/router/gridcapabilities.go
+++ b/hub/router/gridcapabilities.go
@@ -38,6 +38,10 @@ func w3cSessionNotCreated(msg string) *W3CError {
 	return &W3CError{HTTPStatus: 500, Code: "session not created", Message: msg}
 }
 
+func w3cUnknownCommand(msg string) *W3CError {
+	return &W3CError{HTTPStatus: 404, Code: "unknown command", Message: msg}
+}
+
 func writeW3CError(c *gin.Context, e *W3CError) {
 	c.JSON(e.HTTPStatus, createErrorResponse(e.Message, e.Code, ""))
 }

--- a/hub/router/gridcapabilities.go
+++ b/hub/router/gridcapabilities.go
@@ -82,8 +82,9 @@ type GridSessionRequest struct {
 }
 
 // parseSessionRequest parses a new-session request body per the W3C capabilities
-// processing rules (https://www.w3.org/TR/webdriver2/#processing-capabilities), with a
-// legacy fallback to `desiredCapabilities` when no W3C `capabilities` object is present
+// processing rules (https://www.w3.org/TR/webdriver2/#processing-capabilities).
+// A W3C `capabilities` object is required - legacy JSONWP `desiredCapabilities`-only
+// bodies are rejected, same as Appium >= 2 itself does
 func parseSessionRequest(body []byte, prefix string) (*GridSessionRequest, *W3CError) {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -93,74 +94,67 @@ func parseSessionRequest(body []byte, prefix string) (*GridSessionRequest, *W3CE
 	req := &GridSessionRequest{Raw: raw}
 
 	capsValue, hasCaps := raw["capabilities"]
-	if hasCaps {
-		caps, ok := capsValue.(map[string]interface{})
-		if !ok {
-			return nil, w3cInvalidArgument("`capabilities` in the session request is not a JSON object")
-		}
-
-		alwaysMatch := map[string]interface{}{}
-		if amValue, ok := caps["alwaysMatch"]; ok {
-			am, ok := amValue.(map[string]interface{})
-			if !ok {
-				return nil, w3cInvalidArgument("`capabilities.alwaysMatch` is not a JSON object")
-			}
-			alwaysMatch = am
-		}
-
-		firstMatch := []interface{}{map[string]interface{}{}}
-		if fmValue, ok := caps["firstMatch"]; ok {
-			fm, ok := fmValue.([]interface{})
-			if !ok {
-				return nil, w3cInvalidArgument("`capabilities.firstMatch` is not a JSON list")
-			}
-			if len(fm) > 0 {
-				firstMatch = fm
-			}
-		}
-
-		for i, entryValue := range firstMatch {
-			entry, ok := entryValue.(map[string]interface{})
-			if !ok {
-				return nil, w3cInvalidArgument(fmt.Sprintf("`capabilities.firstMatch[%d]` is not a JSON object", i))
-			}
-
-			merged := make(map[string]interface{}, len(alwaysMatch)+len(entry))
-			for k, v := range alwaysMatch {
-				merged[k] = v
-			}
-			for k, v := range entry {
-				if _, exists := merged[k]; exists {
-					return nil, w3cInvalidArgument(fmt.Sprintf("Capability `%s` is present in both alwaysMatch and firstMatch[%d]", k, i))
-				}
-				merged[k] = v
-			}
-
-			candidate, w3cErr := extractCandidate(merged, prefix)
-			if w3cErr != nil {
-				return nil, w3cErr
-			}
-			req.Candidates = append(req.Candidates, candidate)
-		}
-
-		return req, nil
+	if !hasCaps {
+		return nil, w3cInvalidArgument("The session request contains no `capabilities` object - W3C capabilities are required, legacy `desiredCapabilities`-only bodies are not supported")
+	}
+	caps, ok := capsValue.(map[string]interface{})
+	if !ok {
+		return nil, w3cInvalidArgument("`capabilities` in the session request is not a JSON object")
 	}
 
-	// Legacy fallback - no W3C `capabilities` object at all, use `desiredCapabilities` as a single candidate
-	if desiredValue, ok := raw["desiredCapabilities"]; ok {
-		desired, ok := desiredValue.(map[string]interface{})
+	// alwaysMatch is optional - default to an empty capabilities object
+	alwaysMatch := map[string]interface{}{}
+	if rawAlwaysMatch, present := caps["alwaysMatch"]; present {
+		alwaysMatchCaps, ok := rawAlwaysMatch.(map[string]interface{})
 		if !ok {
-			return nil, w3cInvalidArgument("`desiredCapabilities` in the session request is not a JSON object")
+			return nil, w3cInvalidArgument("`capabilities.alwaysMatch` is not a JSON object")
 		}
-		candidate, w3cErr := extractCandidate(desired, prefix)
+		alwaysMatch = alwaysMatchCaps
+	}
+
+	// firstMatch absent -> treat as a single empty entry `[{}]` (spec), so alwaysMatch
+	// alone still produces one candidate
+	firstMatch := []interface{}{map[string]interface{}{}}
+	if rawFirstMatch, present := caps["firstMatch"]; present {
+		firstMatchEntries, ok := rawFirstMatch.([]interface{})
+		if !ok {
+			return nil, w3cInvalidArgument("`capabilities.firstMatch` is not a JSON list")
+		}
+		// Present-but-empty is an error per spec - Appium rejects the body the same way
+		if len(firstMatchEntries) == 0 {
+			return nil, w3cInvalidArgument("`capabilities.firstMatch` must contain at least one entry when present")
+		}
+		firstMatch = firstMatchEntries
+	}
+
+	// Build one merged candidate per firstMatch entry (spec `#dfn-merging-capabilities`):
+	// start from the alwaysMatch capabilities, then add the entry's own. The same
+	// capability appearing in both places is an error per spec, not an overwrite
+	for entryIndex, rawEntry := range firstMatch {
+		firstMatchCaps, ok := rawEntry.(map[string]interface{})
+		if !ok {
+			return nil, w3cInvalidArgument(fmt.Sprintf("`capabilities.firstMatch[%d]` is not a JSON object", entryIndex))
+		}
+
+		mergedCaps := make(map[string]interface{}, len(alwaysMatch)+len(firstMatchCaps))
+		for capName, capValue := range alwaysMatch {
+			mergedCaps[capName] = capValue
+		}
+		for capName, capValue := range firstMatchCaps {
+			if _, alsoInAlwaysMatch := mergedCaps[capName]; alsoInAlwaysMatch {
+				return nil, w3cInvalidArgument(fmt.Sprintf("Capability `%s` is present in both alwaysMatch and firstMatch[%d]", capName, entryIndex))
+			}
+			mergedCaps[capName] = capValue
+		}
+
+		candidate, w3cErr := extractCandidate(mergedCaps, prefix)
 		if w3cErr != nil {
 			return nil, w3cErr
 		}
 		req.Candidates = append(req.Candidates, candidate)
-		return req, nil
 	}
 
-	return nil, w3cInvalidArgument("The session request contains neither a `capabilities` nor a `desiredCapabilities` object")
+	return req, nil
 }
 
 func extractCandidate(caps map[string]interface{}, prefix string) (gridCandidate, *W3CError) {
@@ -265,25 +259,28 @@ func selectGridCandidate(candidates []gridCandidate) (gridCandidate, bool) {
 // from every capabilities location in the session request before it is forwarded to
 // Appium - they are grid-internal and the secret must never reach provider Appium logs
 func stripGadsCaps(sessionReq map[string]interface{}, prefix string) {
-	keyPrefix := prefix + ":"
+	gadsKeyPrefix := prefix + ":"
 
-	stripFromMap := func(value interface{}) {
-		if m, ok := value.(map[string]interface{}); ok {
-			for k := range m {
-				if strings.HasPrefix(k, keyPrefix) {
-					delete(m, k)
+	// Deletes every `<prefix>:*` key if the value is a capabilities object, no-op otherwise
+	stripFromCapsObject := func(rawCapsObject interface{}) {
+		if capsObject, ok := rawCapsObject.(map[string]interface{}); ok {
+			for capName := range capsObject {
+				if strings.HasPrefix(capName, gadsKeyPrefix) {
+					delete(capsObject, capName)
 				}
 			}
 		}
 	}
 
 	if caps, ok := sessionReq["capabilities"].(map[string]interface{}); ok {
-		stripFromMap(caps["alwaysMatch"])
-		if firstMatch, ok := caps["firstMatch"].([]interface{}); ok {
-			for _, entry := range firstMatch {
-				stripFromMap(entry)
+		stripFromCapsObject(caps["alwaysMatch"])
+		if firstMatchEntries, ok := caps["firstMatch"].([]interface{}); ok {
+			for _, firstMatchEntry := range firstMatchEntries {
+				stripFromCapsObject(firstMatchEntry)
 			}
 		}
 	}
-	stripFromMap(sessionReq["desiredCapabilities"])
+	// Old java-clients send a legacy `desiredCapabilities` object alongside the W3C one -
+	// the secret must be stripped from there too before the body is forwarded
+	stripFromCapsObject(sessionReq["desiredCapabilities"])
 }

--- a/hub/router/gridcapabilities_test.go
+++ b/hub/router/gridcapabilities_test.go
@@ -365,6 +365,7 @@ func TestGridCreateSessionHandler(t *testing.T) {
 			ProviderState:            "live",
 			LastUpdatedTimestamp:     time.Now().UnixMilli(),
 			IsAvailableForAutomation: true,
+			AppiumEnabled:            true,
 		}
 		devices.HubDeviceStore.Set(udid, device)
 		defer devices.HubDeviceStore.Delete(udid)

--- a/hub/router/gridcapabilities_test.go
+++ b/hub/router/gridcapabilities_test.go
@@ -1,0 +1,433 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/common/models"
+	"GADS/hub/devices"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSessionRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		wantErrCode    string
+		wantErrStatus  int
+		wantCandidates int
+		check          func(t *testing.T, req *GridSessionRequest)
+	}{
+		{
+			name:           "firstMatch absent - alwaysMatch only",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
+			},
+		},
+		{
+			name:           "firstMatch empty list does not panic and falls back to alwaysMatch",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"},"firstMatch":[]}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
+			},
+		},
+		{
+			name:           "firstMatch single empty object",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"iOS"},"firstMatch":[{}]}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "iOS", req.Candidates[0].PlatformName)
+			},
+		},
+		{
+			name:           "split caps - platformName in alwaysMatch and appium caps in firstMatch merge",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"},"firstMatch":[{"appium:automationName":"UiAutomator2","appium:udid":"some-udid"}]}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
+				assert.Equal(t, "UiAutomator2", req.Candidates[0].AutomationName)
+				assert.Equal(t, "some-udid", req.Candidates[0].DeviceUDID)
+			},
+		},
+		{
+			name:          "duplicate key in alwaysMatch and firstMatch is an error",
+			body:          `{"capabilities":{"alwaysMatch":{"platformName":"Android"},"firstMatch":[{"platformName":"Android"}]}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:           "candidate order preserved for multiple firstMatch entries",
+			body:           `{"capabilities":{"firstMatch":[{"platformName":"iOS"},{"platformName":"Android"}]}}`,
+			wantCandidates: 2,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "iOS", req.Candidates[0].PlatformName)
+				assert.Equal(t, "Android", req.Candidates[1].PlatformName)
+			},
+		},
+		{
+			name:           "legacy desiredCapabilities fallback",
+			body:           `{"desiredCapabilities":{"platformName":"Android","appium:automationName":"UiAutomator2"}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
+				assert.Equal(t, "UiAutomator2", req.Candidates[0].AutomationName)
+			},
+		},
+		{
+			name:           "newCommandTimeout as number",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android","appium:newCommandTimeout":120}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				if assert.NotNil(t, req.Candidates[0].NewCommandTimeout) {
+					assert.Equal(t, int64(120), *req.Candidates[0].NewCommandTimeout)
+				}
+			},
+		},
+		{
+			name:           "newCommandTimeout as numeric string",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android","appium:newCommandTimeout":"45"}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				if assert.NotNil(t, req.Candidates[0].NewCommandTimeout) {
+					assert.Equal(t, int64(45), *req.Candidates[0].NewCommandTimeout)
+				}
+			},
+		},
+		{
+			name:           "newCommandTimeout explicit zero is distinguishable from absent",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android","appium:newCommandTimeout":0}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				if assert.NotNil(t, req.Candidates[0].NewCommandTimeout) {
+					assert.Equal(t, int64(0), *req.Candidates[0].NewCommandTimeout)
+				}
+			},
+		},
+		{
+			name:           "newCommandTimeout absent",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				assert.Nil(t, req.Candidates[0].NewCommandTimeout)
+			},
+		},
+		{
+			name:          "newCommandTimeout as non-numeric string is an error",
+			body:          `{"capabilities":{"alwaysMatch":{"platformName":"Android","appium:newCommandTimeout":"a lot"}}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:           "gads queueTimeout parsed",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:queueTimeout":90}}}`,
+			wantCandidates: 1,
+			check: func(t *testing.T, req *GridSessionRequest) {
+				if assert.NotNil(t, req.Candidates[0].QueueTimeout) {
+					assert.Equal(t, int64(90), *req.Candidates[0].QueueTimeout)
+				}
+			},
+		},
+		{
+			name:          "capabilities not an object is an error",
+			body:          `{"capabilities":"nope"}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:          "firstMatch not a list is an error",
+			body:          `{"capabilities":{"firstMatch":{"platformName":"Android"}}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:          "firstMatch entry not an object is an error",
+			body:          `{"capabilities":{"firstMatch":["Android"]}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:          "no capabilities at all is an error",
+			body:          `{"something":"else"}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:          "invalid JSON is an error",
+			body:          `{not json`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, w3cErr := parseSessionRequest([]byte(tt.body), "gads")
+			if tt.wantErrCode != "" {
+				if assert.NotNil(t, w3cErr) {
+					assert.Equal(t, tt.wantErrCode, w3cErr.Code)
+					assert.Equal(t, tt.wantErrStatus, w3cErr.HTTPStatus)
+				}
+				return
+			}
+			assert.Nil(t, w3cErr)
+			assert.Len(t, req.Candidates, tt.wantCandidates)
+			if tt.check != nil {
+				tt.check(t, req)
+			}
+		})
+	}
+}
+
+func TestCandidateTargetOS(t *testing.T) {
+	tests := []struct {
+		name           string
+		platformName   string
+		automationName string
+		want           string
+	}{
+		{"platformName only", "Android", "", "android"},
+		{"automationName only", "", "XCUITest", "ios"},
+		{"case insensitive", "ANDROID", "", "android"},
+		{"tizen", "TizenTV", "", "tizen"},
+		{"webos", "lgtv", "", "webos"},
+		{"roku", "", "roku", "roku"},
+		{"unknown", "Windows", "", ""},
+		{"empty", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := gridCandidate{PlatformName: tt.platformName, AutomationName: tt.automationName}
+			assert.Equal(t, tt.want, candidateTargetOS(candidate))
+		})
+	}
+}
+
+func TestSelectGridCandidate(t *testing.T) {
+	t.Run("first matching candidate wins in order", func(t *testing.T) {
+		candidates := []gridCandidate{
+			{PlatformName: "Windows"},
+			{PlatformName: "iOS"},
+			{PlatformName: "Android"},
+		}
+		selected, ok := selectGridCandidate(candidates)
+		assert.True(t, ok)
+		assert.Equal(t, "iOS", selected.PlatformName)
+	})
+
+	t.Run("udid alone is enough to match", func(t *testing.T) {
+		candidates := []gridCandidate{{DeviceUDID: "some-udid"}}
+		selected, ok := selectGridCandidate(candidates)
+		assert.True(t, ok)
+		assert.Equal(t, "some-udid", selected.DeviceUDID)
+	})
+
+	t.Run("no candidate matches", func(t *testing.T) {
+		candidates := []gridCandidate{{PlatformName: "Windows"}, {}}
+		_, ok := selectGridCandidate(candidates)
+		assert.False(t, ok)
+	})
+}
+
+func TestStripGadsCaps(t *testing.T) {
+	t.Run("strips prefixed caps from all three locations", func(t *testing.T) {
+		sessionReq := map[string]interface{}{
+			"capabilities": map[string]interface{}{
+				"alwaysMatch": map[string]interface{}{
+					"platformName":      "Android",
+					"gads:clientSecret": "secret",
+				},
+				"firstMatch": []interface{}{
+					map[string]interface{}{
+						"appium:automationName": "UiAutomator2",
+						"gads:queueTimeout":     float64(30),
+					},
+				},
+			},
+			"desiredCapabilities": map[string]interface{}{
+				"platformName":      "Android",
+				"gads:clientSecret": "secret",
+			},
+		}
+
+		stripGadsCaps(sessionReq, "gads")
+
+		marshaled, _ := json.Marshal(sessionReq)
+		assert.NotContains(t, string(marshaled), "gads:")
+		alwaysMatch := sessionReq["capabilities"].(map[string]interface{})["alwaysMatch"].(map[string]interface{})
+		assert.Equal(t, "Android", alwaysMatch["platformName"])
+		firstMatch := sessionReq["capabilities"].(map[string]interface{})["firstMatch"].([]interface{})
+		assert.Equal(t, "UiAutomator2", firstMatch[0].(map[string]interface{})["appium:automationName"])
+	})
+
+	t.Run("custom prefix", func(t *testing.T) {
+		sessionReq := map[string]interface{}{
+			"capabilities": map[string]interface{}{
+				"alwaysMatch": map[string]interface{}{
+					"custom:clientSecret": "secret",
+					"gads:kept":           "yes",
+				},
+			},
+		}
+
+		stripGadsCaps(sessionReq, "custom")
+
+		alwaysMatch := sessionReq["capabilities"].(map[string]interface{})["alwaysMatch"].(map[string]interface{})
+		assert.NotContains(t, alwaysMatch, "custom:clientSecret")
+		assert.Contains(t, alwaysMatch, "gads:kept")
+	})
+}
+
+type fakeGridStore struct {
+	credential    models.ClientCredentials
+	credentialErr error
+	user          models.User
+	workspaces    []models.Workspace
+}
+
+func (f *fakeGridStore) GetClientCredentialBySecret(clientSecret string) (models.ClientCredentials, error) {
+	return f.credential, f.credentialErr
+}
+
+func (f *fakeGridStore) GetUser(username string) (models.User, error) {
+	return f.user, nil
+}
+
+func (f *fakeGridStore) GetUserWorkspaces(username string) []models.Workspace {
+	return f.workspaces
+}
+
+func (f *fakeGridStore) GetWorkspaces() ([]models.Workspace, error) {
+	return f.workspaces, nil
+}
+
+func (f *fakeGridStore) GetOrCreateDefaultTenant() (string, error) {
+	return "default", nil
+}
+
+func newGridTestRouter() *gin.Engine {
+	router := gin.New()
+	appiumGroup := router.Group("/grid")
+	appiumGroup.Use(AppiumGridMiddleware())
+	appiumGroup.Any("/*path")
+	return router
+}
+
+func TestAppiumGridMiddlewareSessionCreate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "test-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	t.Run("session created with split caps and secret stripped before forwarding", func(t *testing.T) {
+		var forwardedBody []byte
+		fakeProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			forwardedBody, _ = readBody(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"value":{"sessionId":"fake-session-id","capabilities":{"platformName":"Android"}}}`))
+		}))
+		defer fakeProvider.Close()
+
+		udid := "grid-test-device"
+		device := &devices.LocalHubDevice{
+			Device: models.DBDevice{
+				UDID:        udid,
+				OS:          "android",
+				OSVersion:   "14.0.0",
+				WorkspaceID: "ws1",
+			},
+			Host:                     strings.TrimPrefix(fakeProvider.URL, "http://"),
+			Connected:                true,
+			ProviderState:            "live",
+			LastUpdatedTimestamp:     time.Now().UnixMilli(),
+			IsAvailableForAutomation: true,
+		}
+		devices.HubDeviceStore.Set(udid, device)
+		defer devices.HubDeviceStore.Delete(udid)
+
+		// platformName only in alwaysMatch, appium:* only in firstMatch - must match after merging
+		sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret"},"firstMatch":[{"appium:automationName":"UiAutomator2"}]}}`
+
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "fake-session-id")
+
+		assert.NotContains(t, string(forwardedBody), "test-secret")
+		assert.NotContains(t, string(forwardedBody), "gads:")
+		assert.Contains(t, string(forwardedBody), "UiAutomator2")
+		assert.Contains(t, string(forwardedBody), "Android")
+
+		device.Mu.RLock()
+		defer device.Mu.RUnlock()
+		assert.Equal(t, "fake-session-id", device.SessionID)
+		assert.True(t, device.IsRunningAutomation)
+		assert.False(t, device.IsAvailableForAutomation)
+	})
+
+	t.Run("malformed JSON body returns 400 invalid argument", func(t *testing.T) {
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(`{not json`))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var response SeleniumSessionErrorResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.Equal(t, "invalid argument", response.Value.Error)
+	})
+
+	t.Run("firstMatch empty list does not panic", func(t *testing.T) {
+		router := newGridTestRouter()
+		body := `{"capabilities":{"alwaysMatch":{"gads:clientSecret":"test-secret"},"firstMatch":[]}}`
+		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(body))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		// No candidate targets a known OS - session not created, but no panic
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		var response SeleniumSessionErrorResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.Equal(t, "session not created", response.Value.Error)
+	})
+
+	t.Run("unknown session ID returns 404 invalid session id", func(t *testing.T) {
+		router := newGridTestRouter()
+		req, _ := http.NewRequest("POST", "/grid/session/does-not-exist-session/url", bytes.NewBufferString(`{"url":"https://example.com"}`))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		var response SeleniumSessionErrorResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.Equal(t, "invalid session id", response.Value.Error)
+		assert.Equal(t, fmt.Sprintf("No session ID `%s` is available to GADS, it timed out or something unexpected occurred", "does-not-exist-session"), response.Value.Message)
+	})
+}

--- a/hub/router/gridcapabilities_test.go
+++ b/hub/router/gridcapabilities_test.go
@@ -329,13 +329,11 @@ func (f *fakeGridStore) GetOrCreateDefaultTenant() (string, error) {
 
 func newGridTestRouter() *gin.Engine {
 	router := gin.New()
-	appiumGroup := router.Group("/grid")
-	appiumGroup.Use(AppiumGridMiddleware())
-	appiumGroup.Any("/*path")
+	registerGridRoutes(router.Group("/grid"))
 	return router
 }
 
-func TestAppiumGridMiddlewareSessionCreate(t *testing.T) {
+func TestGridCreateSessionHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	prevGridDB := gridDB

--- a/hub/router/gridcapabilities_test.go
+++ b/hub/router/gridcapabilities_test.go
@@ -43,12 +43,10 @@ func TestParseSessionRequest(t *testing.T) {
 			},
 		},
 		{
-			name:           "firstMatch empty list does not panic and falls back to alwaysMatch",
-			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"},"firstMatch":[]}}`,
-			wantCandidates: 1,
-			check: func(t *testing.T, req *GridSessionRequest) {
-				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
-			},
+			name:          "firstMatch present but empty is an error (used to panic)",
+			body:          `{"capabilities":{"alwaysMatch":{"platformName":"Android"},"firstMatch":[]}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
 		},
 		{
 			name:           "firstMatch single empty object",
@@ -84,12 +82,17 @@ func TestParseSessionRequest(t *testing.T) {
 			},
 		},
 		{
-			name:           "legacy desiredCapabilities fallback",
-			body:           `{"desiredCapabilities":{"platformName":"Android","appium:automationName":"UiAutomator2"}}`,
+			name:          "legacy desiredCapabilities-only body is rejected",
+			body:          `{"desiredCapabilities":{"platformName":"Android","appium:automationName":"UiAutomator2"}}`,
+			wantErrCode:   "invalid argument",
+			wantErrStatus: 400,
+		},
+		{
+			name:           "desiredCapabilities alongside a W3C capabilities object is ignored",
+			body:           `{"capabilities":{"alwaysMatch":{"platformName":"Android"}},"desiredCapabilities":{"platformName":"iOS"}}`,
 			wantCandidates: 1,
 			check: func(t *testing.T, req *GridSessionRequest) {
 				assert.Equal(t, "Android", req.Candidates[0].PlatformName)
-				assert.Equal(t, "UiAutomator2", req.Candidates[0].AutomationName)
 			},
 		},
 		{
@@ -404,18 +407,17 @@ func TestAppiumGridMiddlewareSessionCreate(t *testing.T) {
 		assert.Equal(t, "invalid argument", response.Value.Error)
 	})
 
-	t.Run("firstMatch empty list does not panic", func(t *testing.T) {
+	t.Run("firstMatch empty list returns 400 without panicking", func(t *testing.T) {
 		router := newGridTestRouter()
 		body := `{"capabilities":{"alwaysMatch":{"gads:clientSecret":"test-secret"},"firstMatch":[]}}`
 		req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(body))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// No candidate targets a known OS - session not created, but no panic
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 		var response SeleniumSessionErrorResponse
 		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-		assert.Equal(t, "session not created", response.Value.Error)
+		assert.Equal(t, "invalid argument", response.Value.Error)
 	})
 
 	t.Run("unknown session ID returns 404 invalid session id", func(t *testing.T) {

--- a/hub/router/gridqueue.go
+++ b/hub/router/gridqueue.go
@@ -1,0 +1,190 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/hub/devices"
+	"strings"
+	"sync"
+	"time"
+)
+
+// How long a session request may wait for a device to free up. Absent
+// `gads:queueTimeout` keeps the historical 10 second wait; explicit values are
+// clamped to the maximum
+const (
+	defaultQueueWait   = 10 * time.Second
+	maxQueueWait       = 300 * time.Second
+	queueSweepInterval = 500 * time.Millisecond
+)
+
+// sessionWaiter is one queued `POST /grid/session` request waiting for a device.
+// Once enqueued the dispatcher owns it: it either delivers a claimed device on the
+// channel or closes the channel on timeout, client disconnect or a fail-fast error
+type sessionWaiter struct {
+	candidate gridCandidate
+	user      gridUser
+	deadline  time.Time
+	// The request context's Done channel - nil means the waiter cannot be cancelled
+	ctxDone <-chan struct{}
+	deliver chan *devices.LocalHubDevice
+	// Written by the dispatcher under the queue mutex and read by the handler only
+	// after `deliver` is closed - the channel close orders the accesses
+	lastErr    error
+	clientGone bool
+}
+
+// sessionQueue hands free devices to session requests in FIFO order. A single
+// dispatcher goroutine walks the waiters on device-freed notifications, enqueue
+// kicks and a coarse tick (device availability can also appear via provider
+// updates, which do not notify)
+type sessionQueue struct {
+	mu              sync.Mutex
+	waiters         []*sessionWaiter
+	kick            chan struct{}
+	startDispatcher sync.Once
+}
+
+var gridQueue = &sessionQueue{kick: make(chan struct{}, 1)}
+
+// queueWaitDuration resolves how long a session request may wait for a device -
+// `gads:queueTimeout` seconds when the client sent it (clamped to [0, maxQueueWait],
+// 0 means a single immediate attempt), otherwise the historical 10 second default
+func queueWaitDuration(candidate gridCandidate) time.Duration {
+	if candidate.QueueTimeout == nil {
+		return defaultQueueWait
+	}
+	wait := time.Duration(*candidate.QueueTimeout) * time.Second
+	if wait < 0 {
+		return 0
+	}
+	if wait > maxQueueWait {
+		return maxQueueWait
+	}
+	return wait
+}
+
+// isFailFastDeviceError reports whether a findAvailableDevice error is a static
+// condition that waiting cannot fix - an unknown/unassigned UDID or a device whose
+// usage forbids automation. The create handler maps these to their own responses
+func isFailFastDeviceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "No device with udid") ||
+		strings.Contains(err.Error(), "is not enabled for automation")
+}
+
+// Acquire finds and claims a device matching the candidate, waiting up to `wait`
+// behind earlier requests when none is free right now. It returns the claimed
+// device, the most recent matching error (for the timeout response), and whether
+// the client went away while waiting
+func (q *sessionQueue) Acquire(candidate gridCandidate, user gridUser, wait time.Duration, ctxDone <-chan struct{}) (*devices.LocalHubDevice, error, bool) {
+	q.startDispatcher.Do(func() { go q.dispatchLoop() })
+
+	waiter := &sessionWaiter{
+		candidate: candidate,
+		user:      user,
+		deadline:  time.Now().Add(wait),
+		ctxDone:   ctxDone,
+		deliver:   make(chan *devices.LocalHubDevice, 1),
+	}
+
+	q.mu.Lock()
+	// A request may only skip the queue when nobody is already waiting - otherwise
+	// a device freed a moment ago would go to the newcomer instead of the first
+	// waiter in line
+	if len(q.waiters) == 0 {
+		device, err := findAvailableDevice(candidate, user.AllowedWorkspaceIDs, user.UserID, user.Tenant)
+		if device != nil || isFailFastDeviceError(err) || wait <= 0 {
+			q.mu.Unlock()
+			return device, err, false
+		}
+		waiter.lastErr = err
+	}
+	q.waiters = append(q.waiters, waiter)
+	q.mu.Unlock()
+	q.wake()
+
+	device, ok := <-waiter.deliver
+	if ok {
+		return device, nil, false
+	}
+	return nil, waiter.lastErr, waiter.clientGone
+}
+
+// wake pokes the dispatcher without blocking - a pending kick already covers this one
+func (q *sessionQueue) wake() {
+	select {
+	case q.kick <- struct{}{}:
+	default:
+	}
+}
+
+func (q *sessionQueue) dispatchLoop() {
+	ticker := time.NewTicker(queueSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-q.kick:
+		case <-devices.DeviceFreedSignal():
+		case <-ticker.C:
+		}
+		q.dispatch()
+	}
+}
+
+// dispatch walks the waiters in FIFO order once. Only the queue mutex is held while
+// walking - device claiming happens inside findAvailableDevice under each device's
+// own mutex, so no device mutex is ever held across the walk
+func (q *sessionQueue) dispatch() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.waiters) == 0 {
+		return
+	}
+
+	now := time.Now()
+	remaining := make([]*sessionWaiter, 0, len(q.waiters))
+	for _, waiter := range q.waiters {
+		select {
+		case <-waiter.ctxDone:
+			waiter.clientGone = true
+			close(waiter.deliver)
+			continue
+		default:
+		}
+
+		device, err := findAvailableDevice(waiter.candidate, waiter.user.AllowedWorkspaceIDs, waiter.user.UserID, waiter.user.Tenant)
+		if device != nil {
+			waiter.deliver <- device
+			continue
+		}
+		if err != nil {
+			waiter.lastErr = err
+		}
+		// The deadline check runs after the attempt so even a zero-wait waiter that
+		// had to queue behind others gets one real matching attempt
+		if isFailFastDeviceError(err) || now.After(waiter.deadline) {
+			close(waiter.deliver)
+			continue
+		}
+		remaining = append(remaining, waiter)
+	}
+	q.waiters = remaining
+}
+
+// depth reports the number of queued waiters. Used by tests to synchronize on
+// enqueue order
+func (q *sessionQueue) depth() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.waiters)
+}

--- a/hub/router/gridqueue.go
+++ b/hub/router/gridqueue.go
@@ -181,8 +181,8 @@ func (q *sessionQueue) dispatch() {
 	q.waiters = remaining
 }
 
-// depth reports the number of queued waiters. Used by tests to synchronize on
-// enqueue order
+// depth reports the number of queued waiters - surfaced on /grid/status and used
+// by tests to synchronize on enqueue order
 func (q *sessionQueue) depth() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/hub/router/gridqueue_test.go
+++ b/hub/router/gridqueue_test.go
@@ -1,0 +1,216 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"GADS/common/models"
+	"GADS/hub/devices"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// acquireResult carries one Acquire outcome from a waiter goroutine to the test
+type acquireResult struct {
+	device     *devices.LocalHubDevice
+	err        error
+	clientGone bool
+}
+
+// acquireAsync runs gridQueue.Acquire in a goroutine and returns the channel its
+// result lands on
+func acquireAsync(candidate gridCandidate, user gridUser, wait time.Duration, ctxDone <-chan struct{}) <-chan acquireResult {
+	results := make(chan acquireResult, 1)
+	go func() {
+		device, err, clientGone := gridQueue.Acquire(candidate, user, wait, ctxDone)
+		results <- acquireResult{device: device, err: err, clientGone: clientGone}
+	}()
+	return results
+}
+
+// waitAcquire receives an Acquire outcome with a hard timeout so a broken queue
+// fails the test instead of hanging it
+func waitAcquire(t *testing.T, results <-chan acquireResult) acquireResult {
+	t.Helper()
+	select {
+	case result := <-results:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatal("Acquire did not return within 5 seconds")
+		return acquireResult{}
+	}
+}
+
+// freeDevice releases the device from automation the way the real code paths do,
+// which also pokes the queue dispatcher
+func freeDevice(device *devices.LocalHubDevice) {
+	device.Mu.Lock()
+	device.ReleaseFromAutomation()
+	device.Mu.Unlock()
+}
+
+func TestQueueWaitDuration(t *testing.T) {
+	seconds := func(s int64) *int64 { return &s }
+
+	tests := []struct {
+		name         string
+		queueTimeout *int64
+		want         time.Duration
+	}{
+		{"absent keeps the historical 10s default", nil, 10 * time.Second},
+		{"explicit value used as-is", seconds(90), 90 * time.Second},
+		{"clamped to the 300s maximum", seconds(400), 300 * time.Second},
+		{"zero means no waiting", seconds(0), 0},
+		{"negative clamped to no waiting", seconds(-5), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, queueWaitDuration(gridCandidate{QueueTimeout: tt.queueTimeout}))
+		})
+	}
+}
+
+func TestGridQueueFIFOOrder(t *testing.T) {
+	device, cleanup := newGridSessionDevice("queue-fifo-device", "", "fake-host")
+	defer cleanup()
+
+	user := gridUser{UserID: "test-user", Tenant: "tenant1", AllowedWorkspaceIDs: []string{"ws1"}}
+	candidate := gridCandidate{DeviceUDID: "queue-fifo-device"}
+
+	// Enqueue two waiters for the same busy device, synchronizing on queue depth
+	// so the enqueue order is deterministic
+	resultsA := acquireAsync(candidate, user, 5*time.Second, nil)
+	assert.Eventually(t, func() bool { return gridQueue.depth() == 1 }, 2*time.Second, 10*time.Millisecond)
+	resultsB := acquireAsync(candidate, user, 5*time.Second, nil)
+	assert.Eventually(t, func() bool { return gridQueue.depth() == 2 }, 2*time.Second, 10*time.Millisecond)
+
+	// Free the device - the FIRST enqueued waiter must get it while the second
+	// keeps waiting
+	freeDevice(device)
+	resultA := waitAcquire(t, resultsA)
+	assert.Same(t, device, resultA.device)
+	assert.False(t, resultA.clientGone)
+	assert.Eventually(t, func() bool { return gridQueue.depth() == 1 }, 2*time.Second, 10*time.Millisecond)
+
+	// Free it again - now the second waiter's turn
+	freeDevice(device)
+	resultB := waitAcquire(t, resultsB)
+	assert.Same(t, device, resultB.device)
+
+	// Acquire claims the device on delivery
+	device.Mu.RLock()
+	defer device.Mu.RUnlock()
+	assert.False(t, device.IsAvailableForAutomation)
+}
+
+func TestGridQueueTimeout(t *testing.T) {
+	_, cleanup := newGridSessionDevice("queue-timeout-device", "", "fake-host")
+	defer cleanup()
+
+	user := gridUser{UserID: "test-user", Tenant: "tenant1", AllowedWorkspaceIDs: []string{"ws1"}}
+	candidate := gridCandidate{DeviceUDID: "queue-timeout-device"}
+
+	start := time.Now()
+	device, err, clientGone := gridQueue.Acquire(candidate, user, 1*time.Second, nil)
+	elapsed := time.Since(start)
+
+	assert.Nil(t, device)
+	assert.False(t, clientGone)
+	// The timeout response carries the last matching error, same as the old retry loop
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "not available for automation")
+	}
+	assert.GreaterOrEqual(t, elapsed, 1*time.Second)
+	assert.Less(t, elapsed, 3*time.Second)
+}
+
+func TestGridQueueZeroWaitFailsImmediately(t *testing.T) {
+	_, cleanup := newGridSessionDevice("queue-zero-wait-device", "", "fake-host")
+	defer cleanup()
+
+	user := gridUser{UserID: "test-user", Tenant: "tenant1", AllowedWorkspaceIDs: []string{"ws1"}}
+	candidate := gridCandidate{DeviceUDID: "queue-zero-wait-device"}
+
+	start := time.Now()
+	device, err, clientGone := gridQueue.Acquire(candidate, user, 0, nil)
+
+	assert.Nil(t, device)
+	assert.False(t, clientGone)
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+}
+
+func TestGridQueueCancelledWaiterLeavesTheQueue(t *testing.T) {
+	device, cleanup := newGridSessionDevice("queue-cancel-device", "", "fake-host")
+	defer cleanup()
+
+	user := gridUser{UserID: "test-user", Tenant: "tenant1", AllowedWorkspaceIDs: []string{"ws1"}}
+	candidate := gridCandidate{DeviceUDID: "queue-cancel-device"}
+
+	ctxDoneA := make(chan struct{})
+	resultsA := acquireAsync(candidate, user, 5*time.Second, ctxDoneA)
+	assert.Eventually(t, func() bool { return gridQueue.depth() == 1 }, 2*time.Second, 10*time.Millisecond)
+	resultsB := acquireAsync(candidate, user, 5*time.Second, nil)
+	assert.Eventually(t, func() bool { return gridQueue.depth() == 2 }, 2*time.Second, 10*time.Millisecond)
+
+	// Cancel the first waiter - it must report the client gone without a device
+	close(ctxDoneA)
+	resultA := waitAcquire(t, resultsA)
+	assert.True(t, resultA.clientGone)
+	assert.Nil(t, resultA.device)
+
+	// The freed device must skip the cancelled waiter and go to the second one
+	freeDevice(device)
+	resultB := waitAcquire(t, resultsB)
+	assert.Same(t, device, resultB.device)
+}
+
+func TestGridCreateSessionQueueTimeoutOverHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	prevGridDB := gridDB
+	defer func() { gridDB = prevGridDB }()
+	gridDB = &fakeGridStore{
+		credential: models.ClientCredentials{UserID: "test-user", Tenant: "tenant1", IsActive: true},
+		workspaces: []models.Workspace{{ID: "ws1", Tenant: "tenant1"}},
+	}
+
+	_, cleanup := newGridSessionDevice("queue-http-device", "", "fake-host")
+	defer cleanup()
+
+	// The only matching device is busy and `gads:queueTimeout: 1` bounds the wait -
+	// the request must come back as a 500 `session not created` after about a second
+	sessionBody := `{"capabilities":{"alwaysMatch":{"platformName":"Android","gads:clientSecret":"test-secret","appium:udid":"queue-http-device","gads:queueTimeout":1}}}`
+
+	router := newGridTestRouter()
+	req, _ := http.NewRequest("POST", "/grid/session", bytes.NewBufferString(sessionBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	router.ServeHTTP(w, req)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.GreaterOrEqual(t, elapsed, 1*time.Second)
+	assert.Less(t, elapsed, 3*time.Second)
+
+	var response SeleniumSessionErrorResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "session not created", response.Value.Error)
+	assert.Contains(t, response.Value.Message, "not available for automation")
+}

--- a/hub/router/handler.go
+++ b/hub/router/handler.go
@@ -12,6 +12,7 @@ package router
 import (
 	"GADS/hub/auth"
 	"GADS/hub/config"
+	"fmt"
 	"io"
 	"io/fs"
 	"log"
@@ -38,11 +39,13 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	r.Use(cors.New(ginConfig))
 
 	// Handle UI serving only if we have UI files embedded
+	var uiFS fs.FS
 	if uiFiles != nil {
-		uiFS, err := fs.Sub(uiFiles, "hub-ui/build")
+		subFS, err := fs.Sub(uiFiles, "hub-ui/build")
 		if err != nil {
 			log.Fatalf("Failed to get UI files filesystem: %v", err)
 		}
+		uiFS = subFS
 
 		r.Use(func(c *gin.Context) {
 			path := c.Request.URL.Path
@@ -63,24 +66,35 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 			fileServer.ServeHTTP(c.Writer, c.Request)
 			c.Abort()
 		})
-
-		r.NoRoute(func(c *gin.Context) {
-			indexFile, err := uiFS.Open("index.html")
-			if err != nil {
-				c.AbortWithStatus(http.StatusInternalServerError)
-				return
-			}
-			defer indexFile.Close()
-
-			stat, err := indexFile.Stat()
-			if err != nil {
-				c.AbortWithStatus(http.StatusInternalServerError)
-				return
-			}
-
-			http.ServeContent(c.Writer, c.Request, "index.html", stat.ModTime(), indexFile.(io.ReadSeeker))
-		})
 	}
+
+	r.NoRoute(func(c *gin.Context) {
+		// Unmatched /grid/* paths must get a W3C error response, not the UI fallback page
+		if strings.HasPrefix(c.Request.URL.Path, "/grid/") {
+			writeW3CError(c, w3cUnknownCommand(fmt.Sprintf("Unknown grid endpoint `%s`", c.Request.URL.Path)))
+			return
+		}
+
+		if uiFS == nil {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		indexFile, err := uiFS.Open("index.html")
+		if err != nil {
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+		defer indexFile.Close()
+
+		stat, err := indexFile.Stat()
+		if err != nil {
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+
+		http.ServeContent(c.Writer, c.Request, "index.html", stat.ModTime(), indexFile.(io.ReadSeeker))
+	})
 
 	authGroup := r.Group("/")
 	// Unauthenticated endpoints
@@ -167,9 +181,7 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	authGroup.POST("/custom-actions/favorites/:id", AddUserFavorite)
 	authGroup.DELETE("/custom-actions/favorites/:id", RemoveUserFavorite)
 
-	appiumGroup := r.Group("/grid")
-	appiumGroup.Use(AppiumGridMiddleware())
-	appiumGroup.Any("/*path")
+	registerGridRoutes(r.Group("/grid"))
 
 	return r
 }

--- a/hub/router/handler.go
+++ b/hub/router/handler.go
@@ -114,6 +114,7 @@ func HandleRequests(uiFiles fs.FS) *gin.Engine {
 	}
 	authGroup.GET("/user-info", auth.GetUserInfoHandler)
 	authGroup.GET("/appium-logs", GetAppiumLogs)
+	authGroup.GET("/automation-sessions", GetAutomationSessions)
 	authGroup.GET("/health", HealthCheck)
 	authGroup.POST("/logout", auth.LogoutHandler)
 	authGroup.POST("/change-password", auth.ChangePasswordHandler)

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -142,7 +142,7 @@ func TestDeviceProxyHandler(t *testing.T) {
 	})
 
 	// NOTE: client-credential enforcement for session creation lives on the /grid
-	// surface (AppiumGridMiddleware) and is covered by gridcapabilities_test.go -
+	// surface (GridCreateSession) and is covered by gridcapabilities_test.go -
 	// DeviceProxyHandler itself performs no credential checks
 }
 

--- a/hub/router/proxy_test.go
+++ b/hub/router/proxy_test.go
@@ -12,9 +12,7 @@ package router
 import (
 	"GADS/common/models"
 	"GADS/hub/devices"
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -143,60 +141,9 @@ func TestDeviceProxyHandler(t *testing.T) {
 		devices.HubDeviceStore.Delete(udid)
 	})
 
-	t.Run("Missing Client Credentials - Should Return W3C Error Format", func(t *testing.T) {
-		// Setup a device
-		udid := "test-device-no-credentials"
-		devices.HubDeviceStore.Set(udid, &devices.LocalHubDevice{
-			Device: models.DBDevice{
-				UDID: udid,
-			},
-			Host:      "localhost:8080",
-			Available: true,
-		})
-
-		// Create request WITHOUT credentials
-		router := gin.New()
-		router.POST("/device/:udid/*path", DeviceProxyHandler)
-
-		sessionReq := map[string]interface{}{
-			"capabilities": map[string]interface{}{
-				"alwaysMatch": map[string]interface{}{
-					"platformName": "iOS",
-					// Note: NO client credentials provided
-				},
-			},
-		}
-		jsonData, _ := json.Marshal(sessionReq)
-
-		req, _ := http.NewRequest("POST", "/device/"+udid+"/session", bytes.NewBuffer(jsonData))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-
-		// Execute request
-		router.ServeHTTP(w, req)
-
-		// Verify status code
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
-
-		// Verify W3C error format
-		var response map[string]interface{}
-		err := json.Unmarshal(w.Body.Bytes(), &response)
-		assert.NoError(t, err)
-
-		// Check W3C structure
-		assert.Contains(t, response, "value")
-		value, ok := response["value"].(map[string]interface{})
-		assert.True(t, ok, "value should be a map")
-
-		assert.Equal(t, "invalid argument", value["error"])
-		expectedMsg := fmt.Sprintf("Client credentials are required. Provide %[1]s:clientSecret in the capabilities.", capabilityPrefix)
-		assert.Equal(t, expectedMsg, value["message"])
-		assert.Equal(t, "", value["stacktrace"])
-
-		// Cleanup
-		devices.HubDeviceStore.Delete(udid)
-	})
-
+	// NOTE: client-credential enforcement for session creation lives on the /grid
+	// surface (AppiumGridMiddleware) and is covered by gridcapabilities_test.go -
+	// DeviceProxyHandler itself performs no credential checks
 }
 
 func TestExtractClientSecretFromSession(t *testing.T) {

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1383,9 +1383,7 @@ func ReleaseDevice(c *gin.Context) {
 
 	// Fully reset any (possibly stuck) automation session so the device becomes
 	// available again immediately instead of waiting for the grid session janitor.
-	releaseDevice.IsRunningAutomation = false
-	releaseDevice.IsAvailableForAutomation = true
-	releaseDevice.SessionID = ""
+	releaseDevice.ReleaseFromAutomation()
 	releaseDevice.ReleaseLock()
 
 	api.OKMessage(c, "Device was successfully released")
@@ -1556,10 +1554,10 @@ func ProviderUpdate(c *gin.Context) {
 			hubDevice.Connected = false
 			hubDevice.ProviderState = providerDevice.ProviderState
 			hubDevice.Host = providerDevice.Host
+			hubDevice.ReleaseFromAutomation()
+			// A disconnected device must not be handed out for automation even though
+			// ReleaseFromAutomation marks devices available by default
 			hubDevice.IsAvailableForAutomation = false
-			hubDevice.IsRunningAutomation = false
-			hubDevice.ReleaseLockIfNotHeld()
-			hubDevice.SessionID = ""
 			hubDevice.Mu.Unlock()
 			continue
 		}

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1517,6 +1517,26 @@ func syncDeviceFields(target *devices.LocalHubDevice, source *models.ProviderDev
 	if target.Host != source.Host {
 		target.Host = source.Host
 	}
+
+	// Appium session truth from the provider - older providers do not report it
+	// (marker false), in which case the hub keeps its own tracking only
+	target.ProviderReportsSessionState = source.ReportsAppiumSessionState
+	if source.ReportsAppiumSessionState {
+		target.ProviderHasSession = source.HasAppiumSession
+		target.ProviderSessionID = source.AppiumSessionID
+		target.ProviderLastCommandTS = source.AppiumLastCommandTS
+		// Track since when the provider stopped reporting a session the hub still
+		// considers live - the janitor releases the device once this persists
+		if target.IsRunningAutomation && target.SessionID != "" && !source.HasAppiumSession {
+			if target.ProviderSessionMissingSinceTS == 0 {
+				target.ProviderSessionMissingSinceTS = time.Now().UnixMilli()
+			}
+		} else {
+			target.ProviderSessionMissingSinceTS = 0
+		}
+	} else {
+		target.ProviderSessionMissingSinceTS = 0
+	}
 }
 
 // ProviderUpdate godoc

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1564,8 +1564,14 @@ func ProviderUpdate(c *gin.Context) {
 		// Stamp when we last heard from the provider about this device
 		hubDevice.LastUpdatedTimestamp = time.Now().UnixMilli()
 
+		wasLive := hubDevice.Connected && hubDevice.ProviderState == "live"
 		syncDeviceFields(hubDevice, providerDevice)
+		nowLive := hubDevice.Connected && hubDevice.ProviderState == "live"
 		hubDevice.Mu.Unlock()
+		// A device that just (re)connected live may satisfy a queued session request
+		if !wasLive && nowLive {
+			devices.NotifyDeviceFreed()
+		}
 	}
 
 	api.OKMessage(c, "Provider data updated in hub")

--- a/provider/devices/platform.go
+++ b/provider/devices/platform.go
@@ -60,7 +60,10 @@ type PlatformDevice interface {
 	SetAppiumSessionID(id string)
 	SetAppiumUp(up bool)
 	SetAppiumLastPingTS(ts int64)
+	SetAppiumLastCommandTS(ts int64)
 	SetHasAppiumSession(has bool)
+	SetAppiumSessionCaps(caps map[string]interface{})
+	GetAppiumSessionCaps() map[string]interface{}
 	GetIsAppiumUp() bool
 
 	// Runtime state accessors (provider-only fields on RuntimeState)

--- a/provider/devices/runtime.go
+++ b/provider/devices/runtime.go
@@ -57,7 +57,9 @@ type RuntimeState struct {
 	StreamJpegQuality    int
 	StreamScalingFactor  int
 	AppiumLastPingTS     int64
+	AppiumLastCommandTS  int64
 	AppiumSessionID      string
+	AppiumSessionCaps    map[string]interface{}
 	IsAppiumUp           bool
 	HasAppiumSession     bool
 	CurrentRotation      string
@@ -88,7 +90,12 @@ func (r *RuntimeState) GetAppiumSessionID() string                   { return r.
 func (r *RuntimeState) SetAppiumSessionID(id string)                 { r.AppiumSessionID = id }
 func (r *RuntimeState) SetAppiumUp(up bool)                          { r.IsAppiumUp = up }
 func (r *RuntimeState) SetAppiumLastPingTS(ts int64)                 { r.AppiumLastPingTS = ts }
+func (r *RuntimeState) SetAppiumLastCommandTS(ts int64)              { r.AppiumLastCommandTS = ts }
 func (r *RuntimeState) SetHasAppiumSession(has bool)                 { r.HasAppiumSession = has }
+func (r *RuntimeState) SetAppiumSessionCaps(caps map[string]interface{}) {
+	r.AppiumSessionCaps = caps
+}
+func (r *RuntimeState) GetAppiumSessionCaps() map[string]interface{} { return r.AppiumSessionCaps }
 func (r *RuntimeState) GetIsResetting() bool                         { return r.IsResetting }
 func (r *RuntimeState) SetIsResetting(v bool)                        { r.IsResetting = v }
 func (r *RuntimeState) GetIsAppiumUp() bool                          { return r.IsAppiumUp }
@@ -116,10 +123,14 @@ func (r *RuntimeState) SetNewContext(ctx context.Context, cancel context.CancelF
 // ToSyncUpdate builds the lightweight struct sent to the hub each second.
 func (r *RuntimeState) ToSyncUpdate() models.ProviderDeviceSync {
 	return models.ProviderDeviceSync{
-		UDID:          r.DBDevice.UDID,
-		Host:          r.Host,
-		Connected:     r.Connected,
-		ProviderState: r.ProviderState,
+		UDID:                      r.DBDevice.UDID,
+		Host:                      r.Host,
+		Connected:                 r.Connected,
+		ProviderState:             r.ProviderState,
+		ReportsAppiumSessionState: true,
+		HasAppiumSession:          r.HasAppiumSession,
+		AppiumSessionID:           r.AppiumSessionID,
+		AppiumLastCommandTS:       r.AppiumLastCommandTS,
 	}
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var targetAppiumPluginVersion = "0.0.11"
+var targetAppiumPluginVersion = "0.0.12"
 
 func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 	logLevel, _ := flags.GetString("log-level")

--- a/provider/providerutil/providerutil.go
+++ b/provider/providerutil/providerutil.go
@@ -135,27 +135,61 @@ func GetAppiumPluginNPMVersion() (string, error) {
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
 		if strings.Contains(line, "appium-gads@") {
-			parts := strings.Split(line, "@")
-			if len(parts) == 2 {
-				return strings.TrimSpace(parts[1]), nil
+			_, versionPart, _ := strings.Cut(line, "appium-gads@")
+			// A local folder install prints `appium-gads@0.0.12 -> /path/to/folder` -
+			// the version is only the first whitespace-separated token
+			versionFields := strings.Fields(versionPart)
+			if len(versionFields) > 0 {
+				return versionFields[0], nil
 			}
 		}
 	}
 	return "", fmt.Errorf("Could not get GADS Appium plugin version on NPM")
 }
 
+// IsAppiumPluginLocalInstallNPM reports whether the globally installed appium-gads
+// package is a local folder install (npm prints those as `appium-gads@x.y.z -> /path`)
+func IsAppiumPluginLocalInstallNPM() bool {
+	cmd := exec.Command("npm", "list", "-g", "appium-gads", "--depth=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "appium-gads@") && strings.Contains(line, "->") {
+			return true
+		}
+	}
+	return false
+}
+
 // Check if the currently installed Appium GADS plugin version corresponds to the expected one for the current GADS binary
 func ShouldUpdateAppiumPluginNPM(targetVersion string) bool {
+	// A developer testing an unpublished plugin installs it from a local folder -
+	// never overwrite that with a release from NPM
+	if IsAppiumPluginLocalInstallNPM() {
+		logger.ProviderLogger.LogInfo("provider_setup", "GADS Appium plugin on NPM is a local folder install, leaving it as is")
+		return false
+	}
+
 	currentVersion, err := GetAppiumPluginNPMVersion()
 	if err != nil {
 		return false
 	}
 
-	targetSemver := semver.MustParse(targetVersion)
-	currentSemver := semver.MustParse(currentVersion)
-	versionCompareResult := targetSemver.Compare(currentSemver)
+	targetSemver, err := semver.NewVersion(targetVersion)
+	if err != nil {
+		return false
+	}
+	currentSemver, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		// npm reported something that is not a release version - do not fight
+		// whatever the developer set up, and above all do not crash the provider
+		logger.ProviderLogger.LogWarnf("provider_setup", "Could not parse the installed GADS Appium plugin version `%s`, leaving it as is", currentVersion)
+		return false
+	}
 
-	return versionCompareResult != 0
+	return targetSemver.Compare(currentSemver) != 0
 }
 
 // Install the GADS Appium plugin on NPM

--- a/provider/router/appium_plugin.go
+++ b/provider/router/appium_plugin.go
@@ -56,6 +56,16 @@ func AppiumPluginAddSession(c *gin.Context) {
 		dev.SetAppiumLastPingTS(time.Now().UnixMilli())
 		dev.SetHasAppiumSession(true)
 		dev.SetAppiumSessionID(sessionID)
+		// Newer plugins also send the resolved session capabilities in the body -
+		// optional, older plugins post with no body at all
+		body, err := io.ReadAll(c.Request.Body)
+		defer c.Request.Body.Close()
+		if err == nil && len(body) > 0 {
+			var sessionCaps map[string]interface{}
+			if json.Unmarshal(body, &sessionCaps) == nil && len(sessionCaps) > 0 {
+				dev.SetAppiumSessionCaps(sessionCaps)
+			}
+		}
 		dev.SetAppiumUp(true)
 		api.OKMessage(c, "Session added")
 		return
@@ -70,6 +80,7 @@ func AppiumPluginRemoveSession(c *gin.Context) {
 		dev.SetAppiumLastPingTS(time.Now().UnixMilli())
 		dev.SetHasAppiumSession(false)
 		dev.SetAppiumSessionID("")
+		dev.SetAppiumSessionCaps(nil)
 		dev.SetAppiumUp(true)
 		api.OKMessage(c, "Session cleared")
 		return
@@ -84,6 +95,22 @@ func AppiumPluginPing(c *gin.Context) {
 		dev.SetAppiumLastPingTS(time.Now().UnixMilli())
 		dev.SetAppiumUp(true)
 		api.OKMessage(c, "Ping for Appium server availability successful")
+		return
+	}
+	api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))
+}
+
+// AppiumPluginCommand The plugin reports driver command activity (throttled on its
+// side) so the provider knows a test is actively driving the device even when the
+// commands do not pass through the hub proxy
+func AppiumPluginCommand(c *gin.Context) {
+	udid := c.Param("udid")
+	if dev, ok := devices.DevManager.Get(udid); ok {
+		now := time.Now().UnixMilli()
+		dev.SetAppiumLastPingTS(now)
+		dev.SetAppiumLastCommandTS(now)
+		dev.SetAppiumUp(true)
+		api.OKMessage(c, "Command activity recorded")
 		return
 	}
 	api.NotFound(c, fmt.Sprintf("Device with udid `%s` not found", udid))

--- a/provider/router/handler.go
+++ b/provider/router/handler.go
@@ -94,6 +94,7 @@ func HandleRequests() *gin.Engine {
 	deviceAppiumPluginGroup.POST("/session/add/:session_id", AppiumPluginAddSession)
 	deviceAppiumPluginGroup.POST("/session/remove", AppiumPluginRemoveSession)
 	deviceAppiumPluginGroup.POST("/ping", AppiumPluginPing)
+	deviceAppiumPluginGroup.POST("/command", AppiumPluginCommand)
 
 	return r
 }


### PR DESCRIPTION
* Improve W3C compatibility and error reporting
* Improve device allocation
* Improve capabilities handling during session creation
* DELETE routing fix, only on proper delete command sessions will be cleared
* Add janitor for clearing real Appium sessions if the hub expires a session on a device - best effort
* Enrich session responses following Appium/Selenium expectations
* Add proper queue for device allocation instead of polling
* Improve GADS Appium plugin - properly chain through await(), wrap every driver command including proxied ones, use proper cli args with a fallback, remove dead method mapping
* Improve grid documentation
* Add endpoints for Appium Grid status information
* Other optimisations