### PR TITLE
Support optional TURN over TLS (turns:) port

### DIFF
--- a/common/db/turn_config.go
+++ b/common/db/turn_config.go
@@ -41,6 +41,7 @@ func (m *MongoStore) GetTURNConfig() (models.TURNConfig, error) {
 		turnConfig = models.TURNConfig{
 			Server:       "",
 			Port:         3478,
+			TLSPort:      0, // TURN over TLS (turns:) is optional — 0 keeps it disabled
 			SharedSecret: "",
 			TTL:          3600,
 			Enabled:      false,

--- a/common/models/config.go
+++ b/common/models/config.go
@@ -86,6 +86,7 @@ type MinioConfig struct {
 type TURNConfig struct {
 	Server       string `json:"server" bson:"server"`
 	Port         int    `json:"port" bson:"port"`
+	TLSPort      int    `json:"tls_port" bson:"tls_port"` // Optional turns: (TURN over TLS) port; 0 (default) disables TLS
 	SharedSecret string `json:"shared_secret" bson:"shared_secret"`
 	TTL          int    `json:"ttl" bson:"ttl"` // Time-to-live in seconds (default: 3600)
 	Enabled      bool   `json:"enabled" bson:"enabled"`

--- a/common/utils/webrtc.go
+++ b/common/utils/webrtc.go
@@ -29,16 +29,20 @@ func GenerateWebRTCConfig() webrtc.Configuration {
 			ttl = 3600
 		}
 		username, password, _ := auth.GenerateTURNCredentials(turnConfig.SharedSecret, ttl, config.ProviderConfig.TURNUsernameSuffix)
-		turnIceServer := webrtc.ICEServer{
-			URLs: []string{
-				fmt.Sprintf("turn:%s:%d?transport=udp", turnConfig.Server, turnConfig.Port),
-				fmt.Sprintf("turn:%s:%d?transport=tcp", turnConfig.Server, turnConfig.Port),
-			},
+		urls := []string{
+			fmt.Sprintf("turn:%s:%d?transport=udp", turnConfig.Server, turnConfig.Port),
+			fmt.Sprintf("turn:%s:%d?transport=tcp", turnConfig.Server, turnConfig.Port),
+		}
+		// TURN over TLS (turns:) is optional — only advertised when a TLS port is configured.
+		if turnConfig.TLSPort > 0 {
+			urls = append(urls, fmt.Sprintf("turns:%s:%d?transport=tcp", turnConfig.Server, turnConfig.TLSPort))
+		}
+		iceServers = append(iceServers, webrtc.ICEServer{
+			URLs:       urls,
 			Username:   username,
 			Credential: password,
-		}
-		iceServers = append(iceServers, turnIceServer)
-		logger.ProviderLogger.LogInfo("webrtc_config", fmt.Sprintf("Applying TURN relay: server=%s:%d suffix=%s", turnConfig.Server, turnConfig.Port, config.ProviderConfig.TURNUsernameSuffix))
+		})
+		logger.ProviderLogger.LogInfo("webrtc_config", fmt.Sprintf("Applying TURN relay: server=%s:%d tls_port=%d suffix=%s", turnConfig.Server, turnConfig.Port, turnConfig.TLSPort, config.ProviderConfig.TURNUsernameSuffix))
 	}
 
 	return webrtc.Configuration{

--- a/docs/webrtc-turn-server-guide.md
+++ b/docs/webrtc-turn-server-guide.md
@@ -487,6 +487,7 @@ Fill in the following fields:
 | **Enable TURN Server** | ✅ Checked          | -                                     |
 | **TURN Server**        | Hostname or IP      | `turn.example.com` or `203.0.113.50`  |
 | **Port**               | TURN listening port | `3478` (default)                      |
+| **TLS Port**           | `turns:` (TURN over TLS) port — **optional** | `5349`, or `0`/empty to disable TLS |
 | **Shared Secret**      | Secret from Step 2  | `O5V/O/yvaWZs...` (paste full secret) |
 | **TTL (seconds)**      | Credential lifetime | `3600` (1 hour recommended)           |
 
@@ -513,10 +514,13 @@ curl -X POST http://YOUR_HUB_IP:10000/admin/turn-config \
     "enabled": true,
     "server": "turn.example.com",
     "port": 3478,
+    "tls_port": 5349,
     "shared_secret": "YOUR_GENERATED_SECRET",
     "ttl": 3600
   }'
 ```
+
+> **`tls_port` is optional.** Omit it or set it to `0` to disable TURN over TLS (`turns:`) — the hub/providers will then advertise only `turn:` (UDP/TCP). Set it to your coturn `tls-listening-port` (default `5349`) to enable TLS.
 
 ### How Configuration Propagates
 

--- a/hub/router/routes.go
+++ b/hub/router/routes.go
@@ -1811,6 +1811,12 @@ func UpdateTURNConfig(c *gin.Context) {
 			return
 		}
 
+		// TLS port is optional: 0 (or empty) disables TURN over TLS (turns:).
+		if config.TLSPort < 0 || config.TLSPort > 65535 {
+			api.BadRequest(c, "TLS port must be between 0 and 65535 (0 disables TLS)")
+			return
+		}
+
 		if config.SharedSecret == "" {
 			api.BadRequest(c, "Shared secret is required when TURN is enabled")
 			return
@@ -1820,6 +1826,7 @@ func UpdateTURNConfig(c *gin.Context) {
 		if config.TTL == 0 {
 			config.TTL = 3600 // Default: 1 hour
 		}
+		// TLS port is intentionally NOT defaulted — leaving it 0 keeps TURN over TLS disabled.
 	}
 
 	err := db.GlobalMongoStore.UpdateTURNConfig(config)

--- a/hub/router/webrtc.go
+++ b/hub/router/webrtc.go
@@ -14,6 +14,7 @@ import (
 	"GADS/common/db"
 	"GADS/hub/config"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -33,9 +34,20 @@ func GetICEConfig(c *gin.Context) {
 		{"urls": "stun:stun.l.google.com:19302"},
 	}
 
-	// Try to add TURN server if configured and enabled
+	// TURN is optional — add it only when configured and enabled. STUN alone covers
+	// most networks; TURN is the fallback for restrictive ones. A missing/failed TURN
+	// config just yields a STUN-only response, never an error. Each outcome is logged so
+	// an incomplete config (e.g. empty shared secret) is distinguishable from TURN being
+	// intentionally disabled.
 	turnConfig, err := db.GlobalMongoStore.GetTURNConfig()
-	if err == nil && turnConfig.Enabled && turnConfig.Server != "" && turnConfig.SharedSecret != "" {
+	switch {
+	case err != nil:
+		slog.Warn(fmt.Sprintf("ice-config: could not load TURN config, serving STUN only - %s", err))
+	case !turnConfig.Enabled:
+		slog.Debug("ice-config: TURN disabled, serving STUN only")
+	case turnConfig.Server == "" || turnConfig.SharedSecret == "":
+		slog.Warn("ice-config: TURN is enabled but its config is incomplete (missing server or shared secret); serving STUN only")
+	default:
 		// Generate ephemeral credentials using TURN REST API
 		ttl := turnConfig.TTL
 		if ttl == 0 {
@@ -43,16 +55,20 @@ func GetICEConfig(c *gin.Context) {
 		}
 		username, password, _ := auth.GenerateTURNCredentials(turnConfig.SharedSecret, ttl, config.GlobalHubConfig.TURNUsernameSuffix)
 
-		// Add TURN server as fallback for restrictive networks
-		turnServer := map[string]interface{}{
-			"urls": []string{
-				fmt.Sprintf("turn:%s:%d?transport=udp", turnConfig.Server, turnConfig.Port),
-				fmt.Sprintf("turn:%s:%d?transport=tcp", turnConfig.Server, turnConfig.Port),
-			},
+		urls := []string{
+			fmt.Sprintf("turn:%s:%d?transport=udp", turnConfig.Server, turnConfig.Port),
+			fmt.Sprintf("turn:%s:%d?transport=tcp", turnConfig.Server, turnConfig.Port),
+		}
+		// TURN over TLS (turns:) is optional — only advertised when a TLS port is configured.
+		if turnConfig.TLSPort > 0 {
+			urls = append(urls, fmt.Sprintf("turns:%s:%d?transport=tcp", turnConfig.Server, turnConfig.TLSPort))
+		}
+		iceServers = append(iceServers, map[string]interface{}{
+			"urls":       urls,
 			"username":   username,
 			"credential": password,
-		}
-		iceServers = append(iceServers, turnServer)
+		})
+		slog.Info(fmt.Sprintf("ice-config: advertising TURN %s:%d (tls=%t) to client", turnConfig.Server, turnConfig.Port, turnConfig.TLSPort > 0))
 	}
 
 	c.JSON(http.StatusOK, gin.H{"iceServers": iceServers})


### PR DESCRIPTION
Add a tls_port field to the TURN configuration so the hub and providers can advertise a turns: (TURN over TLS) ICE URL. TLS is optional: turns: is advertised only when tls_port is set (> 0); with tls_port 0 only turn: (UDP/TCP) URLs are generated.

- models.TURNConfig: tls_port field (optional; 0 = TLS disabled)
- hub/provider WebRTC config: append turns: only when tls_port > 0
- UpdateTURNConfig: validate tls_port 0-65535
- default TURN config: tls_port 0
- docs: document the optional TLS Port in the WebRTC TURN server guide
- bump hub-ui submodule (optional TLS Port field in Global Settings)