### PR TITLE
Add Android emulators support

### DIFF
--- a/common/models/config.go
+++ b/common/models/config.go
@@ -51,6 +51,12 @@ type ProviderDeviceSync struct {
 	HasAppiumSession          bool   `json:"has_appium_session"`
 	AppiumSessionID           string `json:"appium_session_id"`
 	AppiumLastCommandTS       int64  `json:"appium_last_command_ts"`
+	// Ephemeral device descriptor - set only for devices that exist solely in
+	// provider memory (e.g. Android emulators) and have no DB record. The hub
+	// upserts its device store entry from EphemeralDevice instead of the DB.
+	// Both fields are omitted for regular devices so their payload is unchanged.
+	Ephemeral       bool      `json:"ephemeral,omitempty"`
+	EphemeralDevice *DBDevice `json:"ephemeral_device,omitempty"`
 }
 
 type ProviderData struct {

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -10,27 +10,30 @@
 package models
 
 type Provider struct {
-	OS                   string `json:"os" bson:"os"`
-	Nickname             string `json:"nickname" bson:"nickname"`
-	HostAddress          string `json:"host_address" bson:"host_address"`
-	Port                 int    `json:"port" bson:"port"`
-	ProvideAndroid       bool   `json:"provide_android" bson:"provide_android"`
-	ProvideAndroidTv     bool   `json:"provide_androidtv" bson:"provide_androidtv"`
-	ProvideIOS           bool   `json:"provide_ios" bson:"provide_ios"`
-	ProvideTizen         bool   `json:"provide_tizen" bson:"provide_tizen"`
-	ProvideWebOS         bool   `json:"provide_webos" bson:"provide_webos"`
-	ProvideRoku          bool   `json:"provide_roku" bson:"provide_roku"`
-	WdaBundleID          string `json:"wda_bundle_id" bson:"wda_bundle_id"`
-	WebDriverAgentIPA    string `json:"web_driver_agent_ipa" bson:"web_driver_agent_ipa"`
-	BroadcastIPA         string `json:"broadcast_ipa" bson:"broadcast_ipa"`
-	SupervisionPassword  string `json:"supervision_password" bson:"supervision_password"`
-	ProviderFolder       string `json:"-" bson:"-"`
-	LastUpdatedTimestamp int64  `json:"last_updated" bson:"last_updated"`
-	UseGadsIosStream     bool   `json:"use_gads_ios_stream" bson:"use_gads_ios_stream"`
-	HubAddress           string `json:"hub_address" bson:"-"`
-	SetupAppiumServers   bool   `json:"setup_appium_servers" bson:"setup_appium_servers"`
-	TURNUsernameSuffix   string `json:"-" bson:"-"`
-	UseIOSPairCache      bool   `json:"-" bson:"-"`
+	OS               string `json:"os" bson:"os"`
+	Nickname         string `json:"nickname" bson:"nickname"`
+	HostAddress      string `json:"host_address" bson:"host_address"`
+	Port             int    `json:"port" bson:"port"`
+	ProvideAndroid   bool   `json:"provide_android" bson:"provide_android"`
+	ProvideAndroidTv bool   `json:"provide_androidtv" bson:"provide_androidtv"`
+	// Provide running Android emulators as ephemeral devices - discovered from `adb devices`,
+	// never registered in the DB, identity derived from the AVD name.
+	ProvideAndroidEmulators bool   `json:"provide_android_emulators" bson:"provide_android_emulators"`
+	ProvideIOS              bool   `json:"provide_ios" bson:"provide_ios"`
+	ProvideTizen            bool   `json:"provide_tizen" bson:"provide_tizen"`
+	ProvideWebOS            bool   `json:"provide_webos" bson:"provide_webos"`
+	ProvideRoku             bool   `json:"provide_roku" bson:"provide_roku"`
+	WdaBundleID             string `json:"wda_bundle_id" bson:"wda_bundle_id"`
+	WebDriverAgentIPA       string `json:"web_driver_agent_ipa" bson:"web_driver_agent_ipa"`
+	BroadcastIPA            string `json:"broadcast_ipa" bson:"broadcast_ipa"`
+	SupervisionPassword     string `json:"supervision_password" bson:"supervision_password"`
+	ProviderFolder          string `json:"-" bson:"-"`
+	LastUpdatedTimestamp    int64  `json:"last_updated" bson:"last_updated"`
+	UseGadsIosStream        bool   `json:"use_gads_ios_stream" bson:"use_gads_ios_stream"`
+	HubAddress              string `json:"hub_address" bson:"-"`
+	SetupAppiumServers      bool   `json:"setup_appium_servers" bson:"setup_appium_servers"`
+	TURNUsernameSuffix      string `json:"-" bson:"-"`
+	UseIOSPairCache         bool   `json:"-" bson:"-"`
 }
 
 // ProviderDeviceSync is the lightweight struct sent from provider to hub each second
@@ -56,14 +59,14 @@ type ProviderData struct {
 }
 
 type HubConfig struct {
-	HostAddress          string `json:"host_address"`
-	Port                 string `json:"port"`
-	MongoDB              string `json:"mongo_db"`
-	OSTempDir            string `json:"-"`
-	FilesTempDir         string `json:"-"`
-	OS                   string `json:"os"`
-	AuthEnabled          bool   `json:"auth_enabled"`
-	TURNUsernameSuffix   string `json:"-"`
+	HostAddress        string `json:"host_address"`
+	Port               string `json:"port"`
+	MongoDB            string `json:"mongo_db"`
+	OSTempDir          string `json:"-"`
+	FilesTempDir       string `json:"-"`
+	OS                 string `json:"os"`
+	AuthEnabled        bool   `json:"auth_enabled"`
+	TURNUsernameSuffix string `json:"-"`
 }
 
 type MinioConfig struct {

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -48,6 +48,8 @@ You have to provide all the required information and assign each device to a pro
 Changes to the device configuration require the respective provider instance restarted.  
 All fields have tooltips to help you with the required information.
 
+**Android emulators** are the exception - providers with `Provide Android emulators?` enabled discover and report running emulators automatically as ephemeral devices. They never appear in `Admin > Devices` (there is nothing to configure), show up in the device selection list with an emulator badge while running, and are removed within ~15 seconds after the emulator or its provider stops. See the [provider documentation](./provider.md#android-emulators) for details.
+
 ### Appium grid
 
 Using Selenium Grid 4 is a bit of a hassle and some versions do not work properly with Appium relay nodes.  

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -14,6 +14,7 @@ The provider component is responsible for setting up the Appium servers and mana
 - [Device Notes](#device-notes)
   - [iOS Phones](#ios-phones)
   - [Android](#android-phone)
+  - [Android Emulators](#android-emulators)
   - [Android TV](#android-tv)
   - [Tizen TV](#tizen-tv)
   - [WebOS TV](#webos-tv)
@@ -316,6 +317,18 @@ Note that it is possible that on some devices it might not work at all, in this 
 
 **NB** It is complex to handle both device encoder and browser decoder limitations, I would suggest using Chrome/Safari, but I assume that most of the time also Firefox should manage.  
 **NB** WebRTC video has some initial delay/latency while calculating the bitrate and connection capabilities when you access the device control.
+
+### Android Emulators
+
+GADS can provide running Android emulators as **ephemeral devices** - enable the `Provide Android emulators?` option in the provider configuration. The only dependency is `adb`, same as regular Android phones.
+
+- Emulators are discovered automatically from `adb devices` - **they are never registered in the database** and need no setup in `Admin > Devices`.
+- GADS adopts emulators, it does not manage them - boot and stop AVDs with Android Studio or the `emulator` command line as usual. A booted emulator appears in the device list shortly after boot, a stopped one disappears within ~15 seconds. The same applies when the provider itself stops - its emulators leave the device list within ~15 seconds.
+- Device identity is derived from the AVD name (`emu_<provider nickname>_<AVD name>`), not from the `emulator-5554` console serial - the same AVD keeps the same identity across reboots and port changes, on any number of ports.
+- Emulator devices always live in the **default workspace**, are named after their AVD and are shown with an emulator badge in the device list.
+- Because there is no database record, they cannot be edited in `Admin > Devices`. Usage is `enabled` (or `control` when the provider does not run Appium servers) and video streaming uses MJPEG.
+- Only one running instance of a given AVD is provided - a second instance of the same AVD (possible with `emulator -read-only`) is ignored with a warning in the provider log.
+- An emulator that was manually registered in the database under its raw `emulator-XXXX` serial (from before ephemeral support existed) keeps the regular database-device flow - delete the record to switch it to the ephemeral flow.
 
 ### Android TV
 

--- a/hub/devices/devices.go
+++ b/hub/devices/devices.go
@@ -38,6 +38,40 @@ func InitHubDevicesData() {
 	HubDeviceStore = NewDeviceStore()
 }
 
+// ephemeralDeviceExpiryMs is how long an ephemeral device stays in the store after
+// its provider stopped reporting it. Long enough to absorb a briefly hiccuping
+// provider update cycle, short enough that a killed emulator disappears promptly.
+const ephemeralDeviceExpiryMs = 15_000
+
+// RegisterEphemeralDevice creates a store entry for a device that exists only in
+// provider memory (no DB record), built entirely from the provider update payload.
+// Mirrors the store entry creation for DB devices in GetLatestDBDevices.
+func RegisterEphemeralDevice(providerDevice *models.ProviderDeviceSync, providerRunsAppium bool) *LocalHubDevice {
+	hubDevice := &LocalHubDevice{
+		Device:                   *providerDevice.EphemeralDevice,
+		IsRunningAutomation:      false,
+		IsAvailableForAutomation: true,
+		LastAutomationActionTS:   0,
+		AppiumEnabled:            providerRunsAppium,
+		Ephemeral:                true,
+		LastEphemeralReportTS:    time.Now().UnixMilli(),
+	}
+	HubDeviceStore.Set(hubDevice.Device.UDID, hubDevice)
+	return hubDevice
+}
+
+// RefreshEphemeralDevice updates an ephemeral device's descriptor from the latest
+// provider update and stamps its report timestamp so it does not expire.
+func RefreshEphemeralDevice(hubDevice *LocalHubDevice, providerDevice *models.ProviderDeviceSync, providerRunsAppium bool) {
+	hubDevice.Mu.Lock()
+	defer hubDevice.Mu.Unlock()
+	if providerDevice.EphemeralDevice != nil {
+		hubDevice.Device = *providerDevice.EphemeralDevice
+	}
+	hubDevice.AppiumEnabled = providerRunsAppium
+	hubDevice.LastEphemeralReportTS = time.Now().UnixMilli()
+}
+
 // Get the latest devices information from MongoDB each second
 func GetLatestDBDevices() {
 	var latestDBDevices []models.DBDevice
@@ -56,9 +90,20 @@ func GetLatestDBDevices() {
 			}
 		}
 
-		// Remove devices from the store that are no longer in the DB
+		// Remove devices from the store that are no longer in the DB. Ephemeral
+		// devices have no DB record - they expire instead when their provider
+		// stopped reporting them (killed emulator, dead provider)
 		var toDelete []string
 		for _, hubDevice := range HubDeviceStore.All() {
+			if hubDevice.Ephemeral {
+				hubDevice.Mu.RLock()
+				lastReportTS := hubDevice.LastEphemeralReportTS
+				hubDevice.Mu.RUnlock()
+				if time.Now().UnixMilli()-lastReportTS > ephemeralDeviceExpiryMs {
+					toDelete = append(toDelete, hubDevice.Device.UDID)
+				}
+				continue
+			}
 			found := false
 			for _, dbDevice := range latestDBDevices {
 				if dbDevice.UDID == hubDevice.Device.UDID {

--- a/hub/devices/hub_device.go
+++ b/hub/devices/hub_device.go
@@ -25,37 +25,42 @@ const (
 // LocalHubDevice represents a device as tracked by the hub at runtime.
 // All field access must be protected by Mu.
 type LocalHubDevice struct {
-	Mu                       sync.RWMutex  `json:"-" bson:"-"` // protects this device's fields
-	Device                   models.DBDevice `json:"info"`
+	Mu     sync.RWMutex    `json:"-" bson:"-"` // protects this device's fields
+	Device models.DBDevice `json:"info"`
 	// Runtime fields synced from provider
-	Host                     string        `json:"host"`
-	Connected                bool          `json:"connected"`
-	ProviderState            string        `json:"provider_state"`
-	LastUpdatedTimestamp      int64         `json:"last_updated_timestamp"`
-	SessionID                string        `json:"-"`
-	IsRunningAutomation      bool          `json:"is_running_automation"`
-	LastAutomationActionTS   int64         `json:"last_automation_action_ts"`
-	InUse                    bool          `json:"in_use"`
-	InUseBy                  string        `json:"in_use_by"`
-	InUseByTenant            string        `json:"in_use_by_tenant"`
-	InUseTS                  int64         `json:"in_use_ts"`
-	LockSource               string        `json:"lock_source" bson:"-"` // "ui", "api", or ""
-	LeaseExpiresAt           int64         `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
-	AppiumNewCommandTimeout  int64         `json:"appium_new_command_timeout"`
-	AutomationSessionStartTS int64         `json:"-" bson:"-"` // Unix ms when the current Appium grid session was created, 0 = no session
+	Host                     string `json:"host"`
+	Connected                bool   `json:"connected"`
+	ProviderState            string `json:"provider_state"`
+	LastUpdatedTimestamp     int64  `json:"last_updated_timestamp"`
+	SessionID                string `json:"-"`
+	IsRunningAutomation      bool   `json:"is_running_automation"`
+	LastAutomationActionTS   int64  `json:"last_automation_action_ts"`
+	InUse                    bool   `json:"in_use"`
+	InUseBy                  string `json:"in_use_by"`
+	InUseByTenant            string `json:"in_use_by_tenant"`
+	InUseTS                  int64  `json:"in_use_ts"`
+	LockSource               string `json:"lock_source" bson:"-"` // "ui", "api", or ""
+	LeaseExpiresAt           int64  `json:"-" bson:"-"`           // Unix ms, 0 = no active lease
+	AppiumNewCommandTimeout  int64  `json:"appium_new_command_timeout"`
+	AutomationSessionStartTS int64  `json:"-" bson:"-"` // Unix ms when the current Appium grid session was created, 0 = no session
 	// Appium session truth reported by the provider (via the appium-plugin) - only
 	// meaningful while ProviderReportsSessionState is true (older providers do not
 	// send these fields)
-	ProviderReportsSessionState  bool   `json:"-" bson:"-"`
-	ProviderHasSession           bool   `json:"provider_has_session" bson:"-"`
-	ProviderSessionID            string `json:"-" bson:"-"`
-	ProviderLastCommandTS        int64  `json:"provider_last_command_ts" bson:"-"`
-	ProviderSessionMissingSinceTS int64 `json:"-" bson:"-"` // Unix ms since the provider stopped reporting a session the hub still tracks, 0 = not missing
-	IsAvailableForAutomation bool          `json:"is_available_for_automation"`
-	AppiumEnabled            bool          `json:"appium_enabled" bson:"-"` // whether the device's provider runs Appium servers - devices without one can never serve automation
-	Available                bool          `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
-	InUseWSConnection        net.Conn      `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
-	LastActionTS             int64         `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
+	ProviderReportsSessionState   bool   `json:"-" bson:"-"`
+	ProviderHasSession            bool   `json:"provider_has_session" bson:"-"`
+	ProviderSessionID             string `json:"-" bson:"-"`
+	ProviderLastCommandTS         int64  `json:"provider_last_command_ts" bson:"-"`
+	ProviderSessionMissingSinceTS int64  `json:"-" bson:"-"` // Unix ms since the provider stopped reporting a session the hub still tracks, 0 = not missing
+	IsAvailableForAutomation      bool   `json:"is_available_for_automation"`
+	AppiumEnabled                 bool   `json:"appium_enabled" bson:"-"` // whether the device's provider runs Appium servers - devices without one can never serve automation
+	// Ephemeral marks a device with no DB record (e.g. an Android emulator) - its
+	// store entry is created and refreshed purely from provider updates and expires
+	// when the provider stops reporting it
+	Ephemeral             bool     `json:"ephemeral" bson:"-"`
+	LastEphemeralReportTS int64    `json:"-" bson:"-"`         // Unix ms of the last provider update that included this ephemeral device
+	Available             bool     `json:"available" bson:"-"` // if device is currently available - not only connected, but setup completed
+	InUseWSConnection     net.Conn `json:"-" bson:"-"`         // stores the ws connection made when device is in use to send data from different sources
+	LastActionTS          int64    `json:"-" bson:"-"`         // Timestamp of when was the last time an action was performed via the UI through the proxy to the provider
 }
 
 // All methods below assume the caller holds device.Mu.

--- a/hub/router/provider_update_test.go
+++ b/hub/router/provider_update_test.go
@@ -1,0 +1,153 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"GADS/common/models"
+	"GADS/hub/devices"
+)
+
+func postProviderUpdate(t *testing.T, payload models.ProviderData) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/provider-update", ProviderUpdate)
+
+	body, err := json.Marshal(payload)
+	assert.NoError(t, err)
+
+	req, _ := http.NewRequest("POST", "/provider-update", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestProviderUpdateEphemeralDevices(t *testing.T) {
+	emulatorUdid := "emu_test-provider_Pixel_8_API_35"
+
+	ephemeralSync := func() models.ProviderDeviceSync {
+		return models.ProviderDeviceSync{
+			UDID:          emulatorUdid,
+			Host:          "192.168.1.5:10001",
+			Connected:     true,
+			ProviderState: "live",
+			Ephemeral:     true,
+			EphemeralDevice: &models.DBDevice{
+				UDID:         emulatorUdid,
+				OS:           "android",
+				Name:         "Pixel_8_API_35",
+				OSVersion:    "15",
+				Provider:     "test-provider",
+				Usage:        "enabled",
+				DeviceType:   "emulator",
+				ScreenWidth:  "1080",
+				ScreenHeight: "2400",
+				WorkspaceID:  "default-workspace-id",
+			},
+		}
+	}
+
+	t.Run("unknown ephemeral device is upserted into the store", func(t *testing.T) {
+		defer devices.HubDeviceStore.Delete(emulatorUdid)
+
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: true},
+			DeviceData:   []models.ProviderDeviceSync{ephemeralSync()},
+		})
+
+		hubDevice, ok := devices.HubDeviceStore.Get(emulatorUdid)
+		assert.True(t, ok, "expected ephemeral device to be created in the store")
+		assert.True(t, hubDevice.Ephemeral)
+		assert.True(t, hubDevice.Connected)
+		assert.Equal(t, "live", hubDevice.ProviderState)
+		assert.Equal(t, "192.168.1.5:10001", hubDevice.Host)
+		assert.Equal(t, "Pixel_8_API_35", hubDevice.Device.Name)
+		assert.Equal(t, "emulator", hubDevice.Device.DeviceType)
+		assert.Equal(t, "default-workspace-id", hubDevice.Device.WorkspaceID)
+		assert.True(t, hubDevice.AppiumEnabled)
+		assert.NotZero(t, hubDevice.LastEphemeralReportTS)
+	})
+
+	t.Run("subsequent update refreshes descriptor and report timestamp", func(t *testing.T) {
+		defer devices.HubDeviceStore.Delete(emulatorUdid)
+
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: true},
+			DeviceData:   []models.ProviderDeviceSync{ephemeralSync()},
+		})
+		hubDevice, ok := devices.HubDeviceStore.Get(emulatorUdid)
+		assert.True(t, ok)
+		firstReportTS := hubDevice.LastEphemeralReportTS
+
+		// Screen size is detected during device setup on the provider, so a later
+		// update can carry dimensions the initial one did not have yet
+		updated := ephemeralSync()
+		updated.EphemeralDevice.ScreenWidth = "1440"
+		updated.EphemeralDevice.ScreenHeight = "3120"
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: true},
+			DeviceData:   []models.ProviderDeviceSync{updated},
+		})
+
+		hubDevice, ok = devices.HubDeviceStore.Get(emulatorUdid)
+		assert.True(t, ok)
+		assert.Equal(t, "1440", hubDevice.Device.ScreenWidth)
+		assert.GreaterOrEqual(t, hubDevice.LastEphemeralReportTS, firstReportTS)
+	})
+
+	t.Run("provider without Appium servers yields AppiumEnabled false", func(t *testing.T) {
+		defer devices.HubDeviceStore.Delete(emulatorUdid)
+
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: false},
+			DeviceData:   []models.ProviderDeviceSync{ephemeralSync()},
+		})
+
+		hubDevice, ok := devices.HubDeviceStore.Get(emulatorUdid)
+		assert.True(t, ok)
+		assert.False(t, hubDevice.AppiumEnabled)
+	})
+
+	t.Run("unknown non-ephemeral device is still skipped", func(t *testing.T) {
+		unknownUdid := "unknown-real-device"
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: true},
+			DeviceData: []models.ProviderDeviceSync{{
+				UDID:          unknownUdid,
+				Connected:     true,
+				ProviderState: "live",
+			}},
+		})
+
+		_, ok := devices.HubDeviceStore.Get(unknownUdid)
+		assert.False(t, ok, "non-ephemeral unknown device must not be upserted")
+	})
+
+	t.Run("ephemeral flag without descriptor does not create an entry", func(t *testing.T) {
+		malformed := ephemeralSync()
+		malformed.EphemeralDevice = nil
+		postProviderUpdate(t, models.ProviderData{
+			ProviderData: models.Provider{Nickname: "test-provider", SetupAppiumServers: true},
+			DeviceData:   []models.ProviderDeviceSync{malformed},
+		})
+
+		_, ok := devices.HubDeviceStore.Get(emulatorUdid)
+		assert.False(t, ok, "ephemeral device without a descriptor must be skipped")
+	})
+}

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1566,7 +1566,15 @@ func ProviderUpdate(c *gin.Context) {
 		providerDevice := &providerDeviceData.DeviceData[i]
 		hubDevice, ok := devices.HubDeviceStore.Get(providerDevice.UDID)
 		if !ok {
-			continue
+			// Ephemeral devices have no DB record, so the store entry is created
+			// from the provider payload instead of the DB reconciliation loop
+			if providerDevice.Ephemeral && providerDevice.EphemeralDevice != nil {
+				hubDevice = devices.RegisterEphemeralDevice(providerDevice, providerDeviceData.ProviderData.SetupAppiumServers)
+			} else {
+				continue
+			}
+		} else if providerDevice.Ephemeral {
+			devices.RefreshEphemeralDevice(hubDevice, providerDevice, providerDeviceData.ProviderData.SetupAppiumServers)
 		}
 		hubDevice.Mu.Lock()
 		// If device is not connected reset all fields that might allow it to get stuck in Running automation state

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -652,6 +652,12 @@ func (d *AndroidDevice) updateScreenSizeADB() error {
 		d.DBDevice.ScreenHeight = strings.TrimSpace(screenDimensions[1])
 	}
 
+	// Ephemeral devices are never persisted - the detected dimensions live on the
+	// in-memory DBDevice only
+	if d.IsEphemeral() {
+		return nil
+	}
+
 	if err := db.GlobalMongoStore.AddOrUpdateDevice(&d.DBDevice); err != nil {
 		return fmt.Errorf("Failed to upsert new device screen dimensions to DB - %s", err)
 	}

--- a/provider/devices/android.go
+++ b/provider/devices/android.go
@@ -309,7 +309,7 @@ func (d *AndroidDevice) setupAppiumIfNeeded() error {
 // AppiumCapabilities returns the Android-specific Appium server capabilities.
 func (d *AndroidDevice) AppiumCapabilities() models.AppiumServerCapabilities {
 	return models.AppiumServerCapabilities{
-		UDID:           d.GetUDID(),
+		UDID:           d.GetSerial(),
 		AutomationName: "UiAutomator2",
 		PlatformName:   "Android",
 		DeviceName:     d.DBDevice.Name,
@@ -349,7 +349,7 @@ func (d *AndroidDevice) androidRemoteServerRequest(method, endpoint string, requ
 }
 
 func (d *AndroidDevice) isStreamServiceRunning() (bool, error) {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "dumpsys", "activity", "services", d.getStreamServiceName())
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "dumpsys", "activity", "services", d.getStreamServiceName())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("isStreamServiceRunning: Error executing `%s` with combined output - %s", cmd.Args, err)
@@ -361,7 +361,7 @@ func (d *AndroidDevice) isStreamServiceRunning() (bool, error) {
 }
 
 func (d *AndroidDevice) stopStreamService() {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "am", "stopservice", d.getStreamServiceName())
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "am", "stopservice", d.getStreamServiceName())
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogWarnf("android_device_setup", "Failed to stop GADS-stream service properly - %s", err)
 	}
@@ -369,7 +369,7 @@ func (d *AndroidDevice) stopStreamService() {
 
 func (d *AndroidDevice) installGadsSettingsApp() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Installing GADS Settings apk on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "install", "-r", fmt.Sprintf("%s/gads-settings.apk", config.ProviderConfig.ProviderFolder))
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "install", "-r", fmt.Sprintf("%s/gads-settings.apk", config.ProviderConfig.ProviderFolder))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("installGadsSettingsApp: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -378,7 +378,7 @@ func (d *AndroidDevice) installGadsSettingsApp() error {
 
 func (d *AndroidDevice) pushGadsSettingsInTmpLocal() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Pushing GADS Settings apk to /tmp/local on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "push", fmt.Sprintf("%s/gads-settings.apk", config.ProviderConfig.ProviderFolder), "/data/local/tmp/gads-settings")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "push", fmt.Sprintf("%s/gads-settings.apk", config.ProviderConfig.ProviderFolder), "/data/local/tmp/gads-settings")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("pushGadsSettingsInTmpLocal: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -386,11 +386,11 @@ func (d *AndroidDevice) pushGadsSettingsInTmpLocal() error {
 }
 
 func (d *AndroidDevice) startRemoteControlServer() {
-	killCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "pkill -f RemoteControlServerKt")
+	killCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "pkill -f RemoteControlServerKt")
 	_ = killCmd.Run()
 	time.Sleep(1 * time.Second)
 
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"CLASSPATH=/data/local/tmp/gads-settings app_process / com.shamanec.settings.RemoteControlServerKt 1994")
 
 	if err := cmd.Start(); err != nil {
@@ -405,11 +405,11 @@ func (d *AndroidDevice) startRemoteControlServer() {
 }
 
 func (d *AndroidDevice) startH264Stream() {
-	killCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "pkill -f H264Server")
+	killCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "pkill -f H264Server")
 	_ = killCmd.Run()
 	time.Sleep(1 * time.Second)
 
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"CLASSPATH=/data/local/tmp/gads-settings app_process / com.shamanec.settings.server.H264Server")
 
 	if err := cmd.Start(); err != nil {
@@ -425,14 +425,14 @@ func (d *AndroidDevice) startH264Stream() {
 
 func (d *AndroidDevice) setupIME() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Enabling GADS Android IME on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "ime", "enable", "com.gads.settings/com.shamanec.settings.RemoteKeyboardIME")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "ime", "enable", "com.gads.settings/com.shamanec.settings.RemoteKeyboardIME")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("enableGadsAndroidIME: Error executing `%s` - %s", cmd.Args, err)
 	}
 	time.Sleep(1 * time.Second)
 
 	logger.ProviderLogger.LogInfof("android_device_setup", "Setting GADS Android IME as active on device `%v`", d.GetUDID())
-	cmd = exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "ime", "set", "com.gads.settings/com.shamanec.settings.RemoteKeyboardIME")
+	cmd = exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "ime", "set", "com.gads.settings/com.shamanec.settings.RemoteKeyboardIME")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setGadsAndroidIMEAsActive: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -441,7 +441,7 @@ func (d *AndroidDevice) setupIME() error {
 
 func (d *AndroidDevice) addStreamRecordingPermissions() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Adding GADS-stream recording permissions on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "appops", "set", d.getStreamServicePackageName(), "PROJECT_MEDIA", "allow")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "appops", "set", d.getStreamServicePackageName(), "PROJECT_MEDIA", "allow")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("addStreamRecordingPermissions: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -450,7 +450,7 @@ func (d *AndroidDevice) addStreamRecordingPermissions() error {
 
 func (d *AndroidDevice) addStreamPostNotificationsPermission() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Adding GADS app post notification permissions on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "pm", "grant", d.getStreamServicePackageName(), "android.permission.POST_NOTIFICATIONS")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "pm", "grant", d.getStreamServicePackageName(), "android.permission.POST_NOTIFICATIONS")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("addStreamPostNotificationsPermission: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -459,7 +459,7 @@ func (d *AndroidDevice) addStreamPostNotificationsPermission() error {
 
 func (d *AndroidDevice) startStreaming() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Starting GADS-stream app on `%s`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "am", "start", "-n", d.getStreamServiceActivityName())
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "am", "start", "-n", d.getStreamServiceActivityName())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("startStreaming: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -467,14 +467,14 @@ func (d *AndroidDevice) startStreaming() error {
 }
 
 func (d *AndroidDevice) pressHomeButton() {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "input", "keyevent", "KEYCODE_HOME")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "input", "keyevent", "KEYCODE_HOME")
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogErrorf("android_device_setup", "pressHomeButton: Could not 'press' Home button - %v", err)
 	}
 }
 
 func (d *AndroidDevice) forwardPort(devicePort, hostPort string) error {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "forward", "tcp:"+hostPort, "tcp:"+devicePort)
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "forward", "tcp:"+hostPort, "tcp:"+devicePort)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("forwardPort: Error forwarding device port %s to host port %s - %s", devicePort, hostPort, err)
 	}
@@ -486,7 +486,7 @@ func (d *AndroidDevice) removeForwardedPort(hostPort string) {
 		return
 	}
 	// Use context.Background - d.Context may already be cancelled during Reset.
-	cmd := exec.CommandContext(context.Background(), "adb", "-s", d.GetUDID(), "forward", "--remove", "tcp:"+hostPort)
+	cmd := exec.CommandContext(context.Background(), "adb", "-s", d.GetSerial(), "forward", "--remove", "tcp:"+hostPort)
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogDebugf("android_device_setup", "removeForwardedPort: Could not remove `adb` forward for host port %s, device `%v`, - %s", hostPort, d.GetUDID(), err)
 	}
@@ -554,7 +554,7 @@ func (d *AndroidDevice) audioServiceComponent() string {
 // grantRecordAudioPermission grants RECORD_AUDIO to the GADS settings app. Required
 // whenever a foreground service declares a foregroundServiceType containing "microphone".
 func (d *AndroidDevice) grantRecordAudioPermission() {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"pm", "grant", d.getStreamServicePackageName(), "android.permission.RECORD_AUDIO")
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogWarnf("android_device_setup", "Could not grant RECORD_AUDIO to %s for device `%v` - %v", d.getStreamServicePackageName(), d.GetUDID(), err)
@@ -566,7 +566,7 @@ func (d *AndroidDevice) grantRecordAudioPermission() {
 func (d *AndroidDevice) startAudioService() {
 	d.grantRecordAudioPermission()
 
-	stopCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	stopCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"am", "stopservice", "-n", d.audioServiceComponent())
 	_ = stopCmd.Run()
 
@@ -574,7 +574,7 @@ func (d *AndroidDevice) startAudioService() {
 	if audioInputType == "" {
 		audioInputType = "internal"
 	}
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"am", "start-foreground-service", "-n", d.audioServiceComponent(),
 		"--es", "audio_input_type", audioInputType)
 	if err := cmd.Run(); err != nil {
@@ -585,7 +585,7 @@ func (d *AndroidDevice) startAudioService() {
 // startAudioProjectionActivity shows the system MediaProjection dialog; on approval the token
 // is stored in MediaProjectionHolder for AudioService's internal AudioPlaybackCapture.
 func (d *AndroidDevice) startAudioProjectionActivity() {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell",
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell",
 		"am", "start", "-n", d.getStreamServicePackageName()+"/com.shamanec.settings.audio.AudioProjectionActivity")
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogWarnf("android_device_setup", "Could not start AudioProjectionActivity for device `%v` - %v", d.GetUDID(), err)
@@ -595,7 +595,7 @@ func (d *AndroidDevice) startAudioProjectionActivity() {
 // disableKeyguard disables the device lock screen via adb locksettings.
 func (d *AndroidDevice) disableKeyguard() {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Disabling keyguard on Android 15+ device `%v` to keep MediaProjection capture alive on lock", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "locksettings", "set-disabled", "true")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "locksettings", "set-disabled", "true")
 	if err := cmd.Run(); err != nil {
 		logger.ProviderLogger.LogWarnf("android_device_setup", "Could not disable keyguard for device `%v` - %v", d.GetUDID(), err)
 	}
@@ -603,7 +603,7 @@ func (d *AndroidDevice) disableKeyguard() {
 
 func (d *AndroidDevice) enableADBTCPMode() error {
 	// Check if tcpip mode is already enabled to avoid restarting adbd unnecessarily
-	checkCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "getprop", "service.adb.tcp.port")
+	checkCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "getprop", "service.adb.tcp.port")
 	var outBuffer bytes.Buffer
 	checkCmd.Stdout = &outBuffer
 	if err := checkCmd.Run(); err == nil {
@@ -614,7 +614,7 @@ func (d *AndroidDevice) enableADBTCPMode() error {
 	}
 
 	logger.ProviderLogger.LogInfof("android_device_setup", "Enabling ADB TCP mode on device `%v`", d.GetUDID())
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "tcpip", adbTCPPort)
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "tcpip", adbTCPPort)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("enableADBTCPMode: Error executing `%s` - %s", cmd.Args, err)
 	}
@@ -631,7 +631,7 @@ func (d *AndroidDevice) updateScreenSizeADB() error {
 	logger.ProviderLogger.LogInfof("android_device_setup", "Attempting to automatically update the screen size for device `%v`", d.GetUDID())
 
 	var outBuffer bytes.Buffer
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "wm", "size")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "wm", "size")
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("updateScreenSizeADB: Error executing `%s` - %s", cmd.Args, err)
@@ -661,7 +661,7 @@ func (d *AndroidDevice) updateScreenSizeADB() error {
 // GetInstalledAppBundleIDs returns the bundle identifiers (package names) of third-party installed apps.
 func (d *AndroidDevice) GetInstalledAppBundleIDs() []string {
 	installedApps := make([]string, 0)
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "cmd", "package", "list", "packages", "-3")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "cmd", "package", "list", "packages", "-3")
 
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
@@ -706,7 +706,7 @@ func (d *AndroidDevice) GetInstalledApps() ([]models.DeviceApp, error) {
 
 // UninstallApp uninstalls an app by package name.
 func (d *AndroidDevice) UninstallApp(packageName string) error {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "uninstall", packageName)
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "uninstall", packageName)
 	if err := cmd.Run(); err != nil {
 		d.Logger.LogErrorf("uninstall_app", "Error uninstalling app `%s` - %v", packageName, err)
 		return err
@@ -716,7 +716,7 @@ func (d *AndroidDevice) UninstallApp(packageName string) error {
 
 // InstallApp installs an app from a file in the provider folder.
 func (d *AndroidDevice) InstallApp(appName string) error {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "install", "-r", fmt.Sprintf("%s/%s", config.ProviderConfig.ProviderFolder, appName))
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "install", "-r", fmt.Sprintf("%s/%s", config.ProviderConfig.ProviderFolder, appName))
 	if err := cmd.Run(); err != nil {
 		d.Logger.LogErrorf("install_app", "Error installing app `%s` - %v", appName, err)
 		return err
@@ -725,7 +725,7 @@ func (d *AndroidDevice) InstallApp(appName string) error {
 }
 
 func (d *AndroidDevice) disableAutoRotation() error {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "settings", "put", "system", "accelerometer_rotation", "0")
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "settings", "put", "system", "accelerometer_rotation", "0")
 	if err := cmd.Run(); err != nil {
 		return err
 	}
@@ -844,7 +844,7 @@ func (d *AndroidDevice) GetHardwareModel() (string, error) {
 }
 
 func (d *AndroidDevice) getHardwareModel() {
-	brandCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "getprop", "ro.product.brand")
+	brandCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "getprop", "ro.product.brand")
 	var outBuffer bytes.Buffer
 	brandCmd.Stdout = &outBuffer
 	if err := brandCmd.Run(); err != nil {
@@ -853,7 +853,7 @@ func (d *AndroidDevice) getHardwareModel() {
 	brand := outBuffer.String()
 	outBuffer.Reset()
 
-	modelCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "getprop", "ro.product.model")
+	modelCmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "getprop", "ro.product.model")
 	modelCmd.Stdout = &outBuffer
 	if err := modelCmd.Run(); err != nil {
 		d.HardwareModel = "Unknown"
@@ -868,7 +868,7 @@ func (d *AndroidDevice) getHardwareModel() {
 // ActiveDisplayID is set to the first display if it has not been set yet.
 // A failure is non-fatal — the device falls back to screencap without -d.
 func (d *AndroidDevice) fetchAndSetDisplays() {
-	displays, err := getAndroidDisplayIDs(d.GetUDID())
+	displays, err := getAndroidDisplayIDs(d.GetSerial())
 	if err != nil {
 		logger.ProviderLogger.LogWarnf("android_device_setup", "Could not detect displays for device `%s`: %s", d.GetUDID(), err)
 		return
@@ -906,9 +906,9 @@ func (d *AndroidDevice) GetAvailableDisplays() []models.AndroidDisplay {
 }
 
 // getAndroidDisplayIDs runs dumpsys SurfaceFlinger --display-id and returns parsed displays.
-func getAndroidDisplayIDs(udid string) ([]models.AndroidDisplay, error) {
+func getAndroidDisplayIDs(serial string) ([]models.AndroidDisplay, error) {
 	var out bytes.Buffer
-	cmd := exec.Command("adb", "-s", udid, "shell", "dumpsys", "SurfaceFlinger", "--display-id")
+	cmd := exec.Command("adb", "-s", serial, "shell", "dumpsys", "SurfaceFlinger", "--display-id")
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("dumpsys SurfaceFlinger --display-id: %w", err)
@@ -963,7 +963,7 @@ func (d *AndroidDevice) LaunchApp(bundleID string) error {
 
 // KillApp force-stops an Android app by package name.
 func (d *AndroidDevice) KillApp(bundleIdentifier string) error {
-	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetUDID(), "shell", "am", "force-stop", bundleIdentifier)
+	cmd := exec.CommandContext(d.Context, "adb", "-s", d.GetSerial(), "shell", "am", "force-stop", bundleIdentifier)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("KillApp: Failed killing app with package name `%s` via adb shell", bundleIdentifier)
 	}
@@ -975,15 +975,15 @@ func (d *AndroidDevice) ApplyStreamSettings() error {
 	return applyDeviceStreamSettings(d)
 }
 
-func DeleteAndroidSharedStorageFile(device *models.DBDevice, filePath string) error {
-	deleteFileCmd := exec.Command("adb", "-s", device.UDID, "shell", "rm", fmt.Sprintf("\"%s\"", filePath))
+func DeleteAndroidSharedStorageFile(serial string, filePath string) error {
+	deleteFileCmd := exec.Command("adb", "-s", serial, "shell", "rm", fmt.Sprintf("\"%s\"", filePath))
 	_, err := deleteFileCmd.Output()
 	return err
 }
 
-func PullAndroidSharedStorageFile(device *models.DBDevice, filePath string, fileName string) (string, error) {
+func PullAndroidSharedStorageFile(serial string, filePath string, fileName string) (string, error) {
 	var tempFilePath = filepath.Join(os.TempDir(), fileName)
-	pullFileCmd := exec.Command("adb", "-s", device.UDID, "pull", filePath, tempFilePath)
+	pullFileCmd := exec.Command("adb", "-s", serial, "pull", filePath, tempFilePath)
 	_, err := pullFileCmd.Output()
 	return tempFilePath, err
 }
@@ -994,23 +994,23 @@ var (
 )
 
 // cooldown of 30s prevents reconnect spam on each 1-second polling tick
-func reconnectOfflineAndroid(udid string) {
+func reconnectOfflineAndroid(serial string) {
 	const cooldown = 30 * time.Second
 
 	androidOfflineReconnectMu.Lock()
-	if last, ok := androidOfflineReconnectAt[udid]; ok && time.Since(last) < cooldown {
+	if last, ok := androidOfflineReconnectAt[serial]; ok && time.Since(last) < cooldown {
 		androidOfflineReconnectMu.Unlock()
 		return
 	}
-	androidOfflineReconnectAt[udid] = time.Now()
+	androidOfflineReconnectAt[serial] = time.Now()
 	androidOfflineReconnectMu.Unlock()
 
-	logger.ProviderLogger.LogInfof("android_reconnect", "Device %s is offline in ADB, attempting reconnect", udid)
-	cmd := exec.CommandContext(context.Background(), "adb", "-s", udid, "reconnect")
+	logger.ProviderLogger.LogInfof("android_reconnect", "Device %s is offline in ADB, attempting reconnect", serial)
+	cmd := exec.CommandContext(context.Background(), "adb", "-s", serial, "reconnect")
 	if err := cmd.Run(); err != nil {
-		logger.ProviderLogger.LogErrorf("android_reconnect", "Failed to reconnect device %s: %v", udid, err)
+		logger.ProviderLogger.LogErrorf("android_reconnect", "Failed to reconnect device %s: %v", serial, err)
 	} else {
-		logger.ProviderLogger.LogInfof("android_reconnect", "Reconnect issued for device %s", udid)
+		logger.ProviderLogger.LogInfof("android_reconnect", "Reconnect issued for device %s", serial)
 	}
 }
 

--- a/provider/devices/android_emulator.go
+++ b/provider/devices/android_emulator.go
@@ -23,10 +23,8 @@ import (
 	"GADS/provider/logger"
 )
 
-// Emulators default to the H264 WebRTC stream as the most capable path. If live
-// testing shows the app_process H264 capture does not work on emulators, flip this
-// to models.MJPEGStreamTypeId (MJPEG through the GADS-Settings service).
-const emulatorDefaultStreamType = models.AndroidWebRTCGadsH264StreamTypeId
+// Emulators stream MJPEG through the GADS-Settings service
+const emulatorDefaultStreamType = models.MJPEGStreamTypeId
 
 // emulatorSerialRegex matches adb console-port serials like `emulator-5554`.
 var emulatorSerialRegex = regexp.MustCompile(`^emulator-\d+$`)

--- a/provider/devices/android_emulator.go
+++ b/provider/devices/android_emulator.go
@@ -1,0 +1,242 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver"
+
+	"GADS/common/db"
+	"GADS/common/models"
+	"GADS/provider/config"
+	"GADS/provider/logger"
+)
+
+// Emulators default to the H264 WebRTC stream as the most capable path. If live
+// testing shows the app_process H264 capture does not work on emulators, flip this
+// to models.MJPEGStreamTypeId (MJPEG through the GADS-Settings service).
+const emulatorDefaultStreamType = models.AndroidWebRTCGadsH264StreamTypeId
+
+// emulatorSerialRegex matches adb console-port serials like `emulator-5554`.
+var emulatorSerialRegex = regexp.MustCompile(`^emulator-\d+$`)
+
+// emulatorAvdNames caches serial → AVD name so `adb emu avd name` runs once per
+// emulator boot instead of on every 1s tick. Accessed only from the updateDevices
+// goroutine, so no locking is needed.
+var emulatorAvdNames = map[string]string{}
+
+// emulatorDuplicateWarned tracks serials already reported as a second running
+// instance of an AVD so the warning is logged once per boot, not every tick.
+var emulatorDuplicateWarned = map[string]bool{}
+
+// reconcileAndroidEmulators translates connected emulator serials into ephemeral
+// devices keyed by AVD-derived UDIDs and returns the connected list with those
+// serials replaced by the synthesized UDIDs, so the regular matching in
+// updateDevices works unchanged. Ephemeral devices whose emulator disappeared
+// from adb are removed from DevManager entirely - unlike DB devices, which stay
+// visible as disconnected, an ephemeral device's existence is its connection.
+func reconcileAndroidEmulators(connectedDevices []string) []string {
+	reconciled := make([]string, 0, len(connectedDevices))
+	// Every emulator serial present in the adb listing this tick, used to expire
+	// devices and caches for emulators that are gone
+	seenSerials := map[string]bool{}
+	// AVD names already mapped to a serial this tick, to catch a second running
+	// instance of the same AVD (possible with `emulator -read-only`)
+	claimedAvds := map[string]string{}
+
+	for _, entry := range connectedDevices {
+		if !emulatorSerialRegex.MatchString(entry) {
+			reconciled = append(reconciled, entry)
+			continue
+		}
+		serial := entry
+		seenSerials[serial] = true
+
+		// An emulator registered in the DB under its raw serial keeps the regular
+		// DB-device flow - it was set up that way before ephemeral support existed
+		if platDev, exists := DevManager.Get(serial); exists && !platDev.IsEphemeral() {
+			reconciled = append(reconciled, serial)
+			continue
+		}
+
+		avdName, err := resolveEmulatorAvdName(serial)
+		if err != nil {
+			logger.ProviderLogger.LogDebugf("emulator_discovery", "Could not resolve AVD name for `%s`, will retry on next tick - %v", serial, err)
+			continue
+		}
+
+		if claimedSerial, claimed := claimedAvds[avdName]; claimed {
+			if !emulatorDuplicateWarned[serial] {
+				emulatorDuplicateWarned[serial] = true
+				logger.ProviderLogger.LogWarnf("emulator_discovery", "AVD `%s` is running as both `%s` and `%s` - ignoring `%s`, only one instance of an AVD can be provided", avdName, claimedSerial, serial, serial)
+			}
+			continue
+		}
+		claimedAvds[avdName] = serial
+
+		udid, err := ensureEmulatorDevice(serial, avdName)
+		if err != nil {
+			logger.ProviderLogger.LogErrorf("emulator_discovery", "Failed to initialize device for emulator `%s` (AVD `%s`) - %v", serial, avdName, err)
+			continue
+		}
+		reconciled = append(reconciled, udid)
+	}
+
+	for _, platDev := range DevManager.All() {
+		if !platDev.IsEphemeral() {
+			continue
+		}
+		if !seenSerials[platDev.GetSerial()] {
+			logger.ProviderLogger.LogInfof("emulator_discovery", "Emulator `%s` (device `%s`) is no longer connected, removing device", platDev.GetSerial(), platDev.GetUDID())
+			platDev.Reset("Emulator is no longer connected.")
+			DevManager.Delete(platDev.GetUDID())
+		}
+	}
+
+	for serial := range emulatorAvdNames {
+		if !seenSerials[serial] {
+			delete(emulatorAvdNames, serial)
+			delete(emulatorDuplicateWarned, serial)
+		}
+	}
+
+	return reconciled
+}
+
+// ensureEmulatorDevice returns the synthesized UDID for the given emulator,
+// creating and registering the ephemeral device if this AVD has no device yet.
+func ensureEmulatorDevice(serial string, avdName string) (string, error) {
+	udid := fmt.Sprintf("emu_%s_%s", config.ProviderConfig.Nickname, avdName)
+
+	if platDev, exists := DevManager.Get(udid); exists {
+		// Same AVD re-appeared on a different console port - retarget the transport id
+		if andDev, ok := platDev.(*AndroidDevice); ok && andDev.Serial != serial {
+			logger.ProviderLogger.LogInfof("emulator_discovery", "Emulator for AVD `%s` moved from `%s` to `%s`", avdName, andDev.Serial, serial)
+			andDev.Serial = serial
+		}
+		return udid, nil
+	}
+
+	osVersion, err := getEmulatorOSVersion(serial)
+	if err != nil {
+		return "", fmt.Errorf("could not detect OS version - %v", err)
+	}
+
+	usage := "enabled"
+	if !config.ProviderConfig.SetupAppiumServers {
+		// Same rule syncDevicesToDB applies to DB devices - no Appium servers means control-only
+		usage = "control"
+	}
+
+	// Ephemeral devices always live in the default workspace - there is no DB
+	// record an admin could move to another one
+	workspaceID := ""
+	if defaultWorkspace, err := db.GlobalMongoStore.GetDefaultWorkspace(); err == nil {
+		workspaceID = defaultWorkspace.ID
+	} else {
+		logger.ProviderLogger.LogWarnf("emulator_discovery", "Could not resolve default workspace for emulator device `%s` - %v", udid, err)
+	}
+
+	dbDevice := &models.DBDevice{
+		UDID:        udid,
+		OS:          "android",
+		Name:        avdName,
+		OSVersion:   osVersion,
+		Provider:    config.ProviderConfig.Nickname,
+		Usage:       usage,
+		DeviceType:  "emulator",
+		StreamType:  emulatorDefaultStreamType,
+		WorkspaceID: workspaceID,
+	}
+
+	platDev, err := createPlatformDevice(dbDevice)
+	if err != nil {
+		return "", err
+	}
+	andDev, ok := platDev.(*AndroidDevice)
+	if !ok {
+		return "", fmt.Errorf("device for emulator `%s` is not an AndroidDevice", serial)
+	}
+	// Mark the device before registering it so it is never visible in DevManager
+	// unmarked - the DB sync loop would otherwise remove it as not-in-DB
+	andDev.Serial = serial
+	andDev.Ephemeral = true
+	DevManager.Set(udid, platDev)
+
+	logger.ProviderLogger.LogInfof("emulator_discovery", "Discovered emulator `%s` (AVD `%s`, Android %s), providing it as device `%s`", serial, avdName, osVersion, udid)
+	return udid, nil
+}
+
+// resolveEmulatorAvdName returns the AVD name backing the emulator with the given
+// serial, cached per serial for the lifetime of the emulator connection.
+func resolveEmulatorAvdName(serial string) (string, error) {
+	if avdName, cached := emulatorAvdNames[serial]; cached {
+		return avdName, nil
+	}
+
+	out, err := exec.Command("adb", "-s", serial, "emu", "avd", "name").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("`adb emu avd name` failed - %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	avdName := parseAvdNameOutput(string(out))
+	if avdName == "" {
+		return "", fmt.Errorf("`adb emu avd name` returned no name (output: `%s`)", strings.TrimSpace(string(out)))
+	}
+
+	emulatorAvdNames[serial] = avdName
+	return avdName, nil
+}
+
+// parseAvdNameOutput extracts the AVD name from `adb emu avd name` output - the
+// name on its own line followed by an `OK` line. Returns "" if no name is found.
+func parseAvdNameOutput(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && line != "OK" {
+			return line
+		}
+	}
+	return ""
+}
+
+// getEmulatorOSVersion returns a semver-parsable Android version for the emulator.
+// Preview builds report a codename (e.g. `Baklava`) instead of a number as the
+// release version - fall back to the numeric API level for those.
+func getEmulatorOSVersion(serial string) (string, error) {
+	release, err := getEmulatorProp(serial, "ro.build.version.release")
+	if err != nil {
+		return "", err
+	}
+	if _, err := semver.NewVersion(release); err == nil {
+		return release, nil
+	}
+
+	sdk, err := getEmulatorProp(serial, "ro.build.version.sdk")
+	if err != nil {
+		return "", fmt.Errorf("release version `%s` is not semver-parsable and reading the API level failed - %v", release, err)
+	}
+	return sdk, nil
+}
+
+func getEmulatorProp(serial string, property string) (string, error) {
+	out, err := exec.Command("adb", "-s", serial, "shell", "getprop", property).Output()
+	if err != nil {
+		return "", fmt.Errorf("`getprop %s` failed - %v", property, err)
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", fmt.Errorf("`getprop %s` returned an empty value", property)
+	}
+	return value, nil
+}

--- a/provider/devices/android_emulator_test.go
+++ b/provider/devices/android_emulator_test.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of GADS.
+ *
+ * Copyright (c) 2022-2025 Nikola Shabanov
+ *
+ * This source code is licensed under the GNU Affero General Public License v3.0.
+ * You may obtain a copy of the license at https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+package devices
+
+import "testing"
+
+func TestParseAvdNameOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name:     "name followed by OK",
+			output:   "Pixel_8_API_35\nOK\n",
+			expected: "Pixel_8_API_35",
+		},
+		{
+			name:     "windows line endings",
+			output:   "Pixel_8_API_35\r\nOK\r\n",
+			expected: "Pixel_8_API_35",
+		},
+		{
+			name:     "leading blank line",
+			output:   "\nPixel_8_API_35\nOK\n",
+			expected: "Pixel_8_API_35",
+		},
+		{
+			name:     "only OK",
+			output:   "OK\n",
+			expected: "",
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseAvdNameOutput(test.output); got != test.expected {
+				t.Errorf("parseAvdNameOutput(%q) = %q, expected %q", test.output, got, test.expected)
+			}
+		})
+	}
+}
+
+func TestEmulatorSerialRegex(t *testing.T) {
+	matching := []string{"emulator-5554", "emulator-5556", "emulator-12345"}
+	nonMatching := []string{"R58M123ABC", "192.168.1.10:5555", "emulator-", "emulator-5554x", "myemulator-5554"}
+
+	for _, serial := range matching {
+		if !emulatorSerialRegex.MatchString(serial) {
+			t.Errorf("expected `%s` to match the emulator serial pattern", serial)
+		}
+	}
+	for _, serial := range nonMatching {
+		if emulatorSerialRegex.MatchString(serial) {
+			t.Errorf("expected `%s` to NOT match the emulator serial pattern", serial)
+		}
+	}
+}

--- a/provider/devices/androidtv.go
+++ b/provider/devices/androidtv.go
@@ -95,7 +95,7 @@ func (d *AndroidTvDevice) getTVInfo() {
 }
 
 func (d *AndroidTvDevice) getProp(prop string) string {
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "getprop", prop)
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "shell", "getprop", prop)
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
@@ -108,7 +108,7 @@ func (d *AndroidTvDevice) getProp(prop string) string {
 // InstallApp installs an app on the Android TV device.
 func (d *AndroidTvDevice) InstallApp(appName string) error {
 	appPath := fmt.Sprintf("%s/%s", config.ProviderConfig.ProviderFolder, appName)
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "install", "-r", appPath)
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "install", "-r", appPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to install app %s: %s. Output: %s", appName, err, string(output))
@@ -118,7 +118,7 @@ func (d *AndroidTvDevice) InstallApp(appName string) error {
 
 // UninstallApp uninstalls an app from the Android TV device.
 func (d *AndroidTvDevice) UninstallApp(packageName string) error {
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "uninstall", packageName)
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "uninstall", packageName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to uninstall app %s: %s. Output: %s", packageName, err, string(output))
@@ -151,7 +151,7 @@ type androidTvPackage struct {
 func (d *AndroidTvDevice) getInstalledAppsAndroidTv() []androidTvPackage {
 	installedApps := make([]androidTvPackage, 0)
 
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "cmd", "package", "list", "packages", "-3", "-i")
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "shell", "cmd", "package", "list", "packages", "-3", "-i")
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
@@ -180,7 +180,7 @@ func (d *AndroidTvDevice) getAppVersionsAndroidTv() map[string]string {
 	versions := map[string]string{}
 
 	script := `for p in $(pm list packages -3); do p=${p#package:}; v=$(dumpsys package $p | grep -m1 versionName); echo "$p ${v#*=}"; done`
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", script)
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "shell", script)
 	var outBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
@@ -213,7 +213,7 @@ func (d *AndroidTvDevice) LaunchApp(packageName string) error {
 	var lastOutput []byte
 
 	for _, category := range []string{"android.intent.category.LEANBACK_LAUNCHER", "android.intent.category.LAUNCHER"} {
-		cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "monkey", "-p", packageName, "-c", category, "1")
+		cmd := exec.Command("adb", "-s", d.GetSerial(), "shell", "monkey", "-p", packageName, "-c", category, "1")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
 			return nil
@@ -226,7 +226,7 @@ func (d *AndroidTvDevice) LaunchApp(packageName string) error {
 
 // KillApp force-stops an app on the Android TV device.
 func (d *AndroidTvDevice) KillApp(packageName string) error {
-	cmd := exec.Command("adb", "-s", d.GetUDID(), "shell", "am", "force-stop", packageName)
+	cmd := exec.Command("adb", "-s", d.GetSerial(), "shell", "am", "force-stop", packageName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to kill app %s: %s. Output: %s", packageName, err, string(output))

--- a/provider/devices/common.go
+++ b/provider/devices/common.go
@@ -62,6 +62,11 @@ func syncDevicesToDB() {
 
 	allDevs := DevManager.All()
 	for _, platDev := range allDevs {
+		// Ephemeral devices have no DB record to reconcile against - their
+		// lifecycle is driven purely by discovery (reconcileAndroidEmulators)
+		if platDev.IsEphemeral() {
+			continue
+		}
 		udid := platDev.GetUDID()
 		dbDevice := platDev.GetDBDevice()
 		updatedDevice, ok := updatedDevices[udid]
@@ -179,9 +184,24 @@ func updateProviderHub() {
 // initializeDevice initializes a single device: sets up DB-level fields, creates a
 // PlatformDevice with Logger/SemVer on RuntimeState, and stores it in DevManager.
 func initializeDevice(dbDevice *models.DBDevice) error {
+	platDev, err := createPlatformDevice(dbDevice)
+	if err != nil {
+		return err
+	}
+
+	DevManager.Set(dbDevice.UDID, platDev)
+
+	return nil
+}
+
+// createPlatformDevice builds a fully initialized PlatformDevice without registering
+// it in DevManager. Split from initializeDevice so callers that need to adjust runtime
+// state first (e.g. mark discovered emulators ephemeral) can do so before the device
+// becomes visible to the other device loops.
+func createPlatformDevice(dbDevice *models.DBDevice) (PlatformDevice, error) {
 	sv, err := semver.NewVersion(dbDevice.OSVersion)
 	if err != nil {
-		return fmt.Errorf("failed to get semver for device `%s` - %s", dbDevice.UDID, err)
+		return nil, fmt.Errorf("failed to get semver for device `%s` - %s", dbDevice.UDID, err)
 	}
 
 	if config.ProviderConfig.SetupAppiumServers {
@@ -195,7 +215,7 @@ func initializeDevice(dbDevice *models.DBDevice) error {
 		if !exists {
 			err = db.GlobalMongoStore.CreateCappedCollectionWithDB("appium_logs_new", dbDevice.UDID, 30000, 30)
 			if err != nil {
-				return fmt.Errorf("failed to create capped Appium logs collection for device `%s` - %s", dbDevice.UDID, err)
+				return nil, fmt.Errorf("failed to create capped Appium logs collection for device `%s` - %s", dbDevice.UDID, err)
 			}
 		}
 
@@ -220,20 +240,20 @@ func initializeDevice(dbDevice *models.DBDevice) error {
 	if _, err := os.Stat(fmt.Sprintf("%s/device_%s", config.ProviderConfig.ProviderFolder, dbDevice.UDID)); os.IsNotExist(err) {
 		err = os.Mkdir(fmt.Sprintf("%s/device_%s", config.ProviderConfig.ProviderFolder, dbDevice.UDID), os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("could not create logs folder for device `%s` - %s", dbDevice.UDID, err)
+			return nil, fmt.Errorf("could not create logs folder for device `%s` - %s", dbDevice.UDID, err)
 		}
 	}
 
 	// Create a custom logger
 	deviceLogger, err := logger.CreateCustomLogger(fmt.Sprintf("%s/device_%s/device.log", config.ProviderConfig.ProviderFolder, dbDevice.UDID), dbDevice.UDID)
 	if err != nil {
-		return fmt.Errorf("could not create custom logger for device `%s` - %s", dbDevice.UDID, err)
+		return nil, fmt.Errorf("could not create custom logger for device `%s` - %s", dbDevice.UDID, err)
 	}
 
 	// Create PlatformDevice with runtime fields on RuntimeState
 	platDev := newPlatformDevice(dbDevice, *deviceLogger, sv)
 	if platDev == nil {
-		return fmt.Errorf("unsupported OS `%s` for device `%s`", dbDevice.OS, dbDevice.UDID)
+		return nil, fmt.Errorf("unsupported OS `%s` for device `%s`", dbDevice.OS, dbDevice.UDID)
 	}
 
 	// Initialize runtime state
@@ -241,9 +261,7 @@ func initializeDevice(dbDevice *models.DBDevice) error {
 	platDev.SetConnected(false)
 	platDev.SetHost(fmt.Sprintf("%s:%v", config.ProviderConfig.HostAddress, config.ProviderConfig.Port))
 
-	DevManager.Set(dbDevice.UDID, platDev)
-
-	return nil
+	return platDev, nil
 }
 
 // When provider is started and respective devices are taken from the DB, we do the initial device data setup here
@@ -335,6 +353,9 @@ func updateDevices() {
 		case <-ticker.C:
 			syncDevicesToDB()
 			connectedDevices := GetConnectedDevicesCommon()
+			if config.ProviderConfig.ProvideAndroidEmulators {
+				connectedDevices = reconcileAndroidEmulators(connectedDevices)
+			}
 
 			// Create a snapshot of devices to iterate over
 			allDevices := DevManager.All()
@@ -399,7 +420,8 @@ func GetConnectedDevicesCommon() []string {
 
 	// Android TV devices connect over ADB just like Android mobile devices, so the same
 	// `adb devices` listing is used; the concrete device type is resolved from the DB OS field.
-	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv {
+	// Emulators also appear in that listing, so providing only emulators needs it too.
+	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv || config.ProviderConfig.ProvideAndroidEmulators {
 		androidDevices = getConnectedDevicesAndroid()
 	}
 

--- a/provider/devices/platform.go
+++ b/provider/devices/platform.go
@@ -33,6 +33,9 @@ type PlatformDevice interface {
 
 	// State accessors
 	GetUDID() string
+	// GetSerial returns the transport-level identifier for local device commands
+	// (adb -s etc.). Equal to the UDID unless the device identity is synthesized.
+	GetSerial() string
 	GetOS() string
 	GetDBDevice() *models.DBDevice
 	GetProviderState() string

--- a/provider/devices/platform.go
+++ b/provider/devices/platform.go
@@ -36,6 +36,9 @@ type PlatformDevice interface {
 	// GetSerial returns the transport-level identifier for local device commands
 	// (adb -s etc.). Equal to the UDID unless the device identity is synthesized.
 	GetSerial() string
+	// IsEphemeral reports whether the device exists only in memory and must
+	// never be persisted to the DB (e.g. discovered Android emulators).
+	IsEphemeral() bool
 	GetOS() string
 	GetDBDevice() *models.DBDevice
 	GetProviderState() string

--- a/provider/devices/runtime.go
+++ b/provider/devices/runtime.go
@@ -142,7 +142,7 @@ func (r *RuntimeState) SetNewContext(ctx context.Context, cancel context.CancelF
 
 // ToSyncUpdate builds the lightweight struct sent to the hub each second.
 func (r *RuntimeState) ToSyncUpdate() models.ProviderDeviceSync {
-	return models.ProviderDeviceSync{
+	syncUpdate := models.ProviderDeviceSync{
 		UDID:                      r.DBDevice.UDID,
 		Host:                      r.Host,
 		Connected:                 r.Connected,
@@ -152,6 +152,16 @@ func (r *RuntimeState) ToSyncUpdate() models.ProviderDeviceSync {
 		AppiumSessionID:           r.AppiumSessionID,
 		AppiumLastCommandTS:       r.AppiumLastCommandTS,
 	}
+
+	// Ephemeral devices have no DB record the hub could build its store entry
+	// from, so the full device descriptor rides along with every update
+	if r.Ephemeral {
+		deviceCopy := r.DBDevice
+		syncUpdate.Ephemeral = true
+		syncUpdate.EphemeralDevice = &deviceCopy
+	}
+
+	return syncUpdate
 }
 
 // ResetBase cancels the device context, frees the Appium port, and resets state to "init".

--- a/provider/devices/runtime.go
+++ b/provider/devices/runtime.go
@@ -57,6 +57,12 @@ type RuntimeState struct {
 	// the UDID is synthesized from the AVD name but adb needs `emulator-5554`).
 	Serial string
 
+	// Ephemeral marks a device that exists only in memory (provider DevManager +
+	// hub device store) and must never be persisted to the DB. Set once at
+	// creation for discovered Android emulators, before the device is visible in
+	// DevManager, and read-only afterwards.
+	Ephemeral bool
+
 	// Provider-only runtime fields
 	HardwareModel        string
 	IsResetting          bool
@@ -87,6 +93,7 @@ func (r *RuntimeState) GetSerial() string {
 	}
 	return r.DBDevice.UDID
 }
+func (r *RuntimeState) IsEphemeral() bool               { return r.Ephemeral }
 func (r *RuntimeState) GetOS() string                   { return r.DBDevice.OS }
 func (r *RuntimeState) GetDBDevice() *models.DBDevice   { return &r.DBDevice }
 func (r *RuntimeState) GetProviderState() string        { return r.ProviderState }

--- a/provider/devices/runtime.go
+++ b/provider/devices/runtime.go
@@ -50,6 +50,13 @@ type RuntimeState struct {
 	Connected     bool
 	ProviderState string
 
+	// Serial is the transport-level identifier used for local device commands
+	// (e.g. `adb -s`). Left empty for devices whose UDID is the transport id —
+	// GetSerial falls back to the UDID then. Only set when the GADS identity
+	// deliberately differs from the transport id (e.g. Android emulators, where
+	// the UDID is synthesized from the AVD name but adb needs `emulator-5554`).
+	Serial string
+
 	// Provider-only runtime fields
 	HardwareModel        string
 	IsResetting          bool
@@ -73,25 +80,31 @@ type RuntimeState struct {
 
 // Common accessor implementations inherited by all platform types via embedding.
 
-func (r *RuntimeState) GetUDID() string                              { return r.DBDevice.UDID }
-func (r *RuntimeState) GetOS() string                                { return r.DBDevice.OS }
-func (r *RuntimeState) GetDBDevice() *models.DBDevice                { return &r.DBDevice }
-func (r *RuntimeState) GetProviderState() string                     { return r.ProviderState }
-func (r *RuntimeState) SetProviderState(state string)                { r.ProviderState = state }
-func (r *RuntimeState) IsConnected() bool                            { return r.Connected }
-func (r *RuntimeState) SetConnected(connected bool)                  { r.Connected = connected }
-func (r *RuntimeState) GetHost() string                              { return r.Host }
-func (r *RuntimeState) SetHost(host string)                          { r.Host = host }
-func (r *RuntimeState) GetLogger() models.CustomLogger               { return r.Logger }
-func (r *RuntimeState) GetContext() context.Context                  { return r.Context }
-func (r *RuntimeState) GetAppiumPort() string                        { return r.AppiumPort }
-func (r *RuntimeState) SetAppiumPort(port string)                    { r.AppiumPort = port }
-func (r *RuntimeState) GetAppiumSessionID() string                   { return r.AppiumSessionID }
-func (r *RuntimeState) SetAppiumSessionID(id string)                 { r.AppiumSessionID = id }
-func (r *RuntimeState) SetAppiumUp(up bool)                          { r.IsAppiumUp = up }
-func (r *RuntimeState) SetAppiumLastPingTS(ts int64)                 { r.AppiumLastPingTS = ts }
-func (r *RuntimeState) SetAppiumLastCommandTS(ts int64)              { r.AppiumLastCommandTS = ts }
-func (r *RuntimeState) SetHasAppiumSession(has bool)                 { r.HasAppiumSession = has }
+func (r *RuntimeState) GetUDID() string { return r.DBDevice.UDID }
+func (r *RuntimeState) GetSerial() string {
+	if r.Serial != "" {
+		return r.Serial
+	}
+	return r.DBDevice.UDID
+}
+func (r *RuntimeState) GetOS() string                   { return r.DBDevice.OS }
+func (r *RuntimeState) GetDBDevice() *models.DBDevice   { return &r.DBDevice }
+func (r *RuntimeState) GetProviderState() string        { return r.ProviderState }
+func (r *RuntimeState) SetProviderState(state string)   { r.ProviderState = state }
+func (r *RuntimeState) IsConnected() bool               { return r.Connected }
+func (r *RuntimeState) SetConnected(connected bool)     { r.Connected = connected }
+func (r *RuntimeState) GetHost() string                 { return r.Host }
+func (r *RuntimeState) SetHost(host string)             { r.Host = host }
+func (r *RuntimeState) GetLogger() models.CustomLogger  { return r.Logger }
+func (r *RuntimeState) GetContext() context.Context     { return r.Context }
+func (r *RuntimeState) GetAppiumPort() string           { return r.AppiumPort }
+func (r *RuntimeState) SetAppiumPort(port string)       { r.AppiumPort = port }
+func (r *RuntimeState) GetAppiumSessionID() string      { return r.AppiumSessionID }
+func (r *RuntimeState) SetAppiumSessionID(id string)    { r.AppiumSessionID = id }
+func (r *RuntimeState) SetAppiumUp(up bool)             { r.IsAppiumUp = up }
+func (r *RuntimeState) SetAppiumLastPingTS(ts int64)    { r.AppiumLastPingTS = ts }
+func (r *RuntimeState) SetAppiumLastCommandTS(ts int64) { r.AppiumLastCommandTS = ts }
+func (r *RuntimeState) SetHasAppiumSession(has bool)    { r.HasAppiumSession = has }
 func (r *RuntimeState) SetAppiumSessionCaps(caps map[string]interface{}) {
 	r.AppiumSessionCaps = caps
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -176,8 +176,8 @@ func StartProvider(flags *pflag.FlagSet, resourceFiles embed.FS) {
 		log.Fatalf("Failed to extract embedded resource files - %s", err)
 	}
 
-	// If we want to provide Android or Android TV devices check if adb is available on PATH
-	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv {
+	// If we want to provide Android, Android TV or Android emulator devices check if adb is available on PATH
+	if config.ProviderConfig.ProvideAndroid || config.ProviderConfig.ProvideAndroidTv || config.ProviderConfig.ProvideAndroidEmulators {
 		if !providerutil.AdbAvailable() {
 			logger.ProviderLogger.LogError("provider", "adb is not available, you need to set up the host as explained in the readme")
 			fmt.Println("adb is not available, you need to set up the host as explained in the readme")

--- a/provider/router/control.go
+++ b/provider/router/control.go
@@ -141,8 +141,8 @@ func deviceTouchAndHold(dev devices.PlatformDevice, x float64, y float64, durati
 // androidScreenshot captures a screenshot from the given Android device.
 // displayID is the physical display ID to pass via `screencap -d`; pass empty string
 // to let screencap choose the default display (single-display devices).
-func androidScreenshot(udid, displayID string) ([]byte, error) {
-	args := []string{"-s", udid, "exec-out", "screencap", "-p"}
+func androidScreenshot(serial, displayID string) ([]byte, error) {
+	args := []string{"-s", serial, "exec-out", "screencap", "-p"}
 	if displayID != "" {
 		args = append(args, "-d", displayID)
 	}
@@ -162,7 +162,7 @@ func deviceScreenshot(dev devices.PlatformDevice) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("device %s is not an Android device", dev.GetUDID())
 		}
-		imageBytes, err := androidScreenshot(andDev.GetUDID(), andDev.GetActiveDisplayID())
+		imageBytes, err := androidScreenshot(andDev.GetSerial(), andDev.GetActiveDisplayID())
 		if err != nil {
 			return "", err
 		}
@@ -320,7 +320,7 @@ func iOSAppSwitcher(dev devices.PlatformDevice) (*http.Response, error) {
 
 func androidRecents(dev devices.PlatformDevice) error {
 	if dev.GetOS() == "android" {
-		cmd := exec.CommandContext(dev.GetContext(), "adb", "-s", dev.GetUDID(), "shell", "input", "keyevent", "KEYCODE_APP_SWITCH")
+		cmd := exec.CommandContext(dev.GetContext(), "adb", "-s", dev.GetSerial(), "shell", "input", "keyevent", "KEYCODE_APP_SWITCH")
 		return cmd.Run()
 	}
 	return fmt.Errorf("Device is not an Android device")

--- a/provider/router/routes.go
+++ b/provider/router/routes.go
@@ -699,7 +699,7 @@ func PushFileToSharedStorage(c *gin.Context) {
 	}
 
 	// Push the file via adb to from the temporary folder to the target shared storage path
-	adbCmd := exec.Command("adb", "-s", platDev.GetUDID(), "push", tempPath, destPath)
+	adbCmd := exec.Command("adb", "-s", platDev.GetSerial(), "push", tempPath, destPath)
 	_, err = adbCmd.CombinedOutput()
 	if err != nil {
 		api.InternalError(c, fmt.Sprintf("Failed to push file `%s` to `%s` - %s", file.Filename, destPath, err))
@@ -728,8 +728,7 @@ func DeleteFileFromSharedStorage(c *gin.Context) {
 		return
 	}
 
-	device := platDev.GetDBDevice()
-	err := devices.DeleteAndroidSharedStorageFile(device, filePath)
+	err := devices.DeleteAndroidSharedStorageFile(platDev.GetSerial(), filePath)
 	if err != nil {
 		api.InternalError(c, fmt.Sprintf("Failed to delete file on path `%s`", filePath))
 		return
@@ -769,8 +768,7 @@ func PullFileFromSharedStorage(c *gin.Context) {
 		return
 	}
 
-	device := platDev.GetDBDevice()
-	tempFilePath, err := devices.PullAndroidSharedStorageFile(device, filePath, fileName)
+	tempFilePath, err := devices.PullAndroidSharedStorageFile(platDev.GetSerial(), filePath, fileName)
 	defer os.Remove(tempFilePath)
 	if err != nil {
 		api.InternalError(c, fmt.Sprintf("Failed to pull file from path `%s` to a temporary directory", filePath))


### PR DESCRIPTION
* Android emulators are auto-discovered and registered as ephemeral devices and are not registered in the DB, there is no need to add them manually in the Admin panel configuration
* GADS does not manage the emulators, only adopts them - you need to manage the AVDs and the boot/teardown of the emulators yourself
* Android emulators always live in the default workspace